### PR TITLE
[WIP] Proof of concept for not converting objects to strings

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -19,7 +19,7 @@ import numpy as np
 from numpy import ma
 import pandas as pd
 from pandas.core.index import RangeIndex
-from pandas.api.types import is_string_dtype, is_categorical
+from pandas.api.types import is_string_dtype, is_categorical, infer_dtype
 from scipy import sparse
 from scipy.sparse import issparse
 
@@ -1148,15 +1148,16 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             dfs = [df]
         for df in dfs:
-            string_cols = [
-                key
-                for key in df.columns
-                if is_string_dtype(df[key]) and not is_categorical(df[key])
-            ]
-            for key in string_cols:
+            for key in df.columns:
+                dtype = infer_dtype(df[key], skipna=True)
                 # make sure we only have strings
                 # (could be that there are np.nans (float), -666, "-666", for instance)
-                c = df[key].astype("U")
+                if dtype in ["string", "unicode"]:
+                    c = df[key].astype(str)
+                elif dtype == "bytes":
+                    c = df[key].astype(bytes)
+                else:
+                    continue
                 # make a categorical
                 c = pd.Categorical(c, categories=natsorted(np.unique(c)))
                 if len(c.categories) >= len(c):

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -434,3 +434,16 @@ def test_double_index(subset_func, subset_func2):
     assert np.all(asarray(v1.X) == asarray(v2.X))
     assert np.all(v1.obs == v2.obs)
     assert np.all(v1.var == v2.var)
+
+
+def test_string_detection():
+    class Foo(object):
+        def __init__(self, x):
+            self.x = x
+
+    a = gen_adata((10, 10))
+    a.obs["foo"] = [Foo(x) for x in list("abcdeabcde")]
+
+    b = a[2:8].copy()
+    b.strings_to_categoricals()
+    assert {type(f) for f in b.obs["foo"]} == {Foo}


### PR DESCRIPTION
Potentially fixes #115. This just preserves objects during `strings_to_categoricals`.

This will change behaviour for cases where there we mixed types in a `Series` (like: `["abc", 0.6]`), but I'm not sure if that's a common case. It will still convert if there are missing values.

This still converts things to strings for writing, where it should probably error or at least warn.