### PR TITLE
[WIP] Add copy argument to obs/var_vector

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1327,7 +1327,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self.X
 
-    def obs_vector(self, k: str, *, layer: Optional[str] = None) -> np.ndarray:
+    def obs_vector(
+        self, k: str, *, layer: Optional[str] = None, copy: bool = True
+    ) -> np.ndarray:
         """\
         Convenience function for returning a 1 dimensional ndarray of values
         from :attr:`X`, :attr:`layers`\\ `[k]`, or :attr:`obs`.
@@ -1341,6 +1343,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             Key to use. Should be in :attr:`var_names` or :attr:`obs`\\ `.columns`.
         layer
             What layer values should be returned from. If `None`, :attr:`X` is used.
+        copy
+            If possible, should a copy not be returned? If `True`, a copy will be
+            returned. If `False`, a copy may be returned.
 
         Returns
         -------
@@ -1365,9 +1370,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             a = self._get_X(layer=layer)[idx]
         if issparse(a):
             a = a.toarray()
-        return np.ravel(a)
+            a = a.reshape(np.multiply.reduce(a.shape))
+        elif copy:
+            a = a.copy()
+        return a
 
-    def var_vector(self, k, *, layer: Optional[str] = None) -> np.ndarray:
+    def var_vector(
+        self, k, *, layer: Optional[str] = None, copy: bool = True
+    ) -> np.ndarray:
         """\
         Convenience function for returning a 1 dimensional ndarray of values
         from :attr:`X`, :attr:`layers`\\ `[k]`, or :attr:`obs`.
@@ -1381,6 +1391,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             Key to use. Should be in :attr:`obs_names` or :attr:`var`\\ `.columns`.
         layer
             What layer values should be returned from. If `None`, :attr:`X` is used.
+        copy
+            If possible, should a copy not be returned? If `True`, a copy will be
+            returned. If `False`, a copy may be returned.
 
         Returns
         -------
@@ -1405,7 +1418,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             a = self._get_X(layer=layer)[idx]
         if issparse(a):
             a = a.toarray()
-        return np.ravel(a)
+            a = a.reshape(np.multiply.reduce(a.shape))
+        elif copy:
+            a = a.copy()
+        return a
 
     @utils.deprecated("obs_vector")
     def _get_obs_array(self, k, use_raw=False, layer=None):

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -156,7 +156,7 @@ class Raw:
         var = _normalize_index(var, self.var_names)
         return obs, var
 
-    def var_vector(self, k: str) -> np.ndarray:
+    def var_vector(self, k: str, copy: bool = True) -> np.ndarray:
         # TODO decorator to copy AnnData.var_vector docstring
         if k in self.var:
             return self.var[k].values
@@ -165,15 +165,21 @@ class Raw:
             a = self.X[idx]
         if issparse(a):
             a = a.toarray()
-        return np.ravel(a)
+            a = a.reshape(np.multiply.reduce(a.shape))
+        elif copy:
+            a = a.copy()
+        return a
 
-    def obs_vector(self, k: str) -> np.ndarray:
+    def obs_vector(self, k: str, copy: bool = True) -> np.ndarray:
         # TODO decorator to copy AnnData.obs_vector docstring
         idx = self._normalize_indices((slice(None), k))
         a = self.X[idx]
         if issparse(a):
             a = a.toarray()
-        return np.ravel(a)
+            a = a.reshape(np.multiply.reduce(a.shape))
+        elif copy:
+            a = a.copy()
+        return a
 
 
 # This exists to accommodate AlignedMappings,


### PR DESCRIPTION
Per some benchmarking results in https://github.com/theislab/anndata/issues/317#issuecomment-583963717, it looks like we can speed up getting a vector out of a dense array with the `obs_vector` methods. Since it always returned a copy before, I figure this was worth a keyword argument.

This gives a 1000x speed up when the array which values are being taken from is dense.

Needs tests.