### PR TITLE
Ref paths

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -72,14 +72,6 @@ Writing to other formats.
    AnnData.write_loom
    AnnData.write_zarr
 
-Helper classes
---------------
-
-.. autosummary::
-   :toctree: .
-
-   RefPath
-
 Errors and warnings
 -------------------
 

--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -1,5 +1,6 @@
 from ._core.anndata import AnnData, ImplicitModificationWarning
 from ._core.raw import Raw
+from ._core.ref_path import RefPath
 from ._io import (
     read_h5ad,
     read_loom,
@@ -71,6 +72,13 @@ Writing to other formats.
    AnnData.write_loom
    AnnData.write_zarr
 
+Helper classes
+--------------
+
+.. autosummary::
+   :toctree: .
+
+   RefPath
 
 Errors and warnings
 -------------------

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -230,6 +230,11 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         if vals is not None:
             self.update(vals)
 
+    def __setitem__(self, key: str, value: V):
+        if hasattr(value, "index") and isinstance(value.index, pd.RangeIndex):
+            value.index = self.dim_names
+        super().__setitem__(key, value)
+
 
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):
     def __init__(

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -42,6 +42,7 @@ from .views import (
     _resolve_idxs,
 )
 from .sparse_dataset import SparseDataset
+from . import ref_path
 from .. import utils
 from ..utils import convert_to_dict, ensure_df_homogeneous
 from ..logging import anndata_logger as logger
@@ -1347,6 +1348,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             return self.raw.X
         else:
             return self.X
+
+    resolve_path = ref_path.resolve_path
+    get_df = ref_path.get_df
+    get_vector = ref_path.get_vector
 
     def obs_vector(self, k: str, *, layer: Optional[str] = None) -> np.ndarray:
         """\

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1349,7 +1349,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self.X
 
-    resolve_path = ref_path.resolve_path
+    # TODO: export when exporting RefPath.
+    # resolve_path = ref_path.resolve_path
     get_df = ref_path.get_df
     get_vector = ref_path.get_vector
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -275,8 +275,18 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obs: Optional[Union[pd.DataFrame, Mapping[str, Iterable[Any]]]] = None,
         var: Optional[Union[pd.DataFrame, Mapping[str, Iterable[Any]]]] = None,
         uns: Optional[Mapping[str, Any]] = None,
-        obsm: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
-        varm: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
+        obsm: Optional[
+            Union[
+                np.ndarray,
+                Mapping[str, Union[np.ndarray, sparse.spmatrix, pd.DataFrame]],
+            ]
+        ] = None,
+        varm: Optional[
+            Union[
+                np.ndarray,
+                Mapping[str, Union[np.ndarray, sparse.spmatrix, pd.DataFrame]],
+            ]
+        ] = None,
         layers: Optional[Mapping[str, Union[np.ndarray, sparse.spmatrix]]] = None,
         raw: Optional[Mapping[str, Any]] = None,
         dtype: Union[np.dtype, str] = "float32",
@@ -285,8 +295,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         filemode: Optional[Literal["r", "r+"]] = None,
         asview: bool = False,
         *,
-        obsp: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
-        varp: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
+        obsp: Optional[
+            Union[np.ndarray, Mapping[str, Union[np.ndarray, sparse.spmatrix]]]
+        ] = None,
+        varp: Optional[
+            Union[np.ndarray, Mapping[str, Union[np.ndarray, sparse.spmatrix]]]
+        ] = None,
         oidx: Index1D = None,
         vidx: Index1D = None,
     ):

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1384,7 +1384,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     FutureWarning,
                 )
                 layer = None
-        return get_vector(self, k, "obs", "var", layer=layer)
+        return get_vector(self, k, "var", layer=layer)
 
     def var_vector(self, k, *, layer: Optional[str] = None) -> np.ndarray:
         """\
@@ -1416,7 +1416,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     FutureWarning,
                 )
                 layer = None
-        return get_vector(self, k, "var", "obs", layer=layer)
+        return get_vector(self, k, "obs", layer=layer)
 
     @utils.deprecated("obs_vector")
     def _get_obs_array(self, k, use_raw=False, layer=None):

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -1,11 +1,13 @@
 import collections.abc as cabc
 from functools import singledispatch
 from itertools import repeat
-from typing import Union, Sequence, Optional, Tuple, Literal, TYPE_CHECKING
+from typing import Union, Sequence, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import spmatrix, issparse
+
+from ..compat import Literal
 
 if TYPE_CHECKING:
     from .anndata import AnnData

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -1,16 +1,14 @@
 import collections.abc as cabc
 from functools import singledispatch
 from itertools import repeat
-from typing import Union, Sequence, Optional, Tuple, TYPE_CHECKING
+from typing import Union, Sequence, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import spmatrix, issparse
 
 from ..compat import Literal
-
-if TYPE_CHECKING:
-    from .anndata import AnnData
+from . import anndata
 
 
 Index1D = Union[slice, int, str, np.int64, np.ndarray]
@@ -144,7 +142,7 @@ def make_slice(idx, dimidx, n=2):
 
 
 def get_vector(
-    adata: "AnnData",
+    adata: "anndata.AnnData",
     k: str,
     coldim: Literal["obs", "var"],
     idxdim: Literal["obs", "var"],

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -167,7 +167,7 @@ class Raw:
 
     def var_vector(self, k: str) -> np.ndarray:
         # TODO decorator to copy AnnData.var_vector docstring
-        return get_vector(self, k, "var", "obs")
+        return get_vector(self, k, "obs")
 
     def obs_vector(self, k: str) -> np.ndarray:
         # TODO decorator to copy AnnData.obs_vector docstring

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -97,6 +97,10 @@ class Raw:
     def obs_names(self):
         return self._adata.obs_names
 
+    @property
+    def layers(self):
+        return {None: self.X}
+
     def __getitem__(self, index):
         oidx, vidx = self._normalize_indices(index)
 

--- a/anndata/_core/ref_path.py
+++ b/anndata/_core/ref_path.py
@@ -210,7 +210,7 @@ def resolve_path(
         This supports subpaths of the :class:`~anndata.RefPath` syntax.
         `str` keys or tuple subpaths (like `'GeneA'` or `('X_pca', 0)`) are resolved
         according to `dim`, `use_raw`, and `alias_col`.
-        As `RefPath`s are always unique, they get passed through.
+        As `RefPath`\\ s are always unique, they get passed through.
     dim
         Dimension to resolve paths in.
         If `dim=None`, both dimensions are tried and an error is thrown for duplicates.
@@ -278,10 +278,10 @@ add_doc = """\
 
     Parameters
     ----------
+    For syntax and other parameters see :meth:`~anndata.AnnData.resolve_path`.
+
     layer
         The layer to get the vector from if the path resolves to a `<dim>_name`.
-
-    For syntax and other parameters see :meth:`~anndata.AnnData.resolve_path`.
 """
 get_vector.__doc__ += add_doc
 get_df.__doc__ += add_doc

--- a/anndata/_core/ref_path.py
+++ b/anndata/_core/ref_path.py
@@ -1,0 +1,169 @@
+from enum import Enum
+from typing import Iterable, Union, Sequence, Dict, Tuple, Optional, TYPE_CHECKING
+
+import pandas as pd
+import numpy as np
+
+from .index import get_x_vector
+from .raw import Raw
+
+if TYPE_CHECKING:
+    from .anndata import AnnData
+
+
+# TODO: allow sequences: ("obsm", "X_pca", [0, 1])
+
+
+class Attr(Enum):
+    layers = ((str, ("obs", "var"), str), dict(l=(), X=("X",)))
+    obs = ((str,), dict(o=()))
+    obsm = ((str, (int, str)), dict(om=()))
+    obsp = ((str, str, (0, 1)), dict(op=()))
+    var = ((str,), dict(v=()))
+    varm = ((str, (int, str)), dict(vm=()))
+    varp = ((str, str, (0, 1)), dict(vp=()))
+    raw = ((("X", "obs"), ...), dict(rX=("X",), ro=("obs",)))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}.{self.name}"
+
+    @property
+    def validation(self):
+        return self.value[0]
+
+    @property
+    def short_codes(self):
+        return self.value[1]
+
+    def validate(self, path: Sequence[Union[str, int]]):
+        if self is not Attr.raw and not len(path) == len(self.validation):
+            raise ValueError(
+                f"Path length mismatch: required ({len(self.validation)}) ≠ "
+                f"got ({len(path)}) in path {path!r} for attr {self.name}."
+            )
+        for i, (elem, check) in enumerate(zip(path, self.validation)):
+            err_prefix = f"Element path[{i}]={path[i]!r} in path {path!r}"
+            if isinstance(check, tuple):
+                if isinstance(check[0], type):
+                    if not any(isinstance(elem, c) for c in check):
+                        raise ValueError(
+                            f"{err_prefix} is not of one of the types {check!r}"
+                        )
+                elif not any(elem == c for c in check):
+                    raise ValueError(f"{err_prefix} is not of one of {check!r}")
+            elif isinstance(check, type):
+                if not isinstance(elem, check):
+                    raise ValueError(f"{err_prefix} is non of type {check}")
+            else:
+                assert check is Ellipsis
+                assert self is Attr.raw
+                sub_path = RefPath.parse(path)
+                # layers or obs
+                sub_path.attr.validate(sub_path.path)
+
+    @staticmethod
+    def prefix(prefix: str) -> Tuple[str, Tuple[str, ...]]:
+        if prefix in Attr.__members__:  # name
+            return prefix, ()
+        for attr in Attr:
+            path_prefix = attr.short_codes.get(prefix)
+            if path_prefix:
+                return attr.name, path_prefix
+
+
+class RefPath:
+    attr: Attr
+    path: Sequence[Union[str, int]]
+
+    def __init__(self, attr: str, *path: Union[str, int]):
+        self.attr = Attr[attr]
+        self.path = path
+        self.attr.validate(path)
+
+    @staticmethod
+    def parse(full_path: Union["RefPath", str, Sequence[Union[str, int]]]) -> "RefPath":
+        if isinstance(full_path, RefPath):
+            return full_path
+        if isinstance(full_path, str):
+            attr_or_code, *path = full_path.split("/")
+        else:
+            attr_or_code, *path = full_path
+        # path can be shorthand: "obs/Foo" and "o/Foo"
+        attr, path_prefix = Attr.prefix(attr_or_code)
+        return RefPath(attr, *path_prefix, *path)
+
+    def __repr__(self):
+        return f"RefPath({self.attr.name!r}, {', '.join(map(repr, self.path))})"
+
+    def make_name(self, length: int = 1) -> str:
+        path = (self.attr.name, *self.path)
+        if length == 1 and self.attr in {Attr.obsp, Attr.varp}:
+            return path[-2]  # just key
+        if length in {1, 2} and self.attr.name in {Attr.obsm, Attr.varm}:
+            if isinstance(path[-1], int):
+                return f"{path[-2]}{path[-1] + 1}"  # X_pca1
+            else:  # normal
+                return path[-1] if length == 1 else f"{path[-2]}-{path[-1]}"
+        if length <= 2:
+            return "-".join(path[-length:])
+        return f"{path[:-2]}{self.make_name(length=2)}"
+
+    def get_vector(self, adata: Union["AnnData", Raw], alias_col: Optional[str] = None):
+        attr = getattr(adata, self.attr.name, None)
+        if attr is None:
+            raise ValueError(
+                f"Unknown AnnData attribute {self.attr.name!r} (path={self.path!r})"
+            )
+        if attr is adata.layers:  # X is here after normalizing
+            layer_name, dim, key = self.path
+            layer_name = None if layer_name == "X" else layer_name
+            if alias_col is not None:
+                idx = getattr(adata, dim)[alias_col]
+                key = idx.index[idx == key]
+            return get_x_vector(adata, dim, key, layer_name)
+        if attr is adata.obs or attr is adata.var:
+            (col,) = self.path
+            return attr[col]
+        assert not isinstance(adata, Raw)
+        if attr is adata.obsm or attr is adata.varm:
+            m_name, col = self.path
+            m = attr[m_name]
+            return m[col] if isinstance(m, pd.DataFrame) else m[:, col]
+        if attr is adata.obsp or attr is adata.varp:
+            p_name, obs_name, orient = self.path
+            p = attr[p_name]
+            # TODO: take from index
+            return np.ravel(p[:, obs_name] if orient == 1 else p[obs_name, :])
+        if attr is adata.raw:
+            raw_attr, *raw_path = self.path
+            return RefPath(raw_attr, *raw_path).get_vector(adata.raw, alias_col)
+        else:
+            assert False, f"Unhandled attr {self.attr.name!r}"
+
+
+def get_df(
+    adata: "AnnData",
+    paths: Iterable[Union[str, RefPath]] = (),
+    *,
+    gene_symbols: RefPath = None,
+    # no use_raw, no layer.
+) -> pd.DataFrame:
+    paths = list(map(RefPath.parse, paths))
+    names = paths_to_names(paths)
+    columns = {n: p.get_vector(adata, gene_symbols) for n, p in names.items()}
+    return pd.DataFrame(columns, adata.obs_names)
+
+
+def paths_to_names(paths: Sequence[RefPath], length: int = 1) -> Dict[str, RefPath]:
+    names = {}
+    dupes = {}
+    for path, name in zip(paths, (p.make_name(length) for p in paths)):
+        dupes.setdefault(name, []).append(path)
+    for name, paths_dup in dupes.items():
+        if len(paths_dup) == 1:
+            names[name] = paths_dup[0]
+        elif any(len(p) > length for p in paths_dup):
+            names.update(paths_to_names(paths_dup, length + 1))
+        else:
+            raise ValueError(f"Not sure how {name} can be extended for {paths_dup}")
+    return names

--- a/anndata/_core/ref_path.py
+++ b/anndata/_core/ref_path.py
@@ -276,10 +276,10 @@ def get_df(
 
 add_doc = """\
 
-    Parameters
-    ----------
     For syntax and other parameters see :meth:`~anndata.AnnData.resolve_path`.
 
+    Parameters
+    ----------
     layer
         The layer to get the vector from if the path resolves to a `<dim>_name`.
 """

--- a/anndata/_core/ref_path.py
+++ b/anndata/_core/ref_path.py
@@ -214,8 +214,8 @@ def resolve_path(
     dim
         Dimension to resolve paths in.
         If `dim=None`, both dimensions are tried and an error is thrown for duplicates.
-        If e.g. `dim='obs'`, it would find an unique name in `obs_names`
-        or in :attr:`~anndata.AnnData.obs`\\ `.columns`.
+        If e.g. `dim='obs'`, it would find an unique name in
+        :attr:`~anndata.AnnData.obs_names` or :attr:`~anndata.AnnData.obs`\\ `.columns`.
     use_raw
         Resolve partial paths for `X`, `var`, or `varm` in `adata.raw`
         instead of `adata`?

--- a/anndata/_core/ref_path.py
+++ b/anndata/_core/ref_path.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from itertools import product
-from typing import Union, Optional, TYPE_CHECKING  # Special
+from typing import Union, Optional  # Special
 from typing import Iterable, Sequence, Generator  # ABCs
 from typing import Dict, Tuple  # Classes
 
@@ -8,12 +8,10 @@ import pandas as pd
 import numpy as np
 import scipy.sparse as ssp
 
+from ..compat import Literal
+from . import anndata
 from .index import get_x_vector
 from .raw import Raw
-from ..compat import Literal
-
-if TYPE_CHECKING:
-    from .anndata import AnnData
 
 
 # TODO: allow sequences: ("obsm", "X_pca", [0, 1])
@@ -157,7 +155,7 @@ class RefPath:
             return "-".join(path[-length:])
         return f"{path[:-2]}{self.make_name(length=2)}"
 
-    def get_vector(self, adata: Union["AnnData", Raw]):
+    def get_vector(self, adata: Union["anndata.AnnData", Raw]):
         attr = getattr(adata, self.attr.name)
         if self.attr is Attr.layers:  # X is here after normalizing
             layer_name, dim, key = self.path
@@ -195,7 +193,7 @@ RefPathLike = Union[str, Tuple[Union[str, int], ...], RefPath]
 
 
 def resolve_path(
-    adata: "AnnData",
+    adata: "anndata.AnnData",
     *path: Union[str, RefPath, int],
     dim: Optional[Literal["obs", "var"]] = None,
     use_raw: bool = False,
@@ -239,7 +237,7 @@ def resolve_path(
 
 
 def get_vector(
-    adata: "AnnData",
+    adata: "anndata.AnnData",
     *path: Union[str, RefPath, int],
     dim: Optional[Literal["obs", "var"]] = None,
     use_raw: bool = False,
@@ -253,7 +251,7 @@ def get_vector(
 
 
 def get_df(
-    adata: "AnnData",
+    adata: "anndata.AnnData",
     paths: Iterable[RefPathLike],
     *,
     dim: Optional[Literal["obs", "var"]] = None,

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -32,26 +32,27 @@ def adata():
 
 
 paths = [
-    (("layers", "unspliced", "obs", "Cell1"), [0.1, 1.2, 2.3, 3.4]),
-    (("obs", "group"), ["batch1", "batch2"]),
-    (("obsm", "X_pca", 1), [0.4, 0.3]),
-    (("obsm", "protein", "CD14"), [2.1, 3.2]),
-    (("obsp", "neighbors_distances", "Cell2", 0), [0.3, 0]),
-    (("var", "mito"), [0.4, 0.3, 0.2, 0.1]),
-    # (("varm", "", ""), []),
-    (("varp", "cors", "GeneY", 1), [3] * 4),
-    (("raw", "X", "var", "GeneA"), [88, 99]),
-    (("raw", "var", "symbol"), ["Symb1", "Symb2", "Symb3", "Symb4", "Symb5"]),
+    (("layers", "unspliced", "obs", "Cell1"), "var", [0.1, 1.2, 2.3, 3.4]),
+    (("obs", "group"), "obs", ["batch1", "batch2"]),
+    (("obsm", "X_pca", 1), "obs", [0.4, 0.3]),
+    (("obsm", "protein", "CD14"), "obs", [2.1, 3.2]),
+    (("obsp", "neighbors_distances", "Cell2", 0), "obs", [0.3, 0]),
+    (("var", "mito"), "var", [0.4, 0.3, 0.2, 0.1]),
+    # (("varm", "", ""), "var", []),
+    (("varp", "cors", "GeneY", 1), "var", [3] * 4),
+    (("raw", "X", "var", "GeneA"), "obs", [88, 99]),
+    # TODO: is var correct here? It’ll return more variables …
+    (("raw", "var", "symbol"), "var", ["Symb1", "Symb2", "Symb3", "Symb4", "Symb5"]),
 ]
 
 
-@pytest.mark.parametrize("args,expected", paths, ids=repr)
-def test_instantiate(args, expected):
-    RefPath(*args)
+@pytest.mark.parametrize("args,dim,expected", paths, ids=repr)
+def test_dim(args, dim, expected):
+    assert RefPath(*args).dim == dim
 
 
-@pytest.mark.parametrize("args,expected", paths, ids=repr)
-def test_get_vector(args, expected, adata):
+@pytest.mark.parametrize("args,dim,expected", paths, ids=repr)
+def test_get_vector(args, dim, expected, adata):
     rp = RefPath(*args)
     vec = rp.get_vector(adata)
     assert isinstance(vec, np.ndarray)

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -1,0 +1,32 @@
+import pytest
+
+from anndata._core.ref_path import RefPath
+
+
+init_args = [
+    ("layers", "foo", "obs", "Cell1"),
+    ("obs", "group"),
+    ("obsm", "X_pca", 1),
+    ("obsp", "neighbors_distances", "Cell5", 1),
+    ("var", "percent_mito"),
+    ("varm", "protein", "CD14"),
+    ("varp", "cors", "GeneY", 0),  # no idea what to put here
+    ("raw", "X", "var", "GeneX"),
+]
+
+
+@pytest.mark.parametrize("args", init_args)
+def test_instantiate(args):
+    RefPath(*args)
+
+
+@pytest.mark.parametrize(
+    "rp_code", ["RefPath('obs', 'group')", "RefPath('varp', 'neighbors', 'Cell5', 1)"]
+)
+def test_repr(rp_code):
+    rp = eval(rp_code)
+    assert repr(rp) == rp_code
+
+
+def test_get_vector():
+    pass

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -4,7 +4,7 @@ import pandas as pd
 import scipy.sparse as ssp
 
 from anndata import AnnData
-from anndata._core.ref_path import RefPath
+from anndata._core.ref_path import RefPath, split_paths
 
 
 @pytest.fixture
@@ -60,10 +60,6 @@ def test_get_vector(args, dim, expected, adata):
     assert vec.tolist() == expected
 
 
-def test_alias():
-    raise NotImplementedError()
-
-
 @pytest.mark.parametrize(
     "rp_code", ["RefPath('obs', 'group')", "RefPath('varp', 'neighbors', 'Cell5', 1)"]
 )
@@ -98,3 +94,31 @@ def test_parse(spec, resolved):
 def test_parse_failures(spec, err_regex):
     with pytest.raises(ValueError, match=err_regex):
         RefPath.parse(spec)
+
+
+# anndata part (resolving paths)
+
+
+def test_alias():
+    pass  # TODO
+
+
+@pytest.mark.parametrize(
+    "multipath,reference",
+    [
+        ([("obs", "A"), ("X", "var", "G1")], [("obs", "A"), ("X", "var", "G1")]),
+        (("obs", ["A", "B"]), [("obs", "A"), ("obs", "B")]),
+        (
+            (["obs", "var"], ["A", "B"]),
+            [("obs", "A"), ("obs", "B"), ("var", "A"), ("var", "B")],
+        ),
+        (
+            ["G1", ("rX", "var", ["G4", "G5"])],
+            ["G1", ("rX", "var", "G4"), ("rX", "var", "G5")],
+        ),
+    ],
+    ids=repr,
+)
+def test_split_paths(multipath, reference):
+    got = list(split_paths(multipath))
+    assert got == reference

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -77,6 +77,7 @@ def test_repr(rp_code):
     [
         (("X", "var", "GeneX"), ("layers", "X", "var", "GeneX")),
         ("op/foo/bar/0", ("obsp", "foo", "bar", 0)),
+        (("rX", "var", "GeneA"), ("raw", "X", "var", "GeneA")),
     ],
     ids=repr,
 )
@@ -85,14 +86,15 @@ def test_parse(spec, resolved):
 
 
 @pytest.mark.parametrize(
-    "spec,err_cls,err_regex",
+    "spec,err_regex",
     [
-        ("X", ValueError, r".*required .3. ≠ got .1. in path .'X',. for attr layers\."),
-        ("f/XY", ValueError, r"Unknown attr name or short code 'f'\."),
-        ("op/foo/bar/notAnInt", ValueError, r"Invalid.*obsp path: 'notAnInt'\."),
+        (("raw",), r"No path specified\."),
+        ("X", r"required .3. ≠ got .1. in path .'X',. for attr layers\."),
+        ("f/XY", r"Unknown attr name or short code 'f'\."),
+        ("op/foo/bar/notAnInt", r"Invalid.*obsp path: 'notAnInt'\."),
     ],
     ids=repr,
 )
-def test_parse_failures(spec, err_cls, err_regex):
-    with pytest.raises(err_cls, match=err_regex):
+def test_parse_failures(spec, err_regex):
+    with pytest.raises(ValueError, match=err_regex):
         RefPath.parse(spec)

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -1,23 +1,66 @@
 import pytest
+import numpy as np
+import pandas as pd
+import scipy.sparse as ssp
 
+from anndata import AnnData
 from anndata._core.ref_path import RefPath
 
 
-init_args = [
-    ("layers", "foo", "obs", "Cell1"),
-    ("obs", "group"),
-    ("obsm", "X_pca", 1),
-    ("obsp", "neighbors_distances", "Cell5", 1),
-    ("var", "percent_mito"),
-    ("varm", "protein", "CD14"),
-    ("varp", "cors", "GeneY", 0),  # no idea what to put here
-    ("raw", "X", "var", "GeneX"),
+@pytest.fixture
+def adata():
+    return AnnData(
+        X=np.array([[0, 1, 2, 3], [4, 5, 6, 7]]),
+        layers=dict(unspliced=np.array([[0.1, 1.2, 2.3, 3.4], [4.5, 5.6, 6.7, 7.8]])),
+        obs=dict(obs_names=["Cell1", "Cell2"], group=["batch1", "batch2"]),
+        obsm=dict(
+            X_pca=np.array([[0.2, 0.4, 0.6], [0.1, 0.3, 0.5]]),
+            protein=pd.DataFrame(dict(CD14=[2.1, 3.2])),
+        ),
+        obsp=dict(neighbors_distances=ssp.csr_matrix([[0, 0.4], [0.3, 0]])),
+        var=dict(var_names=[f"Gene{i}" for i in "WXYZ"], mito=[0.4, 0.3, 0.2, 0.1]),
+        # varm=dict(...),
+        varp=dict(cors=np.array([(5, 4, 3, 2)] * 4)),
+        raw=dict(
+            X=np.array([[0, 11, 22, 33, 88], [44, 55, 66, 77, 99]]),
+            var=dict(
+                var_names=[f"Gene{i}" for i in "WXYZA"],
+                symbol=[f"Symb{i}" for i in range(1, 6)],
+            ),
+        ),
+    )
+
+
+paths = [
+    (("layers", "unspliced", "obs", "Cell1"), [0.1, 1.2, 2.3, 3.4]),
+    (("obs", "group"), ["batch1", "batch2"]),
+    (("obsm", "X_pca", 1), [0.4, 0.3]),
+    (("obsm", "protein", "CD14"), [2.1, 3.2]),
+    (("obsp", "neighbors_distances", "Cell2", 0), [0.3, 0]),
+    (("var", "mito"), [0.4, 0.3, 0.2, 0.1]),
+    # (("varm", "", ""), []),
+    (("varp", "cors", "GeneY", 1), [3] * 4),
+    (("raw", "X", "var", "GeneA"), [88, 99]),
+    (("raw", "var", "symbol"), ["Symb1", "Symb2", "Symb3", "Symb4", "Symb5"]),
 ]
 
 
-@pytest.mark.parametrize("args", init_args)
-def test_instantiate(args):
+@pytest.mark.parametrize("args,expected", paths, ids=repr)
+def test_instantiate(args, expected):
     RefPath(*args)
+
+
+@pytest.mark.parametrize("args,expected", paths, ids=repr)
+def test_get_vector(args, expected, adata):
+    rp = RefPath(*args)
+    vec = rp.get_vector(adata)
+    assert isinstance(vec, np.ndarray)
+    assert len(vec.shape) == 1
+    assert vec.tolist() == expected
+
+
+def test_alias():
+    raise NotImplementedError()
 
 
 @pytest.mark.parametrize(
@@ -28,5 +71,8 @@ def test_repr(rp_code):
     assert repr(rp) == rp_code
 
 
-def test_get_vector():
-    pass
+@pytest.mark.parametrize(
+    "spec", [(("X", "var", "GeneX"), ("layers", "X", "var", "GeneX")),]
+)
+def test_parse(spec):
+    raise NotImplementedError()

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -73,7 +73,26 @@ def test_repr(rp_code):
 
 
 @pytest.mark.parametrize(
-    "spec", [(("X", "var", "GeneX"), ("layers", "X", "var", "GeneX")),]
+    "spec, resolved",
+    [
+        (("X", "var", "GeneX"), ("layers", "X", "var", "GeneX")),
+        ("op/foo/bar/0", ("obsp", "foo", "bar", 0)),
+    ],
+    ids=repr,
 )
-def test_parse(spec):
-    raise NotImplementedError()
+def test_parse(spec, resolved):
+    assert RefPath.parse(spec) == RefPath(*resolved)
+
+
+@pytest.mark.parametrize(
+    "spec,err_cls,err_regex",
+    [
+        ("X", ValueError, r".*required .3. ≠ got .1. in path .'X',. for attr layers\."),
+        ("f/XY", ValueError, r"Unknown attr name or short code 'f'\."),
+        ("op/foo/bar/notAnInt", ValueError, r"Invalid.*obsp path: 'notAnInt'\."),
+    ],
+    ids=repr,
+)
+def test_parse_failures(spec, err_cls, err_regex):
+    with pytest.raises(err_cls, match=err_regex):
+        RefPath.parse(spec)

--- a/anndata/tests/test_ref_path.py
+++ b/anndata/tests/test_ref_path.py
@@ -142,4 +142,6 @@ def test_split_paths(multipath, reference):
     ids=repr,
 )
 def test_resolve(adata, short_path, resolved):
-    assert resolve_path(adata, short_path) == RefPath(*resolved)
+    if isinstance(short_path, str):
+        short_path = (short_path,)
+    assert resolve_path(adata, *short_path) == RefPath(*resolved)

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -1,5 +1,6 @@
 import warnings
 from functools import wraps, singledispatch
+from textwrap import dedent
 from typing import Mapping, Any, Sequence
 
 import pandas as pd
@@ -170,3 +171,16 @@ class DeprecationMixinMeta(type):
             for item in type.__dir__(cls)
             if not is_deprecated(getattr(cls, item, None))
         ]
+
+
+def _doc_params(**kwds):
+    """\
+    Docstrings should start with "\" in the first line for proper formatting.
+    """
+
+    def dec(obj):
+        obj.__orig_doc__ = obj.__doc__
+        obj.__doc__ = dedent(obj.__doc__).format_map(kwds)
+        return obj
+
+    return dec

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ intersphinx_mapping = dict(
 )
 qualname_overrides = {
     "anndata._core.anndata.AnnData": "anndata.AnnData",
+    "anndata._core.ref_path.RefPath": "anndata.RefPath",
     # Temporarily
     "anndata._core.raw.Raw": "anndata.AnnData",
     "anndata._core.views.ArrayView": "numpy.ndarray",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,8 +106,9 @@ intersphinx_mapping = dict(
 qualname_overrides = {
     "anndata._core.anndata.AnnData": "anndata.AnnData",
     "anndata._core.ref_path.RefPath": "anndata.RefPath",
+    "anndata._core.raw.Raw": "anndata.Raw",
     # Temporarily
-    "anndata._core.raw.Raw": "anndata.AnnData",
+    "anndata._core.sparse_dataset.SparseDataset": "scipy.sparse.spmatrix",
     "anndata._core.views.ArrayView": "numpy.ndarray",
     **{
         f"anndata._core.aligned_mapping.{cls}{kind}": "typing.Mapping"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,4 +20,5 @@ of data and learned annotations. It was initially built for
    api
    fileformat-prose
    benchmarks
+   internal-api
    references

--- a/docs/internal-api.rst
+++ b/docs/internal-api.rst
@@ -1,0 +1,12 @@
+Internal API
+------------
+
+Do not rely on anything in here, it can and will change without notice.
+
+.. currentmodule:: anndata
+
+.. autosummary::
+   :toctree: .
+
+   Raw
+   RefPath


### PR DESCRIPTION
Continuation of theislab/scanpy-tutorials#15 in the proper repo.

This is already pretty usable, I’ll extend and refine it. API:

- [x] `RefPath(attr: str, *path: str|int)` creates and validates a path
- [x] `RefPath.parse(str|(str|int)s|RefPath)` does too, allowing shortcuts like `"o/foo"` → `("obs", "foo")`
- [x] `RefPath.get_vector(adata, alias_col)` fetches a 1D `np.ndarray`
- [x] `AnnData.get_vector(*path: str|RefPathLike, dim: "obs"|"var", layer: str, …)` allows fallback. E.g. `ad.get_vector('foo', dim='obs')` finds foo in `X` or `obs` while `ad.get_vector('X_pca', 0)` finds it in `obsm`. Or so.
- [x] `AnnData.get_df(paths: (str|RefPathLike)s, dim: "obs"|"var", *, layer: str, …)` multiplexed `AnnData.get_vector`. Returns a data frame with unique column names. Colname builder resolves collisions: `"obsm/X_pca/0"` becomes `"X_pca1"` while `"obsm/protein/CD11b_TotalSeqB"` becomes `"CD11b_TotalSeqB"`

Docs:

- [x] [`RefPath`](https://icb-anndata.readthedocs-hosted.com/en/refpaths/anndata.RefPath.html)
- [x] [`AnnData.get_vector`](https://icb-anndata.readthedocs-hosted.com/en/refpaths/anndata.AnnData.get_vector.html)
- [x] [`AnnData.get_df`](https://icb-anndata.readthedocs-hosted.com/en/refpaths/anndata.AnnData.get_df.html)
- [x] [`AnnData.resolve_path`](https://icb-anndata.readthedocs-hosted.com/en/refpaths/anndata.AnnData.resolve_path.html)

Checklist:

- [x] `RefPath.get_vector` supports paths as shorthand `"X/Actb"` or long `("obs", "A/B")`
- [x] add RefPath.dim which is e.g. useful in plotting to check if all RefPaths will return matching stuff
- handle numeric key situation.

  - [x] specifically for varp/obsp
  - [ ] generically for varm/obsm: **But how**? always converting strings to ints when possible is bad since DataFrame ambiguities, but `"obsm/X_pca/0"` is useful if X_pca is an array.

- `get_vector` and `get_df` methods on AnnData that allow leaving things out there when not ambiguous

  - [ ] unambiguous subpaths or keys should resolve (e.g. `("X_pca", 0)` → `("obsm", "X_pca", 0)`), use the usual `layer`, … params as fallback
  - [x] implement `get_df`
    - [x] allow multipaths: `[("obsm", "X_pca", [0, 1])]` would expand to `[("obsm", "X_pca", 0), ("obsm", "X_pca", 1)]`
    - [ ] allow globs: **How**? just allow `"X/var/*"` or so? How to specify in tuples?
      - options: “Could we use either fspath or regex matching?”
    - [ ] maybe allow specifying colnames instead of deriving from paths (maybe by passing `Mapping[str, RefPathLike]`?)
  - [x] implement `get_vector`

- add more tests:

  - [ ] get_df
  - [x] parsing
  - [x] multipath splitting
  - [ ] alias_col
  - [ ] AnnData method