### PR TITLE
Report `n_vars` of `.raw` in `__repr__`

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -549,7 +549,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             backed_at = f"backed at {str(self.filename)!r}"
         else:
             backed_at = ""
-        descr = f"AnnData object with n_obs × n_vars = {n_obs} × {n_vars} {backed_at}"
+        if self.raw is not None:
+            n_vars_raw = f"({self.raw.shape[1]})"
+        else:
+            n_vars_raw = ""
+        descr = f"AnnData object with n_obs × n_vars = {n_obs} × {n_vars}{n_vars_raw} {backed_at}"
         for attr in [
             "obs",
             "var",


### PR DESCRIPTION
It'd be useful to have the shape of the raw data matrix be reported, as that's often what one is interested in. See this example:
![image](https://user-images.githubusercontent.com/16916678/77835216-cf708d80-714a-11ea-9513-d0c059d87858.png)
