### PR TITLE
Improve chunk_X

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1899,28 +1899,41 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if start < n:
             yield (self.X[start:n], start, n)
 
-    def chunk_X(
+    def chunk_obs(
         self,
         select: Union[int, Sequence[int], np.ndarray] = 1000,
+        obs: Optional[str] = None,
+        obsm: Optional[str] = None,
+        layer: Optional[str] = None,
         replace: bool = True,
     ):
         """\
-        Return a chunk of the data matrix :attr:`X` with random or specified indices.
+        Return a chunk of the data matrix :attr:`X`, a key from :attr:`obsm` or
+        a key from :attr:`layers` with random or specified indices.
+        If both obsm and layer are not specified, returns the selection
+        from the data matrix :attr:`X`.
 
         Parameters
         ----------
         select
             Depending on the type:
-
             :class:`int`
                 A random chunk with `select` rows will be returned.
             :term:`sequence` (e.g. a list, tuple or numpy array) of :class:`int`
                 A chunk with these indices will be returned.
-
+        obs
+            If specified, returns a chunk of the annotation from :attr:`obs`.
+        obsm
+            If specified, returns a chunk of the specified key from :attr:`obsm`.
+        layer
+            If specified, returns a chunk of the specified key from :attr:`layers`.
         replace
             If `select` is an integer then `True` means random sampling of
             indices with replacement, `False` without replacement.
         """
+        if obsm is not None and layer is not None:
+            raise ValueError("You can't specify both obsm and layer")
+
         if isinstance(select, int):
             select = select if select < self.n_obs else self.n_obs
             choice = np.random.choice(self.n_obs, select, replace)
@@ -1929,18 +1942,26 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             raise ValueError("select should be int or array")
 
-        reverse = None
-        if self.isbacked:
-            # h5py can only slice with a sorted list of unique index values
-            # so random batch with indices [2, 2, 5, 3, 8, 10, 8] will fail
-            # this fixes the problem
-            indices, reverse = np.unique(choice, return_inverse=True)
-            selection = self.X[indices.tolist()]
+        if obsm is not None:
+            selection = self.obsm[obsm][choice]
+        elif layer is not None:
+            selection = self.layers[layer][choice]
         else:
-            selection = self.X[choice]
+            reverse = None
+            if self.isbacked:
+                # h5py can only slice with a sorted list of unique index values
+                # so random batch with indices [2, 2, 5, 3, 8, 10, 8] will fail
+                # this fixes the problem
+                indices, reverse = np.unique(choice, return_inverse=True)
+                selection = self.X[indices.tolist()]
+            else:
+                selection = self.X[choice]
+            selection = selection.toarray() if issparse(selection) else selection
+            selection = selection if reverse is None else selection[reverse]
 
-        selection = selection.toarray() if issparse(selection) else selection
-        return selection if reverse is None else selection[reverse]
+        if obs is not None:
+            selection = (selection, self.obs[obs])
+        return selection
 
     # --------------------------------------------------------------------------
     # all of the following is for backwards compat

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1910,6 +1910,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         """\
         Return a chunk of the data matrix :attr:`X`, a key from :attr:`obsm` or
         a key from :attr:`layers` with random or specified indices.
+
         If both obsm and layer are not specified, returns the selection
         from the data matrix :attr:`X`.
 
@@ -1917,6 +1918,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         ----------
         select
             Depending on the type:
+
             :class:`int`
                 A random chunk with `select` rows will be returned.
             :term:`sequence` (e.g. a list, tuple or numpy array) of :class:`int`

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1960,7 +1960,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             selection = selection if reverse is None else selection[reverse]
 
         if obs is not None:
-            selection = (selection, self.obs[obs])
+            selection = (selection, self.obs[obs][choice])
         return selection
 
     # --------------------------------------------------------------------------

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1899,6 +1899,49 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if start < n:
             yield (self.X[start:n], start, n)
 
+    @utils.deprecated("chunk_obs")
+    def chunk_X(
+        self,
+        select: Union[int, Sequence[int], np.ndarray] = 1000,
+        replace: bool = True,
+    ):
+        """\
+        Return a chunk of the data matrix :attr:`X` with random or specified indices.
+
+        Parameters
+        ----------
+        select
+            Depending on the type:
+
+            :class:`int`
+                A random chunk with `select` rows will be returned.
+            :term:`sequence` (e.g. a list, tuple or numpy array) of :class:`int`
+                A chunk with these indices will be returned.
+        replace
+            If `select` is an integer then `True` means random sampling of
+            indices with replacement, `False` without replacement.
+        """
+        if isinstance(select, int):
+            select = select if select < self.n_obs else self.n_obs
+            choice = np.random.choice(self.n_obs, select, replace)
+        elif isinstance(select, (np.ndarray, cabc.Sequence)):
+            choice = np.asarray(select)
+        else:
+            raise ValueError("select should be int or array")
+
+        reverse = None
+        if self.isbacked:
+            # h5py can only slice with a sorted list of unique index values
+            # so random batch with indices [2, 2, 5, 3, 8, 10, 8] will fail
+            # this fixes the problem
+            indices, reverse = np.unique(choice, return_inverse=True)
+            selection = self.X[indices.tolist()]
+        else:
+            selection = self.X[choice]
+
+        selection = selection.toarray() if issparse(selection) else selection
+        return selection if reverse is None else selection[reverse]
+
     def chunk_obs(
         self,
         select: Union[int, Sequence[int], np.ndarray] = 1000,


### PR DESCRIPTION
Rename `.chunk_X` to `.chunk_obs`.
Now it can return a selection from annotations in `.obs`.
Also now it can return a selection from a key in `.obsm` or `.layers`.

```
adata.chunk_obs(100, obs='louvain') 
#returns (adata.X[random_chunk], adata.obs['louvain'][random_chunk])

adata.chunk_obs(100, obs='louvain', obsm='X_pca') 
#returns (adata.obsm['X_pca'][random_chunk], adata.obs['louvain'][random_chunk])

adata.chunk_obs([0, 1, 1, 2, 3], obs='louvain')
#returns (adata.X[0, 1, 1, 2, 3], adata.obs['louvain'][0, 1, 1, 2, 3])
```