### PR TITLE
Remove dtype argument from AnnData constructor

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -288,7 +288,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         varm: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
         layers: Optional[Mapping[str, Union[np.ndarray, sparse.spmatrix]]] = None,
         raw: Optional[Mapping[str, Any]] = None,
-        dtype: Union[np.dtype, str] = "float32",
+        dtype: Optional[Union[np.dtype, str]] = None,
         shape: Optional[Tuple[int, int]] = None,
         filename: Optional[PathLike] = None,
         filemode: Optional[Literal["r", "r+"]] = None,
@@ -387,7 +387,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obsp=None,
         raw=None,
         layers=None,
-        dtype="float32",
+        dtype=None,
         shape=None,
         filename=None,
         filemode=None,
@@ -397,6 +397,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._adata_ref = None
         self._oidx = None
         self._vidx = None
+
+        if dtype is not None:
+            warnings.warn(
+                FutureWarning(
+                    "The dtype argument is deprecated and will be removed in anndata 0.8."
+                )
+            )
 
         # ----------------------------------------------------------------------
         # various ways of initializing the data
@@ -460,8 +467,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if shape is not None:
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
             _check_2d_shape(X)
+            # TODO: Remove in 0.8
             # if type doesn’t match, a copy is made, otherwise, use a view
-            if issparse(X) or isinstance(X, ma.MaskedArray):
+            if dtype is None:
+                pass
+            elif issparse(X) or isinstance(X, ma.MaskedArray):
                 # TODO: maybe use view on data attribute of sparse matrix
                 #       as in readwrite.read_10x_h5
                 if X.dtype != np.dtype(dtype):

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1544,17 +1544,17 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Joining on intersection of variables.
 
         >>> adata1 = AnnData(
-        ...     np.array([[1, 2, 3], [4, 5, 6]]),
+        ...     np.array([[1, 2, 3], [4, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s1', 's2'], anno1=['c1', 'c2']),
         ...     dict(var_names=['a', 'b', 'c'], annoA=[0, 1, 2]),
         ... )
         >>> adata2 = AnnData(
-        ...     np.array([[1, 2, 3], [4, 5, 6]]),
+        ...     np.array([[1, 2, 3], [4, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s3', 's4'], anno1=['c3', 'c4']),
         ...     dict(var_names=['d', 'c', 'b'], annoA=[0, 1, 2]),
         ... )
         >>> adata3 = AnnData(
-        ... np.array([[1, 2, 3], [4, 5, 6]]),
+        ... np.array([[1, 2, 3], [4, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s1', 's2'], anno2=['d3', 'd4']),
         ...     dict(var_names=['d', 'c', 'b'], annoA=[0, 2, 3], annoB=[0, 1, 2]),
         ... )
@@ -1667,17 +1667,17 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         >>> from scipy.sparse import csr_matrix
         >>> adata1 = AnnData(
-        ...     csr_matrix([[0, 2, 3], [0, 5, 6]]),
+        ...     csr_matrix([[0, 2, 3], [0, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s1', 's2'], anno1=['c1', 'c2']),
         ...     dict(var_names=['a', 'b', 'c']),
         ... )
         >>> adata2 = AnnData(
-        ... csr_matrix([[0, 2, 3], [0, 5, 6]]),
+        ... csr_matrix([[0, 2, 3], [0, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s3', 's4'], anno1=['c3', 'c4']),
         ...     dict(var_names=['d', 'c', 'b']),
         ... )
         >>> adata3 = AnnData(
-        ... csr_matrix([[1, 2, 0], [0, 5, 6]]),
+        ... csr_matrix([[1, 2, 0], [0, 5, 6]], dtype="float32"),
         ...     dict(obs_names=['s5', 's6'], anno2=['d3', 'd4']),
         ...     dict(var_names=['d', 'c', 'b']),
         ... )

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1231,7 +1231,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Same as `adata = adata[:, index]`, but inplace.
         """
         adata_subset = self[:, index].copy()
-        self._init_as_actual(adata_subset, dtype=self._X.dtype)
+        self._init_as_actual(adata_subset)
 
     def _inplace_subset_obs(self, index: Index1D):
         """\
@@ -1240,7 +1240,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Same as `adata = adata[index, :]`, but inplace.
         """
         adata_subset = self[index].copy()
-        self._init_as_actual(adata_subset, dtype=self.X.dtype)
+        self._init_as_actual(adata_subset)
 
     # TODO: Update, possibly remove
     def __setitem__(
@@ -1292,7 +1292,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             varp=self.obsp.copy(),
             filename=self.filename,
             layers={k: t_csr(v) for k, v in self.layers.items()},
-            dtype=self.X.dtype.name,
         )
 
     T = property(transpose)
@@ -1438,13 +1437,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 X = _subset(self._adata_ref.X, (self._oidx, self._vidx)).copy()
             else:
                 X = self.X.copy()
-            # TODO: Figure out what case this is:
-            if X is not None:
-                dtype = X.dtype
-                if X.shape != self.shape:
-                    X = X.reshape(self.shape)
-            else:
-                dtype = "float32"
             return AnnData(
                 X=X,
                 obs=self.obs.copy(),
@@ -1460,7 +1452,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 varp=self.varp.copy(),
                 raw=self.raw.copy() if self.raw is not None else None,
                 layers=self.layers.copy(),
-                dtype=dtype,
             )
         else:
             from .._io import read_h5ad

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -390,7 +390,7 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index):
            [0., 1., 0.],
            [0., 0., 1.],
            [0., 1., 0.],
-           [1., 0., 0.]], dtype=float32)
+           [1., 0., 0.]])
     """
     return Reindexer(cur_var, new_var)
 
@@ -652,21 +652,21 @@ def concat(
     >>> import anndata as ad, pandas as pd, numpy as np
     >>> from scipy import sparse
     >>> a = ad.AnnData(
-    ...     X=sparse.csr_matrix(np.array([[0, 1], [2, 3]])),
+    ...     X=sparse.csr_matrix(np.array([[0, 1], [2, 3]]), dtype=float),
     ...     obs=pd.DataFrame({"group": ["a", "b"]}, index=["s1", "s2"]),
     ...     var=pd.DataFrame(index=["var1", "var2"]),
     ...     varm={"ones": np.ones((2, 5)), "rand": np.random.randn(2, 3), "zeros": np.zeros((2, 5))},
     ...     uns={"a": 1, "b": 2, "c": {"c.a": 3, "c.b": 4}},
     ... )
     >>> b = ad.AnnData(
-    ...     X=sparse.csr_matrix(np.array([[4, 5, 6], [7, 8, 9]])),
+    ...     X=sparse.csr_matrix(np.array([[4, 5, 6], [7, 8, 9]]), dtype=float),
     ...     obs=pd.DataFrame({"group": ["b", "c"], "measure": [1.2, 4.3]}, index=["s3", "s4"]),
     ...     var=pd.DataFrame(index=["var1", "var2", "var3"]),
     ...     varm={"ones": np.ones((3, 5)), "rand": np.random.randn(3, 5)},
     ...     uns={"a": 1, "b": 3, "c": {"c.b": 4}},
     ... )
     >>> c = ad.AnnData(
-    ...     X=sparse.csr_matrix(np.array([[10, 11], [12, 13]])),
+    ...     X=sparse.csr_matrix(np.array([[10, 11], [12, 13]]), dtype=float),
     ...     obs=pd.DataFrame({"group": ["a", "b"]}, index=["s1", "s2"]),
     ...     var=pd.DataFrame(index=["var3", "var4"]),
     ...     uns={"a": 1, "b": 4, "c": {"c.a": 3, "c.b": 4, "c.c": 5}},

--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -323,16 +323,6 @@ def read_h5ad_backed(filename: Union[str, Path], mode: Literal["r", "r+"]) -> An
 
     d["raw"] = _read_raw(f, attrs={"var", "varm"})
 
-    X_dset = f.get("X", None)
-    if X_dset is None:
-        pass
-    elif isinstance(X_dset, h5py.Group):
-        d["dtype"] = X_dset["data"].dtype
-    elif hasattr(X_dset, "dtype"):
-        d["dtype"] = f["X"].dtype
-    else:
-        raise ValueError()
-
     _clean_uns(d)
 
     return AnnData(**d)
@@ -413,16 +403,6 @@ def read_h5ad(
                 d[k] = read_attribute(f[k])
 
         d["raw"] = _read_raw(f, as_sparse, rdasp)
-
-        X_dset = f.get("X", None)
-        if X_dset is None:
-            pass
-        elif isinstance(X_dset, h5py.Group):
-            d["dtype"] = X_dset["data"].dtype
-        elif hasattr(X_dset, "dtype"):
-            d["dtype"] = f["X"].dtype
-        else:
-            raise ValueError()
 
     _clean_uns(d)  # backwards compat
 

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -139,7 +139,6 @@ def gen_adata(
         layers=layers,
         obsp=obsp,
         varp=varp,
-        dtype=X_dtype,
         uns=uns,
     )
     return adata

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -394,3 +394,19 @@ def assert_adata_equal(a: AnnData, b: AnnData, exact: bool = False):
         assert_equal(a.raw.X, b.raw.X, exact, elem_name="raw/X")
         assert_equal(a.raw.var, b.raw.var, exact, elem_name="raw/var")
         assert_equal(a.raw.varm, b.raw.varm, exact, elem_name="raw/varm")
+
+
+# Common test fixtures
+
+
+@pytest.fixture(
+    params=[asarray, sparse.csr_matrix, sparse.csc_matrix],
+    ids=["np_array", "scipy_csr", "scipy_csc"],
+)
+def array_type(request):
+    return request.param
+
+
+@pytest.fixture(params=[np.int64, np.float64, np.float32])
+def numeric_dtype(request):
+    return request.param

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -8,7 +8,7 @@ from scipy import sparse as sp
 from scipy.sparse import csr_matrix, issparse
 
 from anndata import AnnData
-from anndata.tests.helpers import assert_equal, gen_adata
+from anndata.tests.helpers import assert_equal, gen_adata, array_type, numeric_dtype
 
 
 # some test objects that we use below
@@ -47,6 +47,11 @@ def test_creation():
     assert adata.X is None
     assert adata.shape == shape
     assert "test" in adata.uns
+
+
+def test_X_reference(array_type, numeric_dtype):
+    X = array_type(np.arange(16, dtype=numeric_dtype).reshape(4, 4))
+    assert AnnData(X).X is X
 
 
 def test_create_with_dfs():
@@ -364,9 +369,7 @@ def test_slicing_remove_unused_categories():
 
 def test_get_subset_annotation():
     adata = AnnData(
-        np.array([[1, 2, 3], [4, 5, 6]]),
-        dict(S=["A", "B"]),
-        dict(F=["a", "b", "c"]),
+        np.array([[1, 2, 3], [4, 5, 6]]), dict(S=["A", "B"]), dict(F=["a", "b", "c"]),
     )
 
     assert adata[0, 0].obs["S"].tolist() == ["A"]

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -369,7 +369,9 @@ def test_slicing_remove_unused_categories():
 
 def test_get_subset_annotation():
     adata = AnnData(
-        np.array([[1, 2, 3], [4, 5, 6]]), dict(S=["A", "B"]), dict(F=["a", "b", "c"]),
+        np.array([[1, 2, 3], [4, 5, 6]]),
+        dict(S=["A", "B"]),
+        dict(F=["a", "b", "c"]),
     )
 
     assert adata[0, 0].obs["S"].tolist() == ["A"]

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -17,16 +17,8 @@ from anndata import AnnData, Raw, concat
 from anndata._core.index import _subset
 from anndata._core import merge
 from anndata.tests import helpers
-from anndata.tests.helpers import assert_equal, gen_adata
+from anndata.tests.helpers import assert_equal, gen_adata, array_type
 from anndata.utils import asarray
-
-
-@pytest.fixture(
-    params=[asarray, sparse.csr_matrix, sparse.csc_matrix],
-    ids=["np_array", "scipy_csr", "scipy_csc"],
-)
-def array_type(request):
-    return request.param
 
 
 @pytest.fixture(params=["inner", "outer"])
@@ -863,10 +855,7 @@ def gen_concat_params(unss, compat2result):
             },
         ),
         gen_concat_params(
-            [
-                {"a": {"b": 1, "c": {"d": 3}}},
-                {"a": {"b": 1, "c": {"e": 4}}},
-            ],
+            [{"a": {"b": 1, "c": {"d": 3}}}, {"a": {"b": 1, "c": {"e": 4}}},],
             {
                 None: {},
                 "first": {"a": {"b": 1, "c": {"d": 3, "e": 4}}},
@@ -876,12 +865,7 @@ def gen_concat_params(unss, compat2result):
             },
         ),
         gen_concat_params(
-            [
-                {"a": 1},
-                {"a": 1, "b": 2},
-                {"a": 1, "b": {"b.a": 1}, "c": 3},
-                {"d": 4},
-            ],
+            [{"a": 1}, {"a": 1, "b": 2}, {"a": 1, "b": {"b.a": 1}, "c": 3}, {"d": 4},],
             {
                 None: {},
                 "first": {"a": 1, "b": 2, "c": 3, "d": 4},

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -855,7 +855,10 @@ def gen_concat_params(unss, compat2result):
             },
         ),
         gen_concat_params(
-            [{"a": {"b": 1, "c": {"d": 3}}}, {"a": {"b": 1, "c": {"e": 4}}},],
+            [
+                {"a": {"b": 1, "c": {"d": 3}}},
+                {"a": {"b": 1, "c": {"e": 4}}},
+            ],
             {
                 None: {},
                 "first": {"a": {"b": 1, "c": {"d": 3, "e": 4}}},
@@ -865,7 +868,12 @@ def gen_concat_params(unss, compat2result):
             },
         ),
         gen_concat_params(
-            [{"a": 1}, {"a": 1, "b": 2}, {"a": 1, "b": {"b.a": 1}, "c": 3}, {"d": 4},],
+            [
+                {"a": 1},
+                {"a": 1, "b": 2},
+                {"a": 1, "b": {"b.a": 1}, "c": 3},
+                {"d": 4},
+            ],
             {
                 None: {},
                 "first": {"a": 1, "b": 2, "c": 3, "d": 4},

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -41,14 +41,16 @@ def test_get_obsvar_array(adata):
     with pytest.warns(DeprecationWarning):  # Just to hide warnings
         assert np.allclose(adata._get_obs_array("a"), adata.obs_vector("a"))
         assert np.allclose(
-            adata._get_obs_array("a", layer="x2"), adata.obs_vector("a", layer="x2"),
+            adata._get_obs_array("a", layer="x2"),
+            adata.obs_vector("a", layer="x2"),
         )
         assert np.allclose(
             adata._get_obs_array("a", use_raw=True), adata.raw.obs_vector("a")
         )
         assert np.allclose(adata._get_var_array("s1"), adata.var_vector("s1"))
         assert np.allclose(
-            adata._get_var_array("s1", layer="x2"), adata.var_vector("s1", layer="x2"),
+            adata._get_var_array("s1", layer="x2"),
+            adata.var_vector("s1", layer="x2"),
         )
         assert np.allclose(
             adata._get_var_array("s1", use_raw=True), adata.raw.var_vector("s1")

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -41,16 +41,14 @@ def test_get_obsvar_array(adata):
     with pytest.warns(DeprecationWarning):  # Just to hide warnings
         assert np.allclose(adata._get_obs_array("a"), adata.obs_vector("a"))
         assert np.allclose(
-            adata._get_obs_array("a", layer="x2"),
-            adata.obs_vector("a", layer="x2"),
+            adata._get_obs_array("a", layer="x2"), adata.obs_vector("a", layer="x2"),
         )
         assert np.allclose(
             adata._get_obs_array("a", use_raw=True), adata.raw.obs_vector("a")
         )
         assert np.allclose(adata._get_var_array("s1"), adata.var_vector("s1"))
         assert np.allclose(
-            adata._get_var_array("s1", layer="x2"),
-            adata.var_vector("s1", layer="x2"),
+            adata._get_var_array("s1", layer="x2"), adata.var_vector("s1", layer="x2"),
         )
         assert np.allclose(
             adata._get_var_array("s1", use_raw=True), adata.raw.var_vector("s1")
@@ -92,6 +90,13 @@ def test_force_dense_deprecated(tmp_path):
     assert isinstance(dense.X, np.ndarray)
     assert isinstance(dense.raw.X, np.ndarray)
     assert_equal(adata, dense)
+
+
+def test_dtype_deprecated():
+    X = np.arange(16).reshape(4, 4)
+    with pytest.warns(FutureWarning):
+        a = AnnData(np.arange(16).reshape(4, 4), dtype="float32")
+    assert a.X is not X
 
 
 #######################################

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -22,7 +22,7 @@ def adata():
         [4, 5, 6],
         [7, 8, 9],
     ]  # data matrix of shape n_obs x n_vars
-    X = np.array(X_list)
+    X = np.array(X_list, dtype="int32")
     obs_dict = dict(  # annotation of observations / rows
         row_names=["name1", "name2", "name3"],  # row annotation
         oanno1=["cat1", "cat2", "cat2"],  # categorical annotation
@@ -41,7 +41,6 @@ def adata():
         obsm=dict(o1=np.zeros((X.shape[0], 10))),
         varm=dict(v1=np.ones((X.shape[1], 20))),
         layers=dict(float=X.astype(float), sparse=sparse.csr_matrix(X)),
-        dtype="int32",
     )
 
 

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -35,7 +35,10 @@ uns_dict = dict(  # unstructured annotation
 @pytest.fixture
 def adata_raw():
     adata = ad.AnnData(
-        np.array(data), obs=obs_dict, var=var_dict, uns=uns_dict, dtype="int32"
+        np.array(data, dtype="int32"),
+        obs=obs_dict,
+        var=var_dict,
+        uns=uns_dict,
     )
     adata.raw = adata
     # Make them different shapes

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -172,8 +172,8 @@ def test_readwrite_zarr(typ, tmp_path):
 
 @pytest.mark.parametrize("typ", [np.array, csr_matrix])
 def test_readwrite_maintain_X_dtype(typ, backing_h5ad):
-    X = typ(X_list)
-    adata_src = ad.AnnData(X, dtype="int8")
+    X = typ(X_list, dtype="int8")
+    adata_src = ad.AnnData(X)
     adata_src.write(backing_h5ad)
 
     adata = ad.read(backing_h5ad)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -77,8 +77,8 @@ def mapping_name(request):
 
 
 def test_views():
-    X = np.array(X_list)
-    adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict, dtype="int32")
+    X = np.array(X_list, dtype="int32")
+    adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
 
     assert adata[:, 0].is_view
     assert adata[:, 0].X.tolist() == np.reshape([1, 4, 7], (3, 1)).tolist()
@@ -179,7 +179,7 @@ def test_set_var(adata, subset_func):
 
 
 def test_drop_obs_column():
-    adata = ad.AnnData(np.array(X_list), obs=obs_dict, dtype="int32")
+    adata = ad.AnnData(np.array(X_list, dtype="int32"), obs=obs_dict)
 
     subset = adata[:2]
     assert subset.is_view

--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -65,13 +65,13 @@ For example, given two anndata objects with differing variables:
            [0., 1.],
            [0., 0.],
            [0., 1.],
-           [1., 0.]], dtype=float32)
+           [1., 0.]])
     >>> ad.concat([a, b], join="outer").X.toarray()
     array([[1., 0., 0.],
            [0., 1., 0.],
            [0., 0., 1.],
            [0., 1., 0.],
-           [1., 0., 0.]], dtype=float32)
+           [1., 0., 0.]])
 
 The join argument is used for any element which has both (1) an axis being concatenated and (2) has an axis not being concatenated.
 When concatenating along the `obs` dimension, this means elements of `.X`, `obs`, `.layers`, and `.obsm` will be affected by the choice of `join`.


### PR DESCRIPTION
Fixes #129 

Brought up again by https://github.com/theislab/scanpy/issues/1415

This PR makes the `dtype` argument of the `AnnData` constructor default to `None`, and throws a warning if it is passed. The idea is that we should just accept whatever array was passed as `X`.

This code change breaks some tests in scanpy. AFAICT, this can all be fixed on the scanpy side.

@falexwolf @flying-sheep, how do we want to handle this breaking change? A few thoughts:

* One option: this goes in 0.8, and we throw a warning if `dtype` is passed
* Should we warn about this before it's in a breaking release? Might be hard to do, since it's a changing default.

# TODO

- [ ] Fix tests on scanpy side
- [ ] Figure out how we want to handle this change
- [ ] Check for/ remove old tests for dtype argument