### PR TITLE
Fix ImportError when no zarr module

### DIFF
--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -19,7 +19,7 @@ try:
 except ImportError as e:
 
     def write_zarr(*_, **__):
-        raise e
+        raise ImportError("Couldn't import 'zarr' module (not installed?)")
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
It looks like this was intended to re-raise the `ImportError` thrown from `from .zarr import write_zarr`, but this exception object isn't part of the closure of the stub `write_zarr` function. This results in a rather confusing `NameError`:

```
Python 3.8.5 (default, Jul 28 2020, 12:59:40)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import anndata

In [2]: d = anndata.read_h5ad('test.h5ad')

In [3]: d.write_zarr('test.zarr')
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-3-c464adf1b7d1> in <module>
----> 1 d.write_zarr('test.zarr')

~/.opt/python3.8-venv/lib/python3.8/site-packages/anndata/_core/anndata.py in write_zarr(self, store, chunks)
   1906         from .._io.write import write_zarr
   1907
-> 1908         write_zarr(store, self, chunks=chunks)
   1909
   1910     def chunked_X(self, chunk_size: Optional[int] = None):

~/.opt/python3.8-venv/lib/python3.8/site-packages/anndata/_io/write.py in write_zarr(*_, **__)
     20
     21     def write_zarr(*_, **__):
---> 22         raise e
     23
     24

NameError: name 'e' is not defined
```

Replace this `NameError` with a more interpretable failure, suggesting that people install the `zarr` package as required. I don't have a strong opinion about the wording of the new `ImportError` message, but anything is better than what I pasted above.