### PR TITLE
WIP: add _repr_html_() method to AnnData for nicer rendering in Jupyter

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -588,19 +588,18 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self._gen_repr(self.n_obs, self.n_vars)
 
-
-    def _repr_html_(self) -> str:    
+    def _repr_html_(self) -> str:
         overview = []
-        
+
         if self.is_view:
             overview.append("is a view")
 
         overview.append(f"n_obs: {self.n_obs}")
         overview.append(f"n_vars: {self._n_vars}")
-        overview.append(svg_anndata(self.n_obs,self.n_vars))
+        overview.append(svg_anndata(self.n_obs, self.n_vars))
 
         cols = [make_single_column_table("AnnData object", overview)]
-        
+
         for attr in [
             "obs",
             "var",
@@ -614,9 +613,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             keys = getattr(self, attr).keys()
             if len(keys):
                 cols.append(make_single_column_table(attr, keys))
-        
-        return(make_single_row_table(cols))
 
+        return make_single_row_table(cols)
 
     def __eq__(self, other):
         """Equality testing"""

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -44,6 +44,7 @@ from .views import (
 from .sparse_dataset import SparseDataset
 from .. import utils
 from ..utils import convert_to_dict, ensure_df_homogeneous
+from ..html_repr import make_single_column_table, make_single_row_table
 from ..logging import anndata_logger as logger
 from ..compat import (
     ZarrArray,
@@ -586,6 +587,32 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             return "View of " + self._gen_repr(self.n_obs, self.n_vars)
         else:
             return self._gen_repr(self.n_obs, self.n_vars)
+
+
+    def _repr_html_(self) -> str:
+        html = ""
+        if self.is_view:
+            html += "View of: <br>"
+        backed_at = ("", f" backed at {str(self.filename)!r}")[self.isbacked]
+        html += f"<b>AnnData object</b> with <em>n_obs × n_vars</em> = {self.n_obs} × {self.n_vars}{backed_at}"
+        cols = []
+        for attr in [
+            "obs",
+            "var",
+            "uns",
+            "obsm",
+            "varm",
+            "layers",
+            "obsp",
+            "varp",
+        ]:
+            keys = getattr(self, attr).keys()
+            if len(keys):
+                cols.append(self._make_single_column_table(attr, keys))
+        if len(cols):
+            html += self.make_single_row_table(cols) 
+        return html
+
 
     def __eq__(self, other):
         """Equality testing"""

--- a/anndata/html_repr.py
+++ b/anndata/html_repr.py
@@ -1,4 +1,7 @@
 from typing import Iterable
+import math
+import re
+import numpy as np
 
 def make_single_column_table(heading: str, entries: Iterable[str]) -> str:
     table = f"""
@@ -34,3 +37,122 @@ def make_single_row_table(entries: Iterable[str]) -> str:
         </table>
     """
     return table
+
+# much of the svg code below is copied or adapted
+# from the dask project 
+# https://github.com/dask/dask/blob/main/dask/array/svg.py
+
+
+text_style = 'font-size="1.0rem" font-weight="100" text-anchor="middle"'
+
+
+def svg_anndata(n_obs, n_var, size=200, sizes=None):
+    shape = (n_var, n_obs)
+    sizes = sizes or draw_sizes(shape, size=size)
+    lines, (min_x, max_x, min_y, max_y) = svg_box(sizes[0], sizes[1], size=size)
+
+    header = (
+        '<svg width="%d" height="%d" style="stroke:rgb(0,0,0);stroke-width:1" >\n'
+        % (max_x + 50, max_y + 50)
+    )
+    footer = "\n</svg>"
+
+    #if shape[0] >= 100:
+    #    rotate = -90
+    #else:
+    rotate = 0
+
+    text = [
+        "",
+        "  <!-- Text -->",
+        '  <text x="%f" y="%f" %s >%d</text>'
+        % (max_x / 2, max_y + 20, text_style, shape[0]),
+        '  <text x="%f" y="%f" %s transform="rotate(%d,%f,%f)">%d</text>'
+        % (max_x + 20, max_y / 2, text_style, rotate, max_x + 20, max_y / 2, shape[1]),
+    ]
+
+    return header + "\n".join(lines + text) + footer
+
+
+
+def svg_lines(x1, y1, x2, y2):
+    """Convert points into lines of text for an SVG plot
+    Examples
+    --------
+    >>> svg_lines([0, 1], [0, 0], [10, 11], [1, 1])  # doctest: +NORMALIZE_WHITESPACE
+    ['  <line x1="0" y1="0" x2="10" y2="1" style="stroke-width:2" />',
+     '  <line x1="1" y1="0" x2="11" y2="1" style="stroke-width:2" />']
+    """
+    n = len(x1)
+
+    lines = [
+        '  <line x1="%d" y1="%d" x2="%d" y2="%d" />' % (x1[i], y1[i], x2[i], y2[i])
+        for i in range(n)
+    ]
+
+    lines[0] = lines[0].replace(" /", ' style="stroke-width:2" /')
+    lines[-1] = lines[-1].replace(" /", ' style="stroke-width:2" /')
+    return lines
+
+
+def svg_box(w, h, size=200):
+    """Create lines of SVG text that show a grid
+    Parameters
+    ----------
+    x: numpy.ndarray
+    y: numpy.ndarray
+    offset: tuple
+        translational displacement of the grid in SVG coordinates
+    """
+
+    x = np.array((0,w))
+    y = np.array((0,h))
+    
+    # Horizontal lines
+    x1 = np.zeros_like(y)
+    y1 = y
+    x2 = np.full_like(y, x[-1])
+    y2 = y
+
+    h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
+
+    # Vertical lines
+    x1 = x 
+    y1 = np.zeros_like(x) 
+    x2 = x 
+    y2 = np.full_like(x, y[-1])
+
+    v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
+
+    color = "ECB172" # if len(x) < max_n and len(y) < max_n else "8B4903"
+    corners = f"{x1[0]},{y1[0]} {x1[-1]},{y1[-1]} {x2[-1]},{y2[-1]} {x2[0]},{y2[0]}"
+    rect = [
+        "",
+        "  <!-- Colored Rectangle -->",
+        f'  <polygon points="{corners}" style="fill:#{color}A0;stroke-width:0"/>',
+    ]
+
+    return h_lines + v_lines + rect, (0, w, 0, h)
+
+
+def draw_sizes(shape, size=200):
+    """ Get size in pixels for all dimensions """
+    mx = max(shape)
+    ratios = [mx / max(0.1, d) for d in shape]
+    ratios = [ratio_response(r) for r in ratios]
+    return tuple(size / r for r in ratios)
+
+
+def ratio_response(x):
+    """How we display actual size ratios
+    Common ratios in sizes span several orders of magnitude,
+    which is hard for us to perceive.
+    We keep ratios in the 1-3 range accurate, and then apply a logarithm to
+    values up until about 100 or so, at which point we stop scaling.
+    """
+    if x < math.e:
+        return x
+    elif x <= 100:
+        return math.log(x + 12.4)  # f(e) == e
+    else:
+        return math.log(100 + 12.4)

--- a/anndata/html_repr.py
+++ b/anndata/html_repr.py
@@ -3,6 +3,7 @@ import math
 import re
 import numpy as np
 
+
 def make_single_column_table(heading: str, entries: Iterable[str]) -> str:
     table = f"""
         <table>
@@ -17,11 +18,12 @@ def make_single_column_table(heading: str, entries: Iterable[str]) -> str:
                     <td>{entry}</td>
                 </tr>
                 """
-    table +=  """
+    table += """
             </tbody>
         </table>
-    """  
+    """
     return table
+
 
 def make_single_row_table(entries: Iterable[str]) -> str:
     table = f"""
@@ -31,15 +33,16 @@ def make_single_row_table(entries: Iterable[str]) -> str:
             """
     for entry in entries:
         table += f"""<td style="vertical-align:top">{entry}</td>"""
-    table +=  """
+    table += """
                 </tr>
             </tbody>
         </table>
     """
     return table
 
+
 # much of the svg code below is copied or adapted
-# from the dask project 
+# from the dask project
 # https://github.com/dask/dask/blob/main/dask/array/svg.py
 
 
@@ -57,9 +60,9 @@ def svg_anndata(n_obs, n_var, size=200, sizes=None):
     )
     footer = "\n</svg>"
 
-    #if shape[0] >= 100:
+    # if shape[0] >= 100:
     #    rotate = -90
-    #else:
+    # else:
     rotate = 0
 
     text = [
@@ -72,7 +75,6 @@ def svg_anndata(n_obs, n_var, size=200, sizes=None):
     ]
 
     return header + "\n".join(lines + text) + footer
-
 
 
 def svg_lines(x1, y1, x2, y2):
@@ -105,9 +107,9 @@ def svg_box(w, h, size=200):
         translational displacement of the grid in SVG coordinates
     """
 
-    x = np.array((0,w))
-    y = np.array((0,h))
-    
+    x = np.array((0, w))
+    y = np.array((0, h))
+
     # Horizontal lines
     x1 = np.zeros_like(y)
     y1 = y
@@ -117,14 +119,14 @@ def svg_box(w, h, size=200):
     h_lines = ["", "  <!-- Horizontal lines -->"] + svg_lines(x1, y1, x2, y2)
 
     # Vertical lines
-    x1 = x 
-    y1 = np.zeros_like(x) 
-    x2 = x 
+    x1 = x
+    y1 = np.zeros_like(x)
+    x2 = x
     y2 = np.full_like(x, y[-1])
 
     v_lines = ["", "  <!-- Vertical lines -->"] + svg_lines(x1, y1, x2, y2)
 
-    color = "ECB172" # if len(x) < max_n and len(y) < max_n else "8B4903"
+    color = "ECB172"  # if len(x) < max_n and len(y) < max_n else "8B4903"
     corners = f"{x1[0]},{y1[0]} {x1[-1]},{y1[-1]} {x2[-1]},{y2[-1]} {x2[0]},{y2[0]}"
     rect = [
         "",

--- a/anndata/html_repr.py
+++ b/anndata/html_repr.py
@@ -1,0 +1,36 @@
+from typing import Iterable
+
+def make_single_column_table(heading: str, entries: Iterable[str]) -> str:
+    table = f"""
+        <table>
+            <thead>
+                <tr><th> {heading} </th></tr>
+            </thead>
+            <tbody>
+            """
+    for entry in entries:
+        table += f"""
+                <tr>
+                    <td>{entry}</td>
+                </tr>
+                """
+    table +=  """
+            </tbody>
+        </table>
+    """  
+    return table
+
+def make_single_row_table(entries: Iterable[str]) -> str:
+    table = f"""
+        <table>
+            <tbody>
+                <tr>
+            """
+    for entry in entries:
+        table += f"""<td style="vertical-align:top">{entry}</td>"""
+    table +=  """
+                </tr>
+            </tbody>
+        </table>
+    """
+    return table


### PR DESCRIPTION
## About
This is a draft PR that adds a `_repr_html_()` method to the AnnData class for nicer rendering in Jupyter.
This is heavily inspired from similar functionality in dask and re-uses some of dasks code for generating SVG/HTML.
The new functionality is best described by this screenshot:

![image](https://user-images.githubusercontent.com/2210044/111462831-2c2fd400-871f-11eb-9258-ca239f504b7a.png)

## WIP status

Currently this is still very much in draft status, there are no unit tests, the formatting is a bit wonky and I have not looked at visualizing all aspects of an AnnData object as I am a newcomer to anndata and have only used a very limited subset.

Before I invest more time into this I just wanted to see, whether something like this is of interest at all.
If you think it is worthwhile, there's more work ahead, such as shortening very long lists of variable or observation keys with `...` entries (similar to pandas). 
