### PR TITLE
Sum by method (to create pseudobulk)

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1292,7 +1292,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         N_obs = groupy_object.ngroups
         N_var = X.shape[1]
         X_summed = sparse.lil_matrix((N_obs, N_var))
-        
+
         group_names = []
         index_names = []
         row = 0
@@ -1300,7 +1300,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             X_summed[row] = X[idx_].sum(0)
             row += 1
             group_names.append(group_columns)
-            index_names.append('-'.join(map(str, group_columns)))
+            index_names.append("-".join(map(str, group_columns)))
 
         if sparse.isspmatrix_csr(X):
             X_summed = X_summed.tocsr()
@@ -1310,7 +1310,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obs = pd.DataFrame(group_names, columns=group_list, index=index_names)
 
         return AnnData(X=X_summed, obs=obs, var=self.var)
-    
+
     def transpose(self) -> "AnnData":
         """\
         Transpose whole object.

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1113,7 +1113,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if not is_categorical_dtype(df_full[k]):
                 continue
             all_categories = df_full[k].cat.categories
-            df_sub[k] = df_sub[k].cat.remove_unused_categories()
+            df_sub.loc[:, k] = df_sub[k].cat.remove_unused_categories()
             # also correct the colors...
             color_key = f"{k}_colors"
             if color_key not in uns:


### PR DESCRIPTION
I implemented a helper method for AnnData that allow a user to sum gene expression in `.X` based on groups in columns of `.obs`.

The primary use case for this is 'pseudo-bulk' style analysis. Cells can be grouped by e.g. donor, experimental condition, and cell type. Then the UMI counts can be studied as if there were from a population of cells rather than individual cells.

Here is an example:
```
> import anndata
> adata = anndata.read('/mnt/efs/h5ad/External/Hrvatin et al 2018/GSE102827_merged_all_raw.h5ad')
> adata
AnnData object with n_obs × n_vars = 65539 × 25187
    obs: 'stim', 'sample', 'maintype', 'celltype', 'subtype', 'sample_idx'
    var: 'required', 'highly_variable', 'means', 'dispersions', 'dispersions_norm', 'highly_variable_nbatches', 'highly_variable_intersection'
> sum_adata = adata.sum_by(['stim', 'sample', 'celltype'])
> sum_adata
AnnData object with n_obs × n_vars = 909 × 25187
    obs: 'stim', 'sample', 'celltype'
    var: 'required', 'highly_variable', 'means', 'dispersions', 'dispersions_norm', 'highly_variable_nbatches', 'highly_variable_intersection'
> print(sum_adata.obs.head())
                   stim   sample celltype
0h-B1_1_0h-ExcL4     0h  B1_1_0h    ExcL4
0h-B1_1_0h-ExcL5_3   0h  B1_1_0h  ExcL5_3
0h-B1_1_0h-ExcL5_2   0h  B1_1_0h  ExcL5_2
0h-B1_1_0h-ExcL6     0h  B1_1_0h    ExcL6
0h-B1_1_0h-ExcL23    0h  B1_1_0h   ExcL23
> sum_adata.X
<909x25187 sparse matrix of type '<class 'numpy.float32'>'
	with 7374777 stored elements in Compressed Sparse Row format>
```
