### PR TITLE
Cellarity: GroupBy with sparse-matrix agg, scores

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -5,6 +5,7 @@ from ._metadata import __version__, __author__, __email__, within_flit
 if not within_flit():
     del within_flit
     from ._core.anndata import AnnData, ImplicitModificationWarning
+    from ._core.groupby import GroupBy
     from ._core.merge import concat
     from ._core.raw import Raw
     from ._io import (

--- a/anndata/_core/groupby.py
+++ b/anndata/_core/groupby.py
@@ -330,12 +330,15 @@ class GroupBy:
         """
         Form a coordinate-sparse matrix A such that rows of A * X
         are weighted sums of groups of rows of X.
+
         A[i, j] = w includes X[j,:] in group i with weight w.
+
         Params
         ------
         normalize
             If true, weights for each group are normalized to sum to 1.0,
             corresponding to (weighted) mean.
+
         Returns
         -------
         A

--- a/anndata/_core/groupby.py
+++ b/anndata/_core/groupby.py
@@ -324,21 +324,24 @@ class GroupBy:
         else:
             return df
 
-    def sparse_aggregator(self, normalize: bool = False):
+    def sparse_aggregator(
+        self, normalize: bool = False
+    ) -> Tuple[coo_matrix, np.ndarray]:
         """
-        Form a coordinate-sparse matrix A such that rows of A * X are weighted sums of groups of
-        rows of X.
-
+        Form a coordinate-sparse matrix A such that rows of A * X
+        are weighted sums of groups of rows of X.
         A[i, j] = w includes X[j,:] in group i with weight w.
-
         Params
         ------
-        normalize : bool (default: False)
-            If true, weights for each group are normalized to sum to 1.0, corresponding to (weighted) mean.
-
+        normalize
+            If true, weights for each group are normalized to sum to 1.0,
+            corresponding to (weighted) mean.
         Returns
         -------
-            Tuple (A, keys) where keys is an ndarray with keys[i] the group key corresponding to row i of A.
+        A
+            weighted sums of groups of rows of X.
+        keys
+            An ndarray with keys[i] the group key corresponding to row i of A.
         """
         keys, key_index, obs_index, weight_value = self._extract_indices()
         if obs_index is None:
@@ -401,7 +404,7 @@ class GroupBy:
         self._key_index = key_index  # passed to count and count_mean_var to avoid re-extracting in the latter
         return keys, key_index, obs_index, weight_value
 
-    def pd_mean(self):
+    def pd_mean(self) -> pd.DataFrame:
         """
         Slower implementation of mean that masks NaN values.
         """
@@ -415,7 +418,7 @@ class GroupBy:
         )
         return df.groupby(self.key).mean()
 
-    def pd_count_mean_var(self):
+    def pd_count_mean_var(self) -> pd.DataFrame:
         """
         Slower implementation of count_mean_var that masks NaN values.
         """
@@ -430,7 +433,9 @@ class GroupBy:
         )
         return df.groupby(self.key).agg(aggs)
 
-    def pd_score_pairs(self, score: Score, pairs: Collection[Tuple[str, str]]):
+    def pd_score_pairs(
+        self, score: Score, pairs: Collection[Tuple[str, str]]
+    ) -> pd.DataFrame:
         """
         Slower implementation of score_pairs that masks NaN values.
         """

--- a/anndata/_core/groupby.py
+++ b/anndata/_core/groupby.py
@@ -149,8 +149,8 @@ class GroupBy:
         A, keys = self.sparse_aggregator(normalize=True)
         X = self.adata.X
         count_ = np.bincount(self._key_index)
-        mean_ = _toarray(A * X)
-        mean_sq = _toarray(A * _power(X, 2))
+        mean_ = _toarray(A @ X)
+        mean_sq = _toarray(A @ _power(X, 2))
         if self.weight is None:
             sq_mean = mean_ ** 2
         else:

--- a/anndata/_core/groupby.py
+++ b/anndata/_core/groupby.py
@@ -31,7 +31,7 @@ class GroupBy:
 
     Runtime is effectively computation of the product A * X, i.e. the count of (non-zero)
     entries in X with multiplicity the number of group memberships for that entry. This is
-    O(data) for partitions (each observation belongign to exactly one group), independent of
+    O(data) for partitions (each observation belonging to exactly one group), independent of
     the number of groups.
 
     To compute scores, first statistics are computed for each group in at least one pair, and

--- a/anndata/tests/test_groupby.py
+++ b/anndata/tests/test_groupby.py
@@ -1,0 +1,112 @@
+import anndata as ad
+import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+
+
+def test_groupby():
+    genes = ["A", "B"]
+    cells = [
+        "v0",
+        "v1",
+        "v2",
+        "w0",
+        "w1",
+        "a1",
+        "a2",
+        "a3",
+        "b1",
+        "b2",
+        "c1",
+        "c2",
+        "d0",
+    ]
+    pairs = [("v", "b"), ("v", "a"), ("w", "c"), ("w", "d"), ("w", "v")]
+
+    obs = pd.DataFrame(index=pd.Index(cells, name="cell"))
+    obs["key"] = pd.Categorical([c[0] for c in cells])
+    obs["tuple_key"] = pd.Categorical([(c[0],) for c in cells])
+    obs["weight"] = 2.0
+
+    var = pd.DataFrame(index=genes)
+
+    X = np.array(
+        [
+            [0, -2],
+            [1, 13],
+            [2, 1],  # v
+            [3, 12],
+            [4, 2],  # w
+            [5, 11],
+            [6, 3],
+            [7, 10],  # a
+            [8, 4],
+            [9, 9],  # b
+            [10, 5],
+            [11, 8],  # c
+            [12, 6],  # d
+        ],
+        dtype=np.float32,
+    )
+
+    adata_sparse = ad.AnnData(obs=obs, var=var, X=csr_matrix(X))
+    adata_dense = ad.AnnData(obs=obs, var=var, X=X)
+
+    gb = ad.GroupBy(adata_sparse, key="key")
+    stats_sparse = gb.count_mean_var()
+    stats_dense = ad.GroupBy(adata_dense, key="key").count_mean_var()
+    stats_pd = (
+        ad.GroupBy(adata_dense, key="key")
+        .pd_count_mean_var()
+        .swaplevel(axis=1)
+        .sort_index(axis=1)
+    )
+
+    assert stats_sparse["count"].equals(stats_dense["count"])
+    assert np.allclose(stats_sparse["mean"], stats_dense["mean"])
+    assert np.allclose(stats_sparse["var"], stats_dense["var"], equal_nan=True)
+
+    assert stats_sparse["count"].equals(stats_pd["count"]["A"])
+    assert np.allclose(stats_sparse["mean"], stats_pd["mean"])
+    assert np.allclose(stats_sparse["var"], stats_pd["var"], equal_nan=True)
+
+    gb_weight = ad.GroupBy(adata_sparse, key="key", weight="weight")
+    stats_weight = gb_weight.count_mean_var()
+    sum_ = gb.sum()
+    sum_weight = gb_weight.sum()
+
+    assert np.allclose(2 * sum_, sum_weight)
+    assert np.allclose(stats_sparse["mean"], stats_weight["mean"])
+    assert np.allclose(stats_sparse["var"], stats_dense["var"], equal_nan=True)
+
+    key_set = ["v", "w"]
+    mean_key_set = ad.GroupBy(adata_sparse, key="key", key_set=key_set).mean()
+    assert np.allclose(stats_sparse["mean"].loc[key_set], mean_key_set)
+
+    gb_explode = ad.GroupBy(adata_sparse, key="tuple_key", explode=True)
+    stats_explode = gb_explode.count_mean_var()
+
+    assert stats_sparse["count"].equals(stats_explode["count"])
+    assert np.allclose(stats_sparse["mean"], stats_explode["mean"])
+    assert np.allclose(stats_sparse["var"], stats_explode["var"], equal_nan=True)
+
+    for score in [
+        "diff-score",
+        "fold-score",
+        "t-score",
+        "t-score-pooled",
+        "v-score",
+        "v-score-pooled",
+    ]:
+        score_sparse = gb.score_pairs(score, pairs=pairs, nan_to_zero=False)
+        score_explode = gb_explode.score_pairs(score, pairs, nan_to_zero=False)
+        score_pd = gb.pd_score_pairs(score, pairs=pairs)
+
+        assert np.allclose(score_sparse, score_explode, equal_nan=True)
+        assert np.allclose(score_sparse, score_pd, equal_nan=True)
+
+    score_nan = gb.score_pairs("t-score", pairs=pairs, nan_to_zero=False)
+    assert not np.all(np.isfinite(score_nan))
+
+    score_nan[~np.isfinite(score_nan)] = 0
+    assert np.allclose(score_nan, gb.score_pairs("t-score", pairs=pairs))


### PR DESCRIPTION
[Cellarity](https://cellarity.com/) benefits from anndata / scanpy open-source development and is proud to contribute a class I wrote in July 2020 to speed up our Platform.

GroupBy class supports grouping and aggregating AnnData observations by key, per variable and computing scores between pairs of groups.

Features:
- For groups, supports count, sum, mean, and variance. Observations may be weighted.
- For pairs of groups, supports difference of means, ratio of means (fold-change), t-score, v-score, pooled t-score, and pooled v-score. While t-score detects non-zero difference of mean, v-score is a stable measure of distance between means on a variance scale as the number of observations in each group grows.
- Each observation may belong to multiple groups (and to each of these, multiple times) using a tuple key and explode.
- Sparse-matrix aggregation approach works natively with ndarray or scipy sparse formats. Also includes slower Pandas-based implementations, which require dense data but mask NaN instead of propagating.

Implementation/Performance:
- No view or copy overhead on runtime or memory (even when filtering keys, using key_set). If the data loads, you can aggregate it.
- Sums of groups of observations are computed as A * X where A is a coordinate-sparse matrix encoding group memberships and weights, exposed by sparse_aggregator.
- To compute scores, sufficient statistics are computed per group, from which scores are computed per pair. In practice, runtime is dominated by aggregation, so effectively independent of the number of pairs.

So it’s plenty fast to compute representations like t-scores on the fly for many pairs of groups of cells. E.g., computing t-scores for 500,000 cells over 1000 genes for 1800 pairs is reduced from 30m using scanpy.tl.rank_genes_groups to 1.9s (~1000x speedup). For reference, included pandas implementation is 30s, sparse-agg on densified adata is 5s.

Over the full 43K genes (which don't fit densely in RAM), t-scores take 13s for 148 pairs and 19s for 1800 pairs at finer resolution.

While this was designed to be extensible and support computing and optimizing single-cell representations as the data and models grow, I’m hopeful folks will get creative with use-cases on other data types too!