### PR TITLE
Make index_unique boolean for concatenating AnnDatas

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1529,7 +1529,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         batch_key: str = "batch",
         batch_categories: Sequence[Any] = None,
         uns_merge: Optional[str] = None,
-        index_unique: Optional[str] = "-",
+        index_unique: bool = False,
+        index_delimiter: Optional[str] = "-",
         fill_value=None,
     ) -> "AnnData":
         """\
@@ -1565,9 +1566,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             * `"only"`: A value is included if only one of the AnnData objects has a value at this
               path.
         index_unique
-            Make the index unique by joining the existing index names with the
-            batch category, using `index_unique='-'`, for instance. Provide
-            `None` to keep existing indices.
+            If `True`, make the index unique by using the `keys` and `index_delimiter`. When
+            `False`, the original indices are kept.
+        index_delimiter
+            If `index_unique` is True, this is the delimeter in "{orig_idx}{index_unique}{key}".
         fill_value
             Scalar value to fill newly missing values in arrays with. Note: only applies to arrays
             and sparse matrices (not dataframes) and will only be used if `join="outer"`.
@@ -1764,6 +1766,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             uns_merge=uns_merge,
             fill_value=fill_value,
             index_unique=index_unique,
+            index_delimiter=index_delimiter,
             pairwise=False,
         )
 
@@ -1776,6 +1779,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             label=batch_key,
             keys=batch_categories,
             index_unique=index_unique,
+            index_delimiter=index_delimiter,
         ).obs
         # Removing varm
         del out.varm

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -606,7 +606,8 @@ def concat(
     uns_merge: Union[StrategiesLiteral, Callable, None] = None,
     label: Optional[str] = None,
     keys: Optional[Collection] = None,
-    index_unique: Optional[str] = None,
+    index_unique: bool = False,
+    index_delimiter: Optional[str] = "_",
     fill_value: Optional[Any] = None,
     pairwise: bool = False,
 ) -> AnnData:
@@ -650,9 +651,10 @@ def concat(
         `label` or appended to the index if `index_unique` is not `None`. Defaults to
         incrementing integer labels.
     index_unique
-        Whether to make the index unique by using the keys. If provided, this
-        is the delimeter between "{orig_idx}{index_unique}{key}". When `None`,
-        the original indices are kept.
+        If `True`, make the index unique by using the `keys` and `index_delimiter`. When
+        `False`, the original indices are kept.
+    index_delimiter
+        If `index_unique` is True, this is the delimeter between "{orig_idx}{index_unique}{key}".
     fill_value
         When `join="outer"`, this is the value that will be used to fill the introduced
         indices. By default, sparse arrays are padded with zeros, while dense arrays and
@@ -747,7 +749,7 @@ def concat(
     s2     b     a
     s3     b     b
     s4     c     b
-    >>> ad.concat({"a": a, "b": b}, index_unique="-").obs
+    >>> ad.concat({"a": a, "b": b}, index_unique=True, index_delimiter="-").obs
          group
     s1-a     a
     s2-a     b
@@ -815,7 +817,19 @@ def concat(
         [pd.Series(dim_indices(a, axis=axis)) for a in adatas], ignore_index=True
     )
     if index_unique is not None:
-        concat_indices = concat_indices.str.cat(label_col.map(str), sep=index_unique)
+        if isinstance(index_unique, str):
+            warn(
+                "Passing index delimiters to `index_unique` is deprecated and will not work in a"
+                "future version of AnnData. Please pass delimiters to `index_delimiter`.",
+                FutureWarning,
+                stacklevel=4,
+            )
+            index_delimiter = index_unique
+            index_unique = True
+        if index_unique:
+            concat_indices = concat_indices.str.cat(
+                label_col.map(str), sep=index_delimiter
+            )
     concat_indices = pd.Index(concat_indices)
 
     alt_indices = merge_indices(

--- a/anndata/experimental/multi_files/_anncollection.py
+++ b/anndata/experimental/multi_files/_anncollection.py
@@ -611,10 +611,11 @@ class AnnCollection(_ConcatViewMixin, _IterateViewMixin):
         `label` or appended to the index if `index_unique` is not `None`. Defaults to
         incrementing integer labels.
     index_unique
-        Whether to make the index unique by using the keys. If provided, this
-        is the delimeter between "{orig_idx}{index_unique}{key}". When `None`,
-        the original indices are kept.
-    convert
+        If `True`, make the index unique by using the `keys` and `index_delimiter`. When
+        `False`, the original indices are kept.
+    index_delimiter
+        If `index_unique` is True, this is the delimeter between "{orig_idx}{index_unique}{key}".
+        convert
         You can pass a function or a Mapping of functions which will be applied
         to the values of attributes (`.obs`, `.obsm`, `.layers`, `.X`) or to specific
         keys of these attributes in the subset object.
@@ -662,7 +663,8 @@ class AnnCollection(_ConcatViewMixin, _IterateViewMixin):
         join_vars: Optional[Literal["inner"]] = None,
         label: Optional[str] = None,
         keys: Optional[Sequence[str]] = None,
-        index_unique: Optional[str] = None,
+        index_unique: bool = False,
+        index_delimiter: Optional[str] = "_",
         convert: Optional[ConvertType] = None,
         harmonize_dtypes: bool = True,
         indices_strict: bool = True,
@@ -709,9 +711,19 @@ class AnnCollection(_ConcatViewMixin, _IterateViewMixin):
             categories=keys,
         )
         if index_unique is not None:
-            concat_indices = concat_indices.str.cat(
-                label_col.map(str), sep=index_unique
-            )
+            if isinstance(index_unique, str):
+                warn(
+                    "Passing index delimiters to `index_unique` is deprecated and will not work in a"
+                    "future version of AnnData. Please pass delimiters to `index_delimiter`.",
+                    FutureWarning,
+                    stacklevel=4,
+                )
+                index_delimiter = index_unique
+                index_unique = True
+            if index_unique:
+                concat_indices = concat_indices.str.cat(
+                    label_col.map(str), sep=index_delimiter
+                )
         self.obs_names = pd.Index(concat_indices)
 
         if not self.obs_names.is_unique:

--- a/anndata/experimental/pytorch/_annloader.py
+++ b/anndata/experimental/pytorch/_annloader.py
@@ -145,7 +145,8 @@ class AnnLoader(DataLoader):
             join_obsm = kwargs.pop("join_obsm", None)
             label = kwargs.pop("label", None)
             keys = kwargs.pop("keys", None)
-            index_unique = kwargs.pop("index_unique", None)
+            index_unique = kwargs.pop("index_unique", False)
+            index_delimiter = kwargs.pop("index_delimiter", "_")
             convert = kwargs.pop("convert", None)
             harmonize_dtypes = kwargs.pop("harmonize_dtypes", True)
             indices_strict = kwargs.pop("indices_strict", True)
@@ -157,6 +158,7 @@ class AnnLoader(DataLoader):
                 label=label,
                 keys=keys,
                 index_unique=index_unique,
+                index_delimiter=index_delimiter,
                 convert=convert,
                 harmonize_dtypes=harmonize_dtypes,
                 indices_strict=indices_strict,

--- a/anndata/tests/test_anncollection.py
+++ b/anndata/tests/test_anncollection.py
@@ -27,8 +27,8 @@ def adatas(request):
 
 @pytest.mark.parametrize("adatas", [np.array, csr_matrix], indirect=True)
 def test_full_selection(adatas):
-    dat = AnnCollection(adatas, index_unique="_")
-    adt_concat = ad.concat(adatas, index_unique="_")
+    dat = AnnCollection(adatas, index_unique=True, index_delimiter="_")
+    adt_concat = ad.concat(adatas, index_unique=True, index_delimiter="_")
 
     # sorted selection from one adata
     dat_view = dat[:2, :2]
@@ -59,14 +59,16 @@ def test_full_selection(adatas):
 def test_creation(adatas):
     adatas_inner = [adatas[0], adatas[1][:, :2].copy()]
 
-    dat = AnnCollection(adatas_inner, join_vars="inner", index_unique="_")
-    adt_concat = ad.concat(adatas_inner, index_unique="_")
+    dat = AnnCollection(
+        adatas_inner, join_vars="inner", index_unique=True, index_delimiter="_"
+    )
+    adt_concat = ad.concat(adatas_inner, index_unique=True, index_delimiter="_")
     np.testing.assert_array_equal(dat.var_names, adt_concat.var_names)
 
 
 @pytest.mark.parametrize("adatas", [np.array], indirect=True)
 def test_convert(adatas):
-    dat = AnnCollection(adatas, index_unique="_")
+    dat = AnnCollection(adatas, index_unique=True, index_delimiter="_")
 
     le = LabelEncoder()
     le.fit(dat[:].obs["a_test"])

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -149,7 +149,7 @@ def test_concatenate_roundtrip(join_type, array_type, concat_func, backwards_com
         subsets.append(adata[subset_idx])
         remaining = remaining.difference(subset_idx)
 
-    result = concat_func(subsets, join=join_type, uns_merge="same", index_unique=None)
+    result = concat_func(subsets, join=join_type, uns_merge="same", index_unique=True)
 
     # Correcting for known differences
     orig, result = fix_known_differences(
@@ -1031,10 +1031,13 @@ def test_concat_categories_from_mapping():
 
     assert_equal(mapping_call(), iter_call())
     assert_equal(mapping_call(label="batch"), iter_call(label="batch"))
-    assert_equal(mapping_call(index_unique="-"), iter_call(index_unique="-"))
     assert_equal(
-        mapping_call(label="group", index_unique="+"),
-        iter_call(label="group", index_unique="+"),
+        mapping_call(index_unique=True, index_delimiter="-"),
+        iter_call(index_unique=True, index_delimiter="-"),
+    )
+    assert_equal(
+        mapping_call(label="group", index_unique=True, index_delimiter="+"),
+        iter_call(label="group", index_unique=True, index_delimiter="+"),
     )
 
 
@@ -1046,7 +1049,9 @@ def test_concat_names(axis):
     rhs = gen_adata((10, 10))
 
     assert not get_annot(concat([lhs, rhs], axis=axis)).index.is_unique
-    assert get_annot(concat([lhs, rhs], axis=axis, index_unique="-")).index.is_unique
+    assert get_annot(
+        concat([lhs, rhs], axis=axis, index_unique=True, index_delimiter="-")
+    ).index.is_unique
 
 
 def axis_labels(adata, axis):
@@ -1085,7 +1090,8 @@ def test_concat_size_0_dim(axis, join_type, merge_strategy, shape):
         join=join_type,
         merge=merge_strategy,
         pairwise=True,
-        index_unique="-",
+        index_unique=True,
+        index_delimiter="-",
     )
     assert result.shape == expected_size
 

--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -81,7 +81,7 @@ When building a joint anndata object, we would still like to store the coordinat
 
     >>> coords = np.hstack([np.repeat(np.arange(10), 10), np.tile(np.arange(10), 10)]).T
     >>> spatial = AnnData(
-    ...     sparse.random(5000, 10000, format="csr"), 
+    ...     sparse.random(5000, 10000, format="csr"),
     ...     obsm={"coords": np.random.randn(5000, 2)}
     ... )
     >>> droplet = AnnData(sparse.random(5000, 10000, format="csr"))
@@ -142,7 +142,7 @@ These values can be made unique by appending the relevant key using the `index_u
     Empty DataFrame
     Columns: []
     Index: [cell-0, cell-1, cell-2, cell-0, cell-1, cell-2, cell-3, cell-4]
-    >>> ad.concat(adatas, index_unique="_").obs
+    >>> ad.concat(adatas, index_unique=True, index_delimiter="_").obs
     Empty DataFrame
     Columns: []
     Index: [cell-0_a, cell-1_a, cell-2_a, cell-0_b, cell-1_b, cell-2_b, cell-3_b, cell-4_b]


### PR DESCRIPTION
Hi all, I find `index_unique` being both the indicator for whether or not to concatenate batch labels to the `obs_names` and the option that denotes the delimiter to use to be confusing. I think the best way to do this is to just break this out into two arguments. I think I've replaced everywhere these functions come up, but I haven't run tests yet.

Let me know if you like this idea, happy to continue working on the PR.