### PR TITLE
Add support for DeviceArray from JAX

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -51,6 +51,7 @@ from ..compat import (
     ZarrArray,
     ZappyArray,
     DaskArray,
+    DeviceArray,
     Literal,
     _slice_uns_sparse_matrices,
     _move_adj_mtx,
@@ -66,6 +67,7 @@ class StorageType(Enum):
     ZarrArray = ZarrArray
     ZappyArray = ZappyArray
     DaskArray = DaskArray
+    DeviceArray = DeviceArray
 
     @classmethod
     def classes(cls):

--- a/anndata/compat/__init__.py
+++ b/anndata/compat/__init__.py
@@ -62,6 +62,16 @@ except ImportError:
 
 
 try:
+    from jax.numpy import DeviceArray
+except ImportError:
+
+    class DeviceArray:
+        @staticmethod
+        def __repr__():
+            return "mock jax.numpy.DeviceArray"
+
+
+try:
     from typing import Literal
 except ImportError:
     try:


### PR DESCRIPTION
Allow AnnData objects have `.X` as a `DeviceArray`. Layer support should also be there but seems to currently fail just as it does e.g. for `DaskArray`, as mentioned in #693.

```py
from jax import random
from anndata import AnnData

x = random.normal(random.PRNGKey(1), (100,10))
adata = AnnData(x)

adata.write("demojax.h5ad")
```

As mentioned in #659, it would be nice to also get `DeviceArray` on read in future if possible, currently it is a NumPy Array:

```py
adata = anndata.read("demojax.h5ad")
type(adata.X)
# => numpy.ndarray
```