### PR TITLE
Don't clean uns for newer files

### DIFF
--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -157,7 +157,9 @@ def read_h5ad_backed(filename: Union[str, Path], mode: Literal["r", "r+"]) -> An
     else:
         raise ValueError()
 
-    _clean_uns(d)
+    # Backwards compat to <0.7
+    if isinstance(f["obs"], h5py.Dataset):
+        _clean_uns(d)
 
     return AnnData(**d)
 
@@ -249,7 +251,9 @@ def read_h5ad(
         else:
             raise ValueError()
 
-    _clean_uns(d)  # backwards compat
+        # Backwards compat to <0.7
+        if isinstance(f["obs"], h5py.Dataset):
+            _clean_uns(d)
 
     return AnnData(**d)
 

--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -88,7 +88,9 @@ def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]) -> AnnData:
     if "X" in d:
         d["dtype"] = d["X"].dtype
 
-    _clean_uns(d)
+    # Backwards compat to <0.7
+    if isinstance(f["obs"], zarr.Array):
+        _clean_uns(d)
 
     return AnnData(**d)
 

--- a/anndata/tests/test_io_backwards_compat.py
+++ b/anndata/tests/test_io_backwards_compat.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 import anndata as ad
+import pandas as pd
+from scipy import sparse
 from anndata.tests.helpers import assert_equal
 
 ARCHIVE_PTH = Path(__file__).parent / "data/archives"
@@ -13,6 +15,11 @@ def archive_dir(request):
     return request.param
 
 
+@pytest.fixture(params=["h5ad", "zarr"])
+def diskfmt(request):
+    return request.param
+
+
 def test_backwards_compat_files(archive_dir):
     with pytest.warns(ad.OldFormatWarning):
         from_h5ad = ad.read_h5ad(archive_dir / "adata.h5ad")
@@ -20,3 +27,26 @@ def test_backwards_compat_files(archive_dir):
         from_zarr = ad.read_zarr(archive_dir / "adata.zarr.zip")
 
     assert_equal(from_h5ad, from_zarr, exact=True)
+
+
+def test_clean_uns_backwards_compat(tmp_path, diskfmt):
+    pth = tmp_path / f"test_write.{diskfmt}"
+    write = lambda x, y: getattr(x, f"write_{diskfmt}")(y)
+    read = lambda x: getattr(ad, f"read_{diskfmt}")(x)
+
+    orig = ad.AnnData(
+        sparse.csr_matrix((3, 5), dtype="float32"),
+        obs=pd.DataFrame(
+            {"a": pd.Categorical(list("aab")), "b": [1, 2, 3]},
+            index=[f"cell_{i}" for i in range(3)],
+        ),
+        uns={
+            "a_categories": "some string",
+            "b_categories": "another string",
+        },
+    )
+
+    write(orig, pth)
+    from_disk = read(pth)
+
+    assert_equal(orig, from_disk)

--- a/docs/release-notes/0.8.1.rst
+++ b/docs/release-notes/0.8.1.rst
@@ -4,5 +4,6 @@
 .. rubric:: Bug fixes
 
 * Fix warning from `rename_categories` :pr:`790` :smaller:`I Virshup`
+* Remove backwards compat checks for categories in `uns` when we can tell the file is new enough :pr:`790` :smaller:`I Virshup`
 
 .. rubric:: Documentation


### PR DESCRIPTION
Fixes #792

We don't need to clean categorical values from `uns` for a while now. Storing categorical values in uns changed in the same commit that moved dataframes from recarrays to groups (https://github.com/scverse/anndata/commit/a9b8b035980e505e43d09ba0edb6c47e8c37163d#diff-0a9d8acf21df37a4b75d9fe1625ba334e8ba7977353eb64263f537963b87ab31), so I've condition modifying uns on how dataframes are stored.