### PR TITLE
Bump ci OS version

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
 jobs:
 - job: PyTest
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   strategy:
     matrix:
       Python39:
@@ -70,7 +70,7 @@ jobs:
 
 - job: CheckBuild
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
 
   - task: UsePythonVersion@0


### PR DESCRIPTION
Current CI OS version is deprecated (ubuntu 18.04) so this bumps to 22.04.