### PR TITLE
[DOCS] Explain backed is for X only

### DIFF
--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -184,6 +184,12 @@ def read_h5ad(
         instead of fully loading it into memory (`memory` mode).
         If you want to modify backed attributes of the AnnData object,
         you need to choose `'r+'`.
+
+        Currently, `backed` only support updates to `X`. That means any
+        changes to other slots like `obs` will not be written to disk in
+        `backed` mode. If you would like save changes made to these slots
+        of a `backed` :class:`~anndata.AnnData`, write them to a new file
+        (see :meth:`~anndata.AnnData.write`).
     as_sparse
         If an array was saved as dense, passing its name here will read it as
         a sparse_matrix, by chunk of size `chunk_size`.

--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -189,7 +189,8 @@ def read_h5ad(
         changes to other slots like `obs` will not be written to disk in
         `backed` mode. If you would like save changes made to these slots
         of a `backed` :class:`~anndata.AnnData`, write them to a new file
-        (see :meth:`~anndata.AnnData.write`).
+        (see :meth:`~anndata.AnnData.write`). For an example, see
+        [here] (https://anndata-tutorials.readthedocs.io/en/latest/getting-started.html#Partial-reading-of-large-data).
     as_sparse
         If an array was saved as dense, passing its name here will read it as
         a sparse_matrix, by chunk of size `chunk_size`.

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -4,6 +4,6 @@
 .. rubric:: Features
 
 * Unordered categorical columns are no longer cast to object during :func:`anndata.concat` :pr:`763` :smaller:`ivirshup`
-* Expanded docstring more documentation for ``backed``` argument of :func:`anndata.read_h5ad` `:pr:`812` :smaller:`jeskowagner`
+* Expanded docstring more documentation for ``backed`` argument of :func:`anndata.read_h5ad` :pr:`812` :smaller:`jeskowagner`
 
 .. rubric:: Bug fixes

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -4,5 +4,6 @@
 .. rubric:: Features
 
 * Unordered categorical columns are no longer cast to object during :func:`anndata.concat` :pr:`763` :smaller:`ivirshup`
+* Expanded docstring more documentation for ``backed``` argument of :func:`anndata.read_h5ad` `:pr:`812` :smaller:`jeskowagner`
 
 .. rubric:: Bug fixes


### PR DESCRIPTION
Added documentation to `read_h5ad` in `backed` mode, addressing #811. Let me know if you would like a more dedicated page for it!