### PR TITLE
Add stale bot

### DIFF
--- a/.github/actions/close-stale.yml
+++ b/.github/actions/close-stale.yml
@@ -9,12 +9,9 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          days-before-issue-stale: 65535 # We don't want to mark issues as stale in this action
-          days-before-close: 14
+          days-before-issue-stale: -1 # We don't want to mark issues as stale in this action
+          days-before-issue-close: 14
+          days-before-pr-close: -1 # don't close PRs
           stale-issue-label: stale
           any-of-labels: "needs info"
-          stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had recent activity.
-            It will be closed if no further activity occurs. Thank you for your contributions!
-          stale-pr-message: null # if not provided, will not mark PRs as stale
           debug-only: true # enable dry-run, remove when we know from the logs it's working.

--- a/.github/actions/close-stale.yml
+++ b/.github/actions/close-stale.yml
@@ -2,6 +2,7 @@ name: "Close stale issues"
 on:
   schedule:
     - cron: "0 2 * * *"
+  workflow_dispatch:
 
 jobs:
   stale:

--- a/.github/actions/close-stale.yml
+++ b/.github/actions/close-stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues"
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 65535 # We don't want to mark issues as stale in this action
+          days-before-close: 14
+          stale-issue-label: stale
+          any-of-labels: "needs info"
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions!
+          stale-pr-message: null # if not provided, will not mark PRs as stale
+          debug-only: true # enable dry-run, remove when we know from the logs it's working.

--- a/.github/actions/label-stale.yml
+++ b/.github/actions/label-stale.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/stale@v5
         with:
           days-before-issue-stale: 60
-          days-before-close: 65535 # We don't want to close issues in this action
+          days-before-pr-stale: -1 # We don't want to mark PRs as stale
+          days-before-close: -1 # We don't want to close issues in this action
           stale-issue-label: stale
           exempt-issue-labels: pinned,bug,enhancement
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had recent activity.
-            It will be closed if no further activity occurs. Thank you for your contributions!
-          stale-pr-message: null # if not provided, will not mark PRs as stale
+            Please add a comment if you want to keep the issue open. Thank you for your contributions!
           debug-only: true # enable dry-run, remove when we know from the logs it's working.

--- a/.github/actions/label-stale.yml
+++ b/.github/actions/label-stale.yml
@@ -2,6 +2,7 @@ name: "Label stale issues"
 on:
   schedule:
     - cron: "30 1 * * *"
+  workflow_dispatch:
 
 jobs:
   stale:

--- a/.github/actions/label-stale.yml
+++ b/.github/actions/label-stale.yml
@@ -1,0 +1,20 @@
+name: "Label stale issues"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 60
+          days-before-close: 65535 # We don't want to close issues in this action
+          stale-issue-label: stale
+          exempt-issue-labels: pinned,bug,enhancement
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions!
+          stale-pr-message: null # if not provided, will not mark PRs as stale
+          debug-only: true # enable dry-run, remove when we know from the logs it's working.

--- a/.github/actions/label-stale.yml
+++ b/.github/actions/label-stale.yml
@@ -13,7 +13,7 @@ jobs:
           days-before-pr-stale: -1 # We don't want to mark PRs as stale
           days-before-close: -1 # We don't want to close issues in this action
           stale-issue-label: stale
-          exempt-issue-labels: pinned,bug,enhancement
+          exempt-issue-labels: pinned,enhancement
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had recent activity.
             Please add a comment if you want to keep the issue open. Thank you for your contributions!


### PR DESCRIPTION
Add an action to label stale issues as discussed in https://github.com/scverse/governance/issues/41

There are two separate actions for "mark stale" and "close" for the following reason: 
 * According to the specifications in https://github.com/scverse/governance/issues/41, we want to mark any issue that is not `pinned` or an `enhancement` to be marked as stale
 * We only want to *close* issues if they are marked as stale and have the `needs info` label. 

afaict, having separate conditions for closing and labeling is not possible with a single stale action. 