### PR TITLE
Lazy compute obs/var

### DIFF
--- a/anndata/_core/descriptors.py
+++ b/anndata/_core/descriptors.py
@@ -1,0 +1,91 @@
+from typing import TYPE_CHECKING, MutableMapping, Optional
+from collections import OrderedDict
+from copy import copy
+
+from anndata.compat import _overloaded_uns, OverloadedDict, _slice_uns_sparse_matrices
+from typing_extensions import Literal
+import pandas as pd
+from anndata._core.views import DataFrameView, DictView
+
+if TYPE_CHECKING:
+    from anndata._core.anndata import AnnData
+
+
+class DataFrameDescriptor:
+    """\
+    One-dimensional annotation of observations or features.
+
+    Parameters
+    ----------
+    attr:
+        Named of the attribute.
+    """
+
+    def __init__(self, attr: Literal["obs", "var"]):
+        self._attr = attr
+
+    def __get__(self, adata: "AnnData", objtype: Optional[type] = None) -> pd.DataFrame:
+        print(objtype)
+        if not adata.is_view:
+            return adata._obs if self.attr == "obs" else adata._var
+
+        adata_ref = adata._adata_ref
+        if self.attr == "obs":
+            container_full = adata_ref.obs
+            container = container_full.iloc[adata._oidx]
+        elif self.attr == "var":
+            container_full = adata_ref.var
+            container = adata_ref.var.iloc[adata._vidx]
+        else:
+            raise NotImplementedError(self.attr)
+
+        # we don't care about uns at this point
+        adata._remove_unused_categories(container_full, container, {})
+        return DataFrameView(container, view_args=(adata, self.attr))
+
+    def __set__(self, adata: "AnnData", value: pd.DataFrame) -> None:
+        adata._set_dim_df(value, self.attr)
+
+    def __delete__(self, adata: "AnnData") -> None:
+        setattr(
+            adata, self.attr, pd.DataFrame(index=getattr(adata, f"{self.attr}_names"))
+        )
+
+    @property
+    def attr(self) -> Literal["obs", "var"]:
+        return self._attr
+
+
+class UnsDescriptor:
+    """Unstructured annotation (ordered dictionary)."""
+
+    def __get__(self, adata: "AnnData", objtype: Optional[type] = None):
+        if not adata.is_view:
+            return _overloaded_uns(adata, adata._uns)
+
+        adata_ref = adata._adata_ref
+        # special case for old neighbors, backwards compat. Remove in anndata 0.8.
+        # fix categories
+        uns = _slice_uns_sparse_matrices(
+            copy(adata_ref._uns), adata._oidx, adata_ref.n_obs
+        )
+
+        adata._remove_unused_categories(adata_ref.obs, adata.obs, uns, update_sub=False)
+        adata._remove_unused_categories(adata_ref.var, adata.var, uns, update_sub=False)
+        uns = DictView(uns, view_args=(adata, "_uns"))
+
+        return _overloaded_uns(adata, uns)
+
+    def __set__(self, adata: "AnnData", value: MutableMapping) -> None:
+        if not isinstance(value, MutableMapping):
+            raise ValueError(
+                "Only mutable mapping types (e.g. dict) are allowed for `.uns`."
+            )
+        if isinstance(value, (OverloadedDict, DictView)):
+            value = value.copy()
+        if adata.is_view:
+            adata._init_as_actual(adata.copy())
+        adata._uns = value
+
+    def __delete__(self, adata: "AnnData") -> None:
+        adata._uns = OrderedDict()

--- a/anndata/_core/descriptors.py
+++ b/anndata/_core/descriptors.py
@@ -25,7 +25,6 @@ class DataFrameDescriptor:
         self._attr = attr
 
     def __get__(self, adata: "AnnData", objtype: Optional[type] = None) -> pd.DataFrame:
-        print(objtype)
         if not adata.is_view:
             return adata._obs if self.attr == "obs" else adata._var
 
@@ -40,7 +39,7 @@ class DataFrameDescriptor:
             raise NotImplementedError(self.attr)
 
         # we don't care about uns at this point
-        adata._remove_unused_categories(container_full, container, {})
+        adata._remove_unused_categories(container_full, container, uns={})
         return DataFrameView(container, view_args=(adata, self.attr))
 
     def __set__(self, adata: "AnnData", value: pd.DataFrame) -> None:

--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -35,10 +35,10 @@ def write_csvs(
     if not dir_uns.is_dir():
         dir_uns.mkdir(parents=True, exist_ok=True)
     d = dict(
-        obs=adata._obs,
-        var=adata._var,
-        obsm=adata._obsm.to_df(),
-        varm=adata._varm.to_df(),
+        obs=adata.obs,
+        var=adata.var,
+        obsm=adata.obsm.to_df(),
+        varm=adata.varm.to_df(),
     )
     if not skip_data:
         d["X"] = pd.DataFrame(adata.X.toarray() if issparse(adata.X) else adata.X)

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -142,8 +142,10 @@ def test_slice_uns_sparse_deprecated():
     mtx = sparse.random(n, n, density=0.2, format="csr")
     adata.uns["sparse_mtx"] = mtx
 
+    v = adata[: n // 2]
     with pytest.warns(FutureWarning):
-        v = adata[: n // 2]
+        # uns is handled lazily
+        _ = v.uns
 
     assert_equal(adata.uns["sparse_mtx"], mtx)
     assert_equal(v.uns["sparse_mtx"], mtx[: n // 2, : n // 2])

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -379,9 +379,13 @@ def test_view_delattr(attr, subset_func):
 
     delattr(subset, attr)
 
-    assert not subset.is_view
-    # Should now have same value as default
-    assert_equal(getattr(subset, attr), getattr(empty, attr))
+    if attr == "uns":
+        assert subset.is_view
+        assert_equal({}, getattr(empty, attr))
+    else:
+        assert not subset.is_view
+        # Should now have same value as default
+        assert_equal(getattr(subset, attr), getattr(empty, attr))
     assert orig_hash == joblib.hash(base)  # Original should not be modified
 
 


### PR DESCRIPTION
Whenever `adata_view.{obs,var,uns}` is accessed, it's not computed lazily. This now allows for the below code to work:
```python
from anndata import AnnData
import numpy as np

adata = AnnData(np.random.normal(size=(1000, 30)), dtype=float)
adata_view = adata[:30]
adata.obs['foo'] = 'bar'
assert 'foo' in adata_view.obs
```

This is more of a proof-of-concept: am worried about performance penalty/user expectation when handling large `AnnDatas`.