### PR TITLE
Dask dataframe support 

### DIFF
--- a/anndata/compat/__init__.py
+++ b/anndata/compat/__init__.py
@@ -58,7 +58,16 @@ except ImportError:
     class DaskArray:
         @staticmethod
         def __repr__():
-            return "mock dask.array.core.Array"
+            return "mock dask.array.core.Array" 
+
+try:
+    from dask.dataframe import DataFrame as DaskDataFrame 
+except ImportError:
+
+    class DaskDataFrame:
+        @staticmethod
+        def __repr__():
+            return "mock dask.dataframe.core.DataFrame"
 
 
 @singledispatch

--- a/anndata/compat/__init__.py
+++ b/anndata/compat/__init__.py
@@ -58,10 +58,11 @@ except ImportError:
     class DaskArray:
         @staticmethod
         def __repr__():
-            return "mock dask.array.core.Array" 
+            return "mock dask.array.core.Array"
+
 
 try:
-    from dask.dataframe import DataFrame as DaskDataFrame 
+    from dask.dataframe import DataFrame as DaskDataFrame
 except ImportError:
 
     class DaskDataFrame:

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -322,15 +322,17 @@ def assert_equal_h5py_dataset(a, b, exact=False, elem_name=None):
     a = asarray(a)
     assert_equal(b, a, exact, elem_name=elem_name)
 
+
 @assert_equal.register(DaskDataFrame)
-def assert_equal_dask_dataframe(a,b, exact=False, elem_name=None):
+def assert_equal_dask_dataframe(a, b, exact=False, elem_name=None):
 
     from dask.dataframe.utils import assert_eq
 
     if exact:
         assert_eq(a, b, check_dtype=True)
     else:
-        assert_eq(a,b, check_dtype=False)
+        assert_eq(a, b, check_dtype=False)
+
 
 @assert_equal.register(pd.DataFrame)
 def are_equal_dataframe(a, b, exact=False, elem_name=None):

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -16,6 +16,7 @@ from anndata._core.views import ArrayView
 from anndata._core.sparse_dataset import SparseDataset
 from anndata._core.aligned_mapping import AlignedMapping
 from anndata.utils import asarray
+from anndata.compat import DaskDataFrame
 
 
 def gen_vstr_recarray(m, n, dtype=None):
@@ -321,6 +322,15 @@ def assert_equal_h5py_dataset(a, b, exact=False, elem_name=None):
     a = asarray(a)
     assert_equal(b, a, exact, elem_name=elem_name)
 
+@assert_equal.register(DaskDataFrame)
+def assert_equal_dask_dataframe(a,b, exact=False, elem_name=None):
+
+    from dask.dataframe.utils import assert_eq
+
+    if exact:
+        assert_eq(a, b, check_dtype=True)
+    else:
+        assert_eq(a,b, check_dtype=False)
 
 @assert_equal.register(pd.DataFrame)
 def are_equal_dataframe(a, b, exact=False, elem_name=None):

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -25,14 +25,15 @@ def test_dask_X_view():
     view = adata[:30]
     view.copy()
 
+
 def test_assert_equal_dask_dataframes():
     import dask.dataframe as dd
 
-    data_1 = {'col1': [1, 2, 3, 4], 'col2': [5, 6, 7, 8]}
-    data_2 = {'col1': [1, 2, 3, 4], 'col2': [5, 6, 7, 8]}
-    
+    data_1 = {"col1": [1, 2, 3, 4], "col2": [5, 6, 7, 8]}
+    data_2 = {"col1": [1, 2, 3, 4], "col2": [5, 6, 7, 8]}
+
     a = dd.from_pandas(pd.DataFrame(data=data_1), npartitions=1)
-    
+
     b = dd.from_pandas(pd.DataFrame(data=data_2), npartitions=1)
 
     assert_equal(a, b)

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -6,6 +6,10 @@ import pandas as pd
 
 import pytest
 
+from anndata.tests.helpers import assert_equal
+from anndata.compat import DaskDataFrame
+
+
 pytest.importorskip("dask.array")
 
 
@@ -20,3 +24,15 @@ def test_dask_X_view():
     adata.X = da.ones((M, N))
     view = adata[:30]
     view.copy()
+
+def test_assert_equal_dask_dataframes():
+    import dask.dataframe as dd
+
+    data_1 = {'col1': [1, 2, 3, 4], 'col2': [5, 6, 7, 8]}
+    data_2 = {'col1': [1, 2, 3, 4], 'col2': [5, 6, 7, 8]}
+    
+    a = dd.from_pandas(pd.DataFrame(data=data_1), npartitions=1)
+    
+    b = dd.from_pandas(pd.DataFrame(data=data_2), npartitions=1)
+
+    assert_equal(a, b)


### PR DESCRIPTION
This PR introduces support for Dask dataframes in anndata. 

TODOs:
- [ ] Indexing
- [ ] Writing / Reading
- [ ] Concatenation
- [x] assert_equal for tests
- [ ] adata.to_memory() / adata.copy()

Related PR (Dask array support): https://github.com/scverse/anndata/pull/813
Contributors: @rahulbshrestha @syelman