### PR TITLE
Fix zarr partial reads for sparse and dense arrays

### DIFF
--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -314,10 +314,14 @@ def read_array(elem):
 
 
 @_REGISTRY.register_read_partial(H5Array, IOSpec("array", "0.2.0"))
-@_REGISTRY.register_read_partial(ZarrArray, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_read_partial(ZarrArray, IOSpec("string-array", "0.2.0"))
 def read_array_partial(elem, *, items=None, indices=(slice(None, None))):
     return elem[indices]
+
+
+@_REGISTRY.register_read_partial(ZarrArray, IOSpec("array", "0.2.0"))
+def read_zarr_array_partial(elem, *, items=None, indices=(slice(None, None))):
+    return elem.oindex[indices]
 
 
 # arrays of strings
@@ -476,6 +480,8 @@ def read_sparse(elem):
 
 @_REGISTRY.register_read_partial(H5Group, IOSpec("csc_matrix", "0.1.0"))
 @_REGISTRY.register_read_partial(H5Group, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_read_partial(ZarrGroup, IOSpec("csc_matrix", "0.1.0"))
+@_REGISTRY.register_read_partial(ZarrGroup, IOSpec("csr_matrix", "0.1.0"))
 def read_sparse_partial(elem, *, items=None, indices=(slice(None), slice(None))):
     return SparseDataset(elem)[indices]
 

--- a/anndata/tests/test_io_partial.py
+++ b/anndata/tests/test_io_partial.py
@@ -1,0 +1,28 @@
+from anndata import AnnData
+from anndata._io.specs.registry import read_elem_partial
+from anndata._io import write_zarr
+from scipy.sparse import csr_matrix
+import numpy as np
+import pytest
+from pathlib import Path
+import zarr
+
+X = np.array([[1.0, 0.0, 3.0], [4.0, 0.0, 6.0], [0.0, 8.0, 0.0]], dtype="float32")
+X_check = np.array([[4.0, 0.0], [0.0, 8.0]], dtype="float32")
+
+
+@pytest.mark.parametrize("typ", [np.asarray, csr_matrix])
+def test_zarr_read_partial(tmp_path, typ):
+
+    adata = AnnData(X=typ(X))
+
+    print(tmp_path)
+
+    path = Path(tmp_path) / "test_zarr.zarr"
+
+    write_zarr(path, adata)
+
+    with zarr.open(path, mode="r") as store:
+        X_part = read_elem_partial(store["X"], indices=([1, 2], [0, 1]))
+
+    assert np.all(X_check == X_part)

--- a/anndata/tests/test_io_partial.py
+++ b/anndata/tests/test_io_partial.py
@@ -2,9 +2,9 @@ from anndata import AnnData
 from anndata._io.specs.registry import read_elem_partial
 from anndata._io import write_zarr
 from scipy.sparse import csr_matrix
+from pathlib import Path
 import numpy as np
 import pytest
-from pathlib import Path
 import zarr
 
 X = np.array([[1.0, 0.0, 3.0], [4.0, 0.0, 6.0], [0.0, 8.0, 0.0]], dtype="float32")
@@ -15,8 +15,6 @@ X_check = np.array([[4.0, 0.0], [0.0, 8.0]], dtype="float32")
 def test_zarr_read_partial(tmp_path, typ):
 
     adata = AnnData(X=typ(X))
-
-    print(tmp_path)
 
     path = Path(tmp_path) / "test_zarr.zarr"
 


### PR DESCRIPTION
For sparse array `read_partial` wasn't registered. For dense arrays it actually didn't work.