### PR TITLE
Re-add schema to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@
 .. |Coverage| image:: https://codecov.io/gh/scverse/anndata/branch/master/graph/badge.svg?token=IN1mJN1Wi8
    :target: https://codecov.io/gh/scverse/anndata
 
+.. image:: docs/_static/img/anndata_schema.svg
+   :align: right
+   :width: 350px
 
 anndata - Annotated data
 ========================
@@ -26,6 +29,3 @@ anndata is a Python package for handling annotated data matrices in memory and o
 * Read the `documentation <https://anndata.readthedocs.io>`_.
 * Ask questions on the `scverse Discourse <https://discourse.scverse.org>`_.
 * Install via ``pip install anndata`` or ``conda install anndata -c conda-forge``.
-
-.. would be nice to have the schema also on GitHub, but it’s much too wide there, hence need to duplicate description
-.. GitHub doesn’t plan to resolve scaling images: https://github.com/github/markup/issues/295

--- a/README.rst
+++ b/README.rst
@@ -21,11 +21,17 @@
    :align: right
    :width: 350px
 
+.. after image
+
 anndata - Annotated data
 ========================
 
 anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. anndata offers a broad range of computationally efficient features including, among others, sparse data support, lazy operations, and a PyTorch interface.
 
+* Discuss development on `GitHub <https://github.com/scverse/anndata>`_.
 * Read the `documentation <https://anndata.readthedocs.io>`_.
 * Ask questions on the `scverse Discourse <https://discourse.scverse.org>`_.
 * Install via ``pip install anndata`` or ``conda install anndata -c conda-forge``.
+* Consider citing the `anndata paper <https://doi.org/10.1101/2021.12.16.473007>`__.
+* See `Scanpy's documentation <https://scanpy.readthedocs.io/>`__ for usage
+  related to single cell data. anndata was initially built for Scanpy.

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,9 @@
 .. |Coverage| image:: https://codecov.io/gh/scverse/anndata/branch/master/graph/badge.svg?token=IN1mJN1Wi8
    :target: https://codecov.io/gh/scverse/anndata
 
-.. image:: docs/_static/img/anndata_schema.svg
+.. use URL instead of path here so PyPI can render it
+
+.. image:: https://raw.githubusercontent.com/scverse/anndata/master/docs/_static/img/anndata_schema.svg
    :align: right
    :width: 350px
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,21 +1,15 @@
-.. include:: ../README.rst
-   :end-line: 22
-
 .. role:: small
 .. role:: smaller
+
+.. include:: ../README.rst
+   :end-before: .. image
 
 .. image:: _static/img/anndata_schema.svg
    :align: right
    :width: 40%
 
-anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. anndata offers a broad range of computationally efficient features including, among others, sparse data support, lazy operations, and a PyTorch interface.
-
-* Discuss development on `GitHub <https://github.com/scverse/anndata>`_.
-* Ask questions on the `scverse Discourse <https://discourse.scverse.org>`_.
-* Install via `pip install anndata` or `conda install anndata -c conda-forge`.
-* Consider citing the `anndata paper <https://doi.org/10.1101/2021.12.16.473007>`__.
-* See `Scanpy's documentation <https://scanpy.readthedocs.io/>`__ for usage
-  related to single cell data. anndata was initially built for Scanpy.
+.. include:: ../README.rst
+   :start-after: .. after image
 
 News
 ----


### PR DESCRIPTION
As mentioned in https://github.com/github/markup/issues/163#issuecomment-1282676832, this works now!

The docs index page doesn’t change after this, but it includes everything from the readme instead of containg a copy of its text: https://icb-anndata--838.com.readthedocs.build/en/838/