### PR TITLE
Deprecate AnnData.concatenate

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1757,8 +1757,16 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         """
         from .merge import concat, merge_outer, merge_dataframes, merge_same
 
+        warnings.warn(
+            "The AnnData.concatenate method is deprecated in favour of the "
+            "anndata.concat function. Please use anndata.concat instead.\n\n"
+            "See the tutorial for concat at: "
+            "https://anndata.readthedocs.io/en/latest/concatenation.html",
+            FutureWarning,
+        )
+
         if self.isbacked:
-            raise ValueError("Currently, concatenate does only work in memory mode.")
+            raise ValueError("Currently, concatenate only works in memory mode.")
 
         if len(adatas) == 0:
             return self.copy()

--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -1,10 +1,6 @@
 Concatenation
 =============
 
-.. warning::
-
-    The :func:`~anndata.concat` function is marked as experimental for the `0.7` release series, and will supercede the :meth:`AnnData.concatenate() <anndata.AnnData.concatenate>` method in future releases. While the current API is not likely to change much, this gives us a bit of freedom to make sure we've got the arguments and feature set right.
-
 With :func:`~anndata.concat`, :class:`~anndata.AnnData` objects can be combined via a composition of two operations: concatenation and merging.
 
 * Concatenation is when we keep all sub elements of each object, and stack these elements in an ordered way.

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -14,4 +14,4 @@
 
 .. rubric:: Deprecations
 
-* :method:`AnnData.concatenate` is now deprecated in favour of :func:`anndata.concat` :pr:`845` :smaller:`ivirshup`
+* :meth:`AnnData.concatenate() <anndata.AnnData.concatenate>` is now deprecated in favour of :func:`anndata.concat` :pr:`845` :smaller:`ivirshup`

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -11,3 +11,7 @@
 .. rubric:: Updates
 
 * Bump minimum python version to 3.8 :pr:`820` :smaller:`ivirshup`
+
+.. rubric:: Deprecations
+
+* :method:`AnnData.concatenate` is now deprecated in favour of :func:`anndata.concat` :pr:`845` :smaller:`ivirshup`


### PR DESCRIPTION
Getting around to deprecating `AnnData.concatenate` in favor of `ad.concat`