### PR TITLE
Handle non-csr/csc sparse matrices in anndata.write

### DIFF
--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -469,6 +469,21 @@ _REGISTRY.register_write(ZarrGroup, views.SparseCSCView, IOSpec("csc_matrix", "0
 )
 
 
+@_REGISTRY.register_write(H5Group, sparse.coo_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(H5Group, sparse.lil_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(H5Group, sparse.dia_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(H5Group, sparse.bsr_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(H5Group, sparse.dok_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, sparse.coo_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, sparse.lil_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, sparse.dia_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, sparse.bsr_matrix, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, sparse.dok_matrix, IOSpec("csr_matrix", "0.1.0"))
+def write_sparse_non_compressed(f, k, elem, dataset_kwargs=MappingProxyType({})):
+    elem = elem.tocsr()
+    write_sparse_compressed(f, k, elem, fmt="csr", dataset_kwargs=dataset_kwargs)
+
+
 @_REGISTRY.register_write(H5Group, SparseDataset, IOSpec("", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, SparseDataset, IOSpec("", "0.1.0"))
 def write_sparse_dataset(f, k, elem, dataset_kwargs=MappingProxyType({})):

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_categorical_dtype
 import pytest
-from scipy.sparse import csr_matrix, csc_matrix
+from scipy.sparse import csr_matrix, csc_matrix, coo_matrix
 import zarr
 
 import anndata as ad
@@ -96,7 +96,7 @@ diskfmt2 = diskfmt
 # ------------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("typ", [np.array, csr_matrix, as_dense_dask_array])
+@pytest.mark.parametrize("typ", [np.array, csr_matrix, coo_matrix, as_dense_dask_array])
 def test_readwrite_roundtrip(typ, tmp_path, diskfmt, diskfmt2):
     tmpdir = Path(tmp_path)
     pth1 = tmpdir / f"first.{diskfmt}"


### PR DESCRIPTION
Attempting to save an AnnData object with non-CSR/CSC sparse matrices throws an error:

```
File "/usr/src/singlecellopenproblems/openproblems/api/utils.py", line 58, in write_h5ad
      adata.write_h5ad(filename)
    File "/usr/local/lib/python3.8/site-packages/anndata/_core/anndata.py", line 1918, in write_h5ad
      _write_h5ad(
    File "/usr/local/lib/python3.8/site-packages/anndata/_io/h5ad.py", line 85, in write_h5ad
      write_elem(f, "X", adata.X, dataset_kwargs=dataset_kwargs)
    File "/usr/local/lib/python3.8/site-packages/anndata/_io/utils.py", line 220, in func_wrapper
      raise type(e)(
  TypeError: No method has been defined for writing <class 'scipy.sparse._coo.coo_matrix'> elements to <class 'h5py._hl.group.Group'>
  
  Above error raised while writing key 'X' of <class 'h5py._hl.group.Group'> to /
```

This PR fixes that by registering an appropriate method which converts all sparse matrices without an explicitly defined conversion to CSR.