### PR TITLE
Stop using dtype argument

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -166,8 +166,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         If passing a :class:`~numpy.ndarray`, it needs to have a structured datatype.
     layers
         Key-indexed multi-dimensional arrays aligned to dimensions of `X`.
-    dtype
-        Data type used for storage.
     shape
         Shape tuple (#observations, #variables). Can only be provided if `X` is `None`.
     filename
@@ -451,27 +449,21 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
             _check_2d_shape(X)
             # if type doesn’t match, a copy is made, otherwise, use a view
-            if dtype is None and X.dtype != np.float32:
+            if dtype is not None:
+                # TODO: Decide on whether this should warn yet
                 warnings.warn(
-                    f"X.dtype being converted to np.float32 from {X.dtype}. In the next "
-                    "version of anndata (0.9) conversion will not be automatic. Pass "
-                    "dtype explicitly to avoid this warning. Pass "
-                    "`AnnData(X, dtype=X.dtype, ...)` to get the future behavour.",
-                    FutureWarning,
-                    stacklevel=3,
+                    "The dtype argument is deprecated and will be removed in 0.10.0",
+                    DeprecationWarning,
                 )
-                dtype = np.float32
-            elif dtype is None:
-                dtype = np.float32
-            if issparse(X) or isinstance(X, ma.MaskedArray):
-                # TODO: maybe use view on data attribute of sparse matrix
-                #       as in readwrite.read_10x_h5
-                if X.dtype != np.dtype(dtype):
+                if issparse(X) or isinstance(X, ma.MaskedArray):
+                    # TODO: maybe use view on data attribute of sparse matrix
+                    #       as in readwrite.read_10x_h5
+                    if X.dtype != np.dtype(dtype):
+                        X = X.astype(dtype)
+                elif isinstance(X, (ZarrArray, DaskArray)):
                     X = X.astype(dtype)
-            elif isinstance(X, (ZarrArray, DaskArray)):
-                X = X.astype(dtype)
-            else:  # is np.ndarray or a subclass, convert to true np.ndarray
-                X = np.array(X, dtype, copy=False)
+                else:  # is np.ndarray or a subclass, convert to true np.ndarray
+                    X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X
             self._n_obs, self._n_vars = self._X.shape
@@ -1243,11 +1235,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Same as `adata = adata[:, index]`, but inplace.
         """
         adata_subset = self[:, index].copy()
-        if adata_subset._has_X():
-            dtype = adata_subset.X.dtype
-        else:
-            dtype = None
-        self._init_as_actual(adata_subset, dtype=dtype)
+        self._init_as_actual(adata_subset)
 
     def _inplace_subset_obs(self, index: Index1D):
         """\
@@ -1256,11 +1244,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Same as `adata = adata[index, :]`, but inplace.
         """
         adata_subset = self[index].copy()
-        if adata_subset._has_X():
-            dtype = adata_subset.X.dtype
-        else:
-            dtype = None
-        self._init_as_actual(adata_subset, dtype=dtype)
+        self._init_as_actual(adata_subset)
 
     # TODO: Update, possibly remove
     def __setitem__(
@@ -1312,7 +1296,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             varp=self.obsp.copy(),
             filename=self.filename,
             layers={k: t_csr(v) for k, v in self.layers.items()},
-            dtype=self.X.dtype.name if X is not None else "float32",
         )
 
     T = property(transpose)
@@ -1466,10 +1449,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 new[key] = getattr(self, key).copy()
         if "X" in kwargs:
             new["X"] = kwargs["X"]
-            new["dtype"] = new["X"].dtype
         elif self._has_X():
             new["X"] = self.X.copy()
-            new["dtype"] = new["X"].dtype
         if "uns" in kwargs:
             new["uns"] = kwargs["uns"]
         else:
@@ -1519,9 +1500,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 "var": to_memory(self.raw.var, copy),
                 "varm": to_memory(self.raw.varm, copy),
             }
-
-        if self._has_X():
-            new["dtype"] = new["X"].dtype
 
         if self.isbacked:
             self.file.close()
@@ -1649,12 +1627,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             obs: 'anno1', 'anno2', 'batch'
             var: 'annoA-0', 'annoA-1', 'annoA-2', 'annoB-2'
         >>> adata.X
-        array([[2., 3.],
-               [5., 6.],
-               [3., 2.],
-               [6., 5.],
-               [3., 2.],
-               [6., 5.]], dtype=float32)
+        array([[2, 3],
+               [5, 6],
+               [3, 2],
+               [6, 5],
+               [3, 2],
+               [6, 5]])
         >>> adata.obs
              anno1 anno2 batch
         s1-0    c1   NaN     0
@@ -1691,9 +1669,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                [nan,  3.,  2.,  1.],
                [nan,  6.,  5.,  4.],
                [nan,  3.,  2.,  1.],
-               [nan,  6.,  5.,  4.]], dtype=float32)
+               [nan,  6.,  5.,  4.]])
         >>> outer.X.sum(axis=0)
-        array([nan, 25., 23., nan], dtype=float32)
+        array([nan, 25., 23., nan])
         >>> import pandas as pd
         >>> Xdf = pd.DataFrame(outer.X, columns=outer.var_names)
         >>> Xdf
@@ -1709,7 +1687,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         b    25.0
         c    23.0
         d    10.0
-        dtype: float32
+        dtype: float64
 
         One way to deal with missing values is to use masked arrays:
 
@@ -1729,10 +1707,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 [ True, False, False, False],
                 [ True, False, False, False],
                 [ True, False, False, False]],
-          fill_value=1e+20,
-          dtype=float32)
+          fill_value=1e+20)
         >>> outer.X.sum(axis=0).data
-        array([ 5., 25., 23., 10.], dtype=float32)
+        array([ 5., 25., 23., 10.])
 
         The masked array is not saved but has to be reinstantiated after saving.
 
@@ -1745,7 +1722,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                [nan,  3.,  2.,  1.],
                [nan,  6.,  5.,  4.],
                [nan,  3.,  2.,  1.],
-               [nan,  6.,  5.,  4.]], dtype=float32)
+               [nan,  6.,  5.,  4.]])
 
         For sparse data, everything behaves similarly,
         except that for `join='outer'`, zeros are added.

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -450,10 +450,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             _check_2d_shape(X)
             # if type doesn’t match, a copy is made, otherwise, use a view
             if dtype is not None:
-                # TODO: Decide on whether this should warn yet
                 warnings.warn(
-                    "The dtype argument is deprecated and will be removed in 0.10.0",
-                    DeprecationWarning,
+                    "The dtype argument will be deprecated in anndata 0.10.0",
+                    PendingDeprecationWarning,
                 )
                 if issparse(X) or isinstance(X, ma.MaskedArray):
                     # TODO: maybe use view on data attribute of sparse matrix

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -507,7 +507,7 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index):
            [0., 1., 0.],
            [0., 0., 1.],
            [0., 1., 0.],
-           [1., 0., 0.]], dtype=float32)
+           [1., 0., 0.]])
     """
     return Reindexer(cur_var, new_var)
 
@@ -831,14 +831,14 @@ def concat(
 
     >>> ad.concat([a, b]).to_df()
         var1  var2
-    s1   0.0   1.0
-    s2   2.0   3.0
-    s3   4.0   5.0
-    s4   7.0   8.0
+    s1     0     1
+    s2     2     3
+    s3     4     5
+    s4     7     8
     >>> ad.concat([a, c], axis=1).to_df()
         var1  var2  var3  var4
-    s1   0.0   1.0  10.0  11.0
-    s2   2.0   3.0  12.0  13.0
+    s1     0     1    10    11
+    s2     2     3    12    13
 
     Inner and outer joins
 
@@ -857,10 +857,10 @@ def concat(
     Index(['var1', 'var2', 'var3'], dtype='object')
     >>> outer.to_df()  # Sparse arrays are padded with zeroes by default
         var1  var2  var3
-    s1   0.0   1.0   0.0
-    s2   2.0   3.0   0.0
-    s3   4.0   5.0   6.0
-    s4   7.0   8.0   9.0
+    s1     0     1     0
+    s2     2     3     0
+    s3     4     5     6
+    s4     7     8     9
 
     Keeping track of source objects
 
@@ -1026,7 +1026,6 @@ def concat(
             [
                 AnnData(
                     X=a.raw.X,
-                    dtype=a.raw.X.dtype,
                     obs=pd.DataFrame(index=a.obs_names),
                     var=a.raw.var,
                     varm=a.raw.varm,
@@ -1049,7 +1048,6 @@ def concat(
     return AnnData(
         **{
             "X": X,
-            "dtype": None if X is None else X.dtype,
             "layers": layers,
             dim: concat_annot,
             alt_dim: alt_annot,

--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -146,16 +146,6 @@ def read_h5ad_backed(filename: Union[str, Path], mode: Literal["r", "r+"]) -> An
 
     d["raw"] = _read_raw(f, attrs={"var", "varm"})
 
-    X_dset = f.get("X", None)
-    if X_dset is None:
-        pass
-    elif isinstance(X_dset, h5py.Group):
-        d["dtype"] = X_dset["data"].dtype
-    elif hasattr(X_dset, "dtype"):
-        d["dtype"] = f["X"].dtype
-    else:
-        raise ValueError()
-
     # Backwards compat to <0.7
     if isinstance(f["obs"], h5py.Dataset):
         _clean_uns(d)
@@ -246,16 +236,6 @@ def read_h5ad(
                 d[k] = read_elem(f[k])
 
         d["raw"] = _read_raw(f, as_sparse, rdasp)
-
-        X_dset = f.get("X", None)
-        if X_dset is None:
-            pass
-        elif isinstance(X_dset, h5py.Group):
-            d["dtype"] = X_dset["data"].dtype
-        elif hasattr(X_dset, "dtype"):
-            d["dtype"] = f["X"].dtype
-        else:
-            raise ValueError()
 
         # Backwards compat to <0.7
         if isinstance(f["obs"], h5py.Dataset):

--- a/anndata/_io/read.py
+++ b/anndata/_io/read.py
@@ -76,7 +76,7 @@ def read_excel(
     X = df.values[:, 1:]
     row = dict(row_names=df.iloc[:, 0].values.astype(str))
     col = dict(col_names=np.array(df.columns[1:], dtype=str))
-    return AnnData(X, row, col, dtype=dtype)
+    return AnnData(X, row, col)
 
 
 def read_umi_tools(filename: PathLike, dtype=None) -> AnnData:
@@ -93,15 +93,13 @@ def read_umi_tools(filename: PathLike, dtype=None) -> AnnData:
     table = pd.read_table(filename, dtype={"gene": "category", "cell": "category"})
 
     X = sparse.csr_matrix(
-        (table["count"], (table["cell"].cat.codes, table["gene"].cat.codes))
+        (table["count"], (table["cell"].cat.codes, table["gene"].cat.codes)),
+        dtype=dtype,
     )
     obs = pd.DataFrame(index=pd.Index(table["cell"].cat.categories, name="cell"))
     var = pd.DataFrame(index=pd.Index(table["gene"].cat.categories, name="gene"))
 
-    if dtype is None:
-        dtype = X.dtype
-
-    return AnnData(X=X, obs=obs, var=var, dtype=dtype)
+    return AnnData(X=X, obs=obs, var=var)
 
 
 def read_hdf(filename: PathLike, key: str) -> AnnData:
@@ -133,7 +131,7 @@ def read_hdf(filename: PathLike, key: str) -> AnnData:
         for iname, name in enumerate(["row_names", "col_names"]):
             if name in keys:
                 rows_cols[iname][name] = f[name][()]
-    adata = AnnData(X, rows_cols[0], rows_cols[1], dtype=X.dtype.name)
+    adata = AnnData(X, rows_cols[0], rows_cols[1])
     return adata
 
 
@@ -252,6 +250,7 @@ def read_loom(
         if X_name not in lc.layers.keys():
             X_name = ""
         X = lc.layers[X_name].sparse().T.tocsr() if sparse else lc.layers[X_name][()].T
+        X = X.astype(dtype, copy=False)
 
         layers = OrderedDict()
         if X_name != "":
@@ -295,7 +294,6 @@ def read_loom(
             obsm=obsm if obsm else None,
             varm=varm if varm else None,
             uns=uns,
-            dtype=dtype,
         )
     return adata
 
@@ -318,7 +316,7 @@ def read_mtx(filename: PathLike, dtype: str = "float32") -> AnnData:
     from scipy.sparse import csr_matrix
 
     X = csr_matrix(X)
-    return AnnData(X, dtype=dtype)
+    return AnnData(X)
 
 
 def read_text(
@@ -472,7 +470,6 @@ def _read_text(
         data,
         obs=dict(obs_names=row_names),
         var=dict(var_names=col_names),
-        dtype=dtype,
     )
 
 

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -246,8 +246,6 @@ def read_anndata(elem):
     ]:
         if k in elem:
             d[k] = read_elem(elem[k])
-        if "X" in d:
-            d["dtype"] = d["X"].dtype
     return AnnData(**d)
 
 

--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -85,9 +85,6 @@ def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]) -> AnnData:
 
     d["raw"] = _read_legacy_raw(f, d.get("raw"), read_dataframe, read_elem)
 
-    if "X" in d:
-        d["dtype"] = d["X"].dtype
-
     # Backwards compat to <0.7
     if isinstance(f["obs"], zarr.Array):
         _clean_uns(d)

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -177,7 +177,6 @@ def gen_adata(
         layers=layers,
         obsp=obsp,
         varp=varp,
-        dtype=X_dtype,
         uns=uns,
     )
     return adata

--- a/anndata/tests/test_anncollection.py
+++ b/anndata/tests/test_anncollection.py
@@ -12,13 +12,11 @@ _dense = lambda a: a.toarray() if issparse(a) else a
 
 @pytest.fixture
 def adatas(request):
-    adata1 = ad.AnnData(
-        X=request.param([[1, 2, 0], [4, 5, 0], [7, 8, 0]]), dtype="float32"
-    )
+    adata1 = ad.AnnData(X=request.param([[1, 2, 0], [4, 5, 0], [7, 8, 0]]))
     adata1.obs["a_test"] = ["a", "a", "b"]
     adata1.obsm["o_test"] = np.ones((adata1.n_obs, 2))
 
-    adata2 = ad.AnnData(X=request.param([[1, 3, 0], [9, 8, 0]]), dtype="float32")
+    adata2 = ad.AnnData(X=request.param([[1, 3, 0], [9, 8, 0]]))
     adata2.obs["a_test"] = ["c", "c"]
     adata2.obsm["o_test"] = np.zeros((adata2.n_obs, 2))
 

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -1241,11 +1241,9 @@ def test_concat_null_X():
 
 # https://github.com/scverse/ehrapy/issues/151#issuecomment-1016753744
 def test_concat_X_dtype():
-    adatas_orig = {
-        k: AnnData(np.ones((20, 10), dtype=np.int8), dtype=np.int8) for k in list("abc")
-    }
+    adatas_orig = {k: AnnData(np.ones((20, 10), dtype=np.int8)) for k in list("abc")}
     for adata in adatas_orig.values():
-        adata.raw = AnnData(np.ones((20, 30), dtype=np.float64), dtype=np.float64)
+        adata.raw = AnnData(np.ones((20, 30), dtype=np.float64))
 
     result = concat(adatas_orig, index_unique="-")
 
@@ -1266,11 +1264,9 @@ def test_concat_different_types_dask(merge_strategy, array_type):
 
     varm_array = sparse.random(5, 20, density=0.5, format="csr")
 
-    ad1 = ad.AnnData(X=np.ones((5, 5)), varm={"a": varm_array}, dtype=np.float64)
-    ad1_other = ad.AnnData(
-        X=np.ones((5, 5)), varm={"a": array_type(varm_array)}, dtype=np.float64
-    )
-    ad2 = ad.AnnData(X=np.zeros((5, 5)), varm={"a": da.ones(5, 20)}, dtype=np.float64)
+    ad1 = ad.AnnData(X=np.ones((5, 5)), varm={"a": varm_array})
+    ad1_other = ad.AnnData(X=np.ones((5, 5)), varm={"a": array_type(varm_array)})
+    ad2 = ad.AnnData(X=np.zeros((5, 5)), varm={"a": da.ones(5, 20)})
 
     result1 = ad.concat([ad1, ad2], merge=merge_strategy)
     target1 = ad.concat([ad1_other, ad2], merge=merge_strategy)

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -204,7 +204,7 @@ def test_deprecated_neighbors_set_other(adata_neighbors):
 # This should break in 0.9
 def test_dtype_warning():
     # Tests a warning is thrown
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         a = AnnData(np.ones((3, 3)), dtype=np.float32)
     assert a.X.dtype == np.float32
 
@@ -217,7 +217,7 @@ def test_dtype_warning():
     assert b.X.dtype == np.float64
 
     # Should warn, should copy
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         c_X = np.ones((3, 3), dtype=np.float32)
         c = AnnData(c_X, dtype=np.float64)
         assert not record

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -205,21 +205,21 @@ def test_deprecated_neighbors_set_other(adata_neighbors):
 def test_dtype_warning():
     # Tests a warning is thrown
     with pytest.warns(FutureWarning):
-        a = AnnData(np.ones((3, 3), dtype=np.float64))
+        a = AnnData(np.ones((3, 3)), dtype=np.float32)
     assert a.X.dtype == np.float32
 
     # This shouldn't warn, shouldn't copy
     with warnings.catch_warnings(record=True) as record:
         b_X = np.ones((3, 3), dtype=np.float64)
-        b = AnnData(b_X, dtype=np.float64)
+        b = AnnData(b_X)
         assert not record
     assert b_X is b.X
     assert b.X.dtype == np.float64
 
-    # Shouldn't warn, should copy
-    with warnings.catch_warnings(record=True) as record:
+    # Should warn, should copy
+    with pytest.warns(FutureWarning):
         c_X = np.ones((3, 3), dtype=np.float32)
-        c = AnnData(np.ones((3, 3), dtype=np.float32), dtype=np.float64)
+        c = AnnData(c_X, dtype=np.float64)
         assert not record
     assert c_X is not c.X
     assert c.X.dtype == np.float64

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -204,7 +204,7 @@ def test_deprecated_neighbors_set_other(adata_neighbors):
 # This should break in 0.9
 def test_dtype_warning():
     # Tests a warning is thrown
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PendingDeprecationWarning):
         a = AnnData(np.ones((3, 3)), dtype=np.float32)
     assert a.X.dtype == np.float32
 
@@ -217,7 +217,7 @@ def test_dtype_warning():
     assert b.X.dtype == np.float64
 
     # Should warn, should copy
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PendingDeprecationWarning):
         c_X = np.ones((3, 3), dtype=np.float32)
         c = AnnData(c_X, dtype=np.float64)
         assert not record

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -48,7 +48,6 @@ def adata():
         obsm=dict(o1=np.zeros((X.shape[0], 10))),
         varm=dict(v1=np.ones((X.shape[1], 20))),
         layers=dict(float=X.astype(float), sparse=sparse.csr_matrix(X)),
-        dtype="int32",
     )
 
 

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -35,7 +35,7 @@ uns_dict = dict(  # unstructured annotation
 @pytest.fixture
 def adata_raw():
     adata = ad.AnnData(
-        np.array(data), obs=obs_dict, var=var_dict, uns=uns_dict, dtype="int32"
+        np.array(data, dtype="int32"), obs=obs_dict, var=var_dict, uns=uns_dict
     )
     adata.raw = adata
     # Make them different shapes

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -197,8 +197,8 @@ def test_readwrite_zarr(typ, tmp_path):
 
 @pytest.mark.parametrize("typ", [np.array, csr_matrix, as_dense_dask_array])
 def test_readwrite_maintain_X_dtype(typ, backing_h5ad):
-    X = typ(X_list)
-    adata_src = ad.AnnData(X, dtype="int8")
+    X = typ(X_list).astype("int8")
+    adata_src = ad.AnnData(X)
     adata_src.write(backing_h5ad)
 
     adata = ad.read(backing_h5ad)
@@ -778,7 +778,7 @@ def test_io_dtype(tmp_path, diskfmt, dtype):
     read = lambda pth: getattr(ad, f"read_{diskfmt}")(pth)
     write = lambda adata, pth: getattr(adata, f"write_{diskfmt}")(pth)
 
-    orig = ad.AnnData(np.ones((5, 8), dtype=dtype), dtype=dtype)
+    orig = ad.AnnData(np.ones((5, 8), dtype=dtype))
     write(orig, pth)
     curr = read(pth)
 

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -80,8 +80,8 @@ def mapping_name(request):
 
 
 def test_views():
-    X = np.array(X_list)
-    adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict, dtype="int32")
+    X = np.array(X_list, dtype="int32")
+    adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
 
     assert adata[:, 0].is_view
     assert adata[:, 0].X.tolist() == np.reshape([1, 4, 7], (3, 1)).tolist()
@@ -182,7 +182,7 @@ def test_set_var(adata, subset_func):
 
 
 def test_drop_obs_column():
-    adata = ad.AnnData(np.array(X_list), obs=obs_dict, dtype="int32")
+    adata = ad.AnnData(np.array(X_list, dtype="int32"), obs=obs_dict)
 
     subset = adata[:2]
     assert subset.is_view

--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -61,13 +61,13 @@ For example, given two anndata objects with differing variables:
            [0., 1.],
            [0., 0.],
            [0., 1.],
-           [1., 0.]], dtype=float32)
+           [1., 0.]])
     >>> ad.concat([a, b], join="outer").X.toarray()
     array([[1., 0., 0.],
            [0., 1., 0.],
            [0., 0., 1.],
            [0., 1., 0.],
-           [1., 0., 0.]], dtype=float32)
+           [1., 0., 0.]])
 
 The join argument is used for any element which has both (1) an axis being concatenated and (2) has an axis not being concatenated.
 When concatenating along the `obs` dimension, this means elements of `.X`, `obs`, `.layers`, and `.obsm` will be affected by the choice of `join`.

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -9,7 +9,7 @@
 
 .. rubric:: Breaking changes
 
-* Not `AnnData` `dtype`` argument no longer defaults to `float32`` :pr:`854` :smaller:`ivirshup`
+* The `AnnData` `dtype`` argument no longer defaults to `float32` :pr:`854` :smaller:`ivirshup`
 
 .. rubric:: Bug fixes
 

--- a/docs/release-notes/0.9.0.rst
+++ b/docs/release-notes/0.9.0.rst
@@ -7,6 +7,10 @@
 * Expanded docstring more documentation for ``backed`` argument of :func:`anndata.read_h5ad` :pr:`812` :smaller:`jeskowagner`
 * Added support for dask arrays :pr:`813` :smaller:`syelman` :smaller:`rahulbshrestha`
 
+.. rubric:: Breaking changes
+
+* Not `AnnData` `dtype`` argument no longer defaults to `float32`` :pr:`854` :smaller:`ivirshup`
+
 .. rubric:: Bug fixes
 
 .. rubric:: Updates


### PR DESCRIPTION
Supersedes #434

Start deprecation of `AnnData(..., dtype=dtype)`. Now just makes not passing it do nothing, and will throw a quite PendingDeprecation warning. During this release cycle it will start warning for everyone.