### PR TITLE
Fix sklearn package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest-cov>=2.10",
     "zarr",
     "matplotlib",
-    "sklearn",
+    "scikit-learn",
     "openpyxl",
     "joblib",
     "boltons",


### PR DESCRIPTION
```
The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
```

Signed-off-by: zethson <lukas.heumos@posteo.net>