### PR TITLE
Remove AnnDataFileManager._adata

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -395,9 +395,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         # init from file
         if filename is not None:
-            self.file = AnnDataFileManager(self, filename, filemode)
+            self.file = AnnDataFileManager(filename, filemode)
         else:
-            self.file = AnnDataFileManager(self, None)
+            self.file = AnnDataFileManager(None)
 
             # init from AnnData
             if isinstance(X, AnnData):
@@ -1051,7 +1051,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # change from backing-mode back to full loading into memory
         if filename is None:
             if self.filename is not None:
-                self.file._to_memory_mode()
+                self.file._to_memory_mode(self)
             else:
                 # both filename and self.filename are None
                 # do nothing

--- a/anndata/_core/file_backing.py
+++ b/anndata/_core/file_backing.py
@@ -16,11 +16,9 @@ class AnnDataFileManager:
 
     def __init__(
         self,
-        adata: "anndata.AnnData",
         filename: Optional[PathLike] = None,
         filemode: Optional[Literal["r", "r+"]] = None,
     ):
-        self._adata = adata
         self.filename = filename
         self._filemode = filemode
         self._file = None
@@ -76,9 +74,9 @@ class AnnDataFileManager:
         if self._file is not None:
             self._file.close()
 
-    def _to_memory_mode(self):
+    def _to_memory_mode(self, adata: "anndata.AnnData"):
         """Close the backing file, forget filename, *do* change to memory mode."""
-        self._adata.__X = self._adata.X[()]
+        adata.__X = adata.X[()]
         self._file.close()
         self._file = None
         self._filename = None


### PR DESCRIPTION
Original post on [discourse](https://discourse.scverse.org/t/avoiding-anndata-file-adata-self-reference/1097)

Slight tweaks to remove the cyclical reference `AnnDataFileManager._adata` which causes stack overflows when the AnnData object is parsed by parsers such as fastapi's [`jsonable_encoder`](https://fastapi.tiangolo.com/tutorial/encoder/)