### PR TITLE
Allow dim_len of records to be the number of fields.

### DIFF
--- a/anndata/tests/test_awkward.py
+++ b/anndata/tests/test_awkward.py
@@ -269,6 +269,21 @@ def test_awkward_io(tmp_path, array):
             id="null_awk:recordoflists-outer",
         ),
         pytest.param(
+            [ak.Array([{"a": 1}, {"a": 2}]), ak.Array([{"a": 3}, {"a": 4}])],
+            "inner",
+            ak.Array([{"a": i} for i in range(1, 5)]),
+            id="awk-simple-record",
+        ),
+        pytest.param(
+            [
+                ak.Array([{"a": 1, "b": 1}, {"a": 2, "b": 2}]),
+                ak.Array([{"a": 3}, {"a": 4}]),
+            ],
+            "inner",
+            ak.Array([{"a": i} for i in range(1, 5)]),
+            id="awk-simple-record-inner",
+        ),
+        pytest.param(
             [
                 None,
                 ak.Array([{"a": [1, 2], "b": [1, 2]}, {"a": [3], "b": [4]}]),

--- a/anndata/tests/test_awkward.py
+++ b/anndata/tests/test_awkward.py
@@ -18,7 +18,7 @@ import pandas as pd
         # numpy array
         [ak.Array(np.arange(2 * 3 * 4 * 5).reshape((2, 3, 4, 5))), (2, 3, 4, 5)],
         # record
-        [ak.Array([{"a": 1, "b": 2}, {"a": 1, "b": 3}]), (2,)],
+        [ak.Array([{"a": 1, "b": 2}, {"a": 1, "b": 3}]), (2, 2)],
         # ListType, variable length
         [ak.Array([[1], [2, 3], [4, 5, 6]]), (3, None)],
         # ListType, happens to have the same length, but is not regular
@@ -28,7 +28,7 @@ import pandas as pd
         # nested record
         [
             ak.to_regular(ak.Array([[{"a": 0}, {"b": 1}], [{"c": 2}, {"d": 3}]]), 1),
-            (2, 2),
+            (2, 2, 4),
         ],
         # mixed types (variable length)
         [ak.Array([[1, 2], ["a"]]), (2, None)],
@@ -283,6 +283,16 @@ def test_awkward_io(tmp_path, array):
             ak.Array([{"a": i} for i in range(1, 5)]),
             id="awk-simple-record-inner",
         ),
+        # TODO:
+        # pytest.param(
+        #     [
+        #         ak.Array([{"a": 1, "b": 1}, {"a": 2, "b": 2}]),
+        #         ak.Array([{"a": 3}, {"a": 4}]),
+        #     ],
+        #     "outer",
+        #     ak.Array([{"a": 1, "b": 1}, {"a": 2, "b": 2}, {"a": 3}, {"a": 4},]),
+        #     id="awk-simple-record-outer",
+        # ),
         pytest.param(
             [
                 None,

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -102,10 +102,14 @@ try:
                 lateral_context["out"] = -1
             return ak.contents.EmptyArray()
 
+        elif layout.is_record and depth == lateral_context["axis"]:
+            lateral_context["out"] = len(layout.fields)
+            return ak.contents.EmptyArray()
+
         elif layout.is_record:
             # if it's a record, you want to stop descent with an error
-            raise TypeError(
-                f"axis={lateral_context['axis']} is too deep, reaches record"
+            raise NotImplementedError(
+                f"Cannot recurse into record type found at axis={lateral_context['axis']}"
             )
 
         elif layout.is_union:

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -107,8 +107,10 @@ try:
             return ak.contents.EmptyArray()
 
         elif layout.is_record:
-            # if it's a record, you want to stop descent with an error
-            raise NotImplementedError(
+            # currently, we don't recurse into records
+            # in theory we could, just not sure how to do it at the moment
+            # Would need to consider cases like: scalars, unevenly sized values
+            raise TypeError(
                 f"Cannot recurse into record type found at axis={lateral_context['axis']}"
             )
 


### PR DESCRIPTION
Maybe fixes #912

Does NOT allow recursing past records. Maybe the same approach as was done for unions thing would work here, but idk if that code branch actually works. It says it throws an error if the lengths of two branches aren't the same size, but that's not what it looks like to me. Would be worth a test.

At the moment two tests break since they are expecting errors. We could change those, but idk if we made any other assumptions about the length of record arrays.