### PR TITLE
Try checking against upstream release candidates

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,6 +16,9 @@ jobs:
         RUN_COVERAGE: yes
       Python38:
         python.version: '3.8'
+      PreRelease:
+        python.version: '3.10'
+        PRERELEASE_DEPENDENCIES: yes
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -36,6 +39,11 @@ jobs:
       pip install pytest-cov wheel
       pip install .[dev,test]
     displayName: 'Install dependencies'
+
+  - script: |
+      pip install -U --pre ".[dev,test]"
+    displayName: 'Install dependencies release candidates'
+    condition: eq(variables['PRERELEASE_DEPENDENCIES'], 'yes')
 
   - script: |
       pip list

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,9 +39,12 @@ jobs:
       pip install pytest-cov wheel
       pip install .[dev,test]
     displayName: 'Install dependencies'
+    condition: eq(variables['PRERELEASE_DEPENDENCIES'], 'no')
 
   - script: |
-      pip install -U --pre ".[dev,test]"
+      python -m pip install --pre --upgrade pip
+      pip install --pre pytest-cov wheel
+      pip install --pre .[dev,test]
     displayName: 'Install dependencies release candidates'
     condition: eq(variables['PRERELEASE_DEPENDENCIES'], 'yes')
 


### PR DESCRIPTION
Adding a test job that uses `pip install --pre` to test against upstream release candidates.

Could use some consideration on how exactly this works.

- [ ] Decide if this should be required
- [ ] Check that installation is happening correctly