### PR TITLE
Pandas 2.0 compat

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -4,6 +4,7 @@ trigger:
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
   RUN_COVERAGE: no
+  PRERELEASE_DEPENDENCIES: no
 
 jobs:
 - job: PyTest
@@ -16,6 +17,9 @@ jobs:
         RUN_COVERAGE: yes
       Python38:
         python.version: '3.8'
+      PreRelease:
+        python.version: '3.10'
+        PRERELEASE_DEPENDENCIES: yes
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -36,6 +40,14 @@ jobs:
       pip install pytest-cov wheel
       pip install .[dev,test]
     displayName: 'Install dependencies'
+    condition: eq(variables['PRERELEASE_DEPENDENCIES'], 'no')
+
+  - script: |
+      python -m pip install --pre --upgrade pip
+      pip install --pre pytest-cov wheel
+      pip install --pre .[dev,test]
+    displayName: 'Install dependencies release candidates'
+    condition: eq(variables['PRERELEASE_DEPENDENCIES'], 'yes')
 
   - script: |
       pip list

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -99,7 +99,7 @@ def _check_2d_shape(X):
 @singledispatch
 def _gen_dataframe(anno, length, index_names):
     if anno is None or len(anno) == 0:
-        return pd.DataFrame(index=pd.RangeIndex(0, length, name=None).astype(str))
+        return pd.DataFrame({}, index=pd.RangeIndex(0, length, name=None).astype(str))
     for index_name in index_names:
         if index_name in anno:
             return pd.DataFrame(
@@ -844,7 +844,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     @obs.deleter
     def obs(self):
-        self.obs = pd.DataFrame(index=self.obs_names)
+        self.obs = pd.DataFrame({}, index=self.obs_names)
 
     @property
     def obs_names(self) -> pd.Index:
@@ -867,7 +867,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     @var.deleter
     def var(self):
-        self.var = pd.DataFrame(index=self.var_names)
+        self.var = pd.DataFrame({}, index=self.var_names)
 
     @property
     def var_names(self) -> pd.Index:

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -591,7 +591,7 @@ def test_write_categorical(tmp_path, diskfmt):
 def test_write_categorical_index(tmp_path, diskfmt):
     adata_pth = tmp_path / f"adata.{diskfmt}"
     orig = ad.AnnData(
-        uns={"df": pd.DataFrame(index=pd.Categorical(list("aabcd")))},
+        uns={"df": pd.DataFrame({}, index=pd.Categorical(list("aabcd")))},
     )
     getattr(orig, f"write_{diskfmt}")(adata_pth)
     curr = getattr(ad, f"read_{diskfmt}")(adata_pth)


### PR DESCRIPTION
Getting ready for pandas 2.0

It looks like general test breakages can be done separately from nullable string types. But I will need to make a release of scanpy to remove some deprecated calls for this PR to pass. That should be fine as it's locally fixed by a find and replace in one file.