### PR TITLE
Make default for to_memory, copy=False

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1457,7 +1457,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             new["raw"] = self.raw.copy()
         return AnnData(**new)
 
-    def to_memory(self, copy=True) -> "AnnData":
+    def to_memory(self, copy=False) -> "AnnData":
         """Return a new AnnData object with all backed arrays loaded into memory.
 
         Params

--- a/anndata/_core/file_backing.py
+++ b/anndata/_core/file_backing.py
@@ -93,7 +93,7 @@ class AnnDataFileManager:
 
 
 @singledispatch
-def to_memory(x, copy=True):
+def to_memory(x, copy=False):
     """Permissivley convert objects to in-memory representation.
 
     If they already are in-memory, (or are just unrecognized) pass a copy through.
@@ -106,30 +106,30 @@ def to_memory(x, copy=True):
 
 @to_memory.register(ZarrArray)
 @to_memory.register(h5py.Dataset)
-def _(x, copy=True):
+def _(x, copy=False):
     return x[...]
 
 
 @to_memory.register(SparseDataset)
-def _(x: SparseDataset, copy=True):
+def _(x: SparseDataset, copy=False):
     return x.to_memory()
 
 
 @to_memory.register(DaskArray)
-def _(x, copy=True):
+def _(x, copy=False):
     return x.compute()
 
 
 @to_memory.register(Mapping)
-def _(x: Mapping, copy=True):
+def _(x: Mapping, copy=False):
     return {k: to_memory(v, copy=copy) for k, v in x.items()}
 
 
 @to_memory.register(AwkArray)
-def _(x, copy=True):
-    from copy import copy
+def _(x, copy=False):
+    from copy import copy as _copy
 
     if copy:
-        return copy(x)
+        return _copy(x)
     else:
         return x

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -445,7 +445,7 @@ def assert_equal_awkarray(a, b, exact=False, elem_name=None):
     from anndata.compat import awkward as ak
 
     if exact:
-        assert a.type == b.type, format_msg(elem_name)
+        assert a.type == b.type, f"{a.type} != {b.type}, {format_msg(elem_name)}"
     assert ak.to_list(a) == ak.to_list(b), format_msg(elem_name)
 
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -592,3 +592,21 @@ def test_copy():
         assert_eq_not_id(map_sprs.keys(), map_copy.keys())
         for key in map_sprs.keys():
             assert_eq_not_id(map_sprs[key], map_copy[key])
+
+
+def test_to_memory_no_copy():
+    adata = gen_adata((3, 5))
+    mem = adata.to_memory()
+
+    assert mem.X is adata.X
+    # Currently does not hold for `obs`, `var`, but should in future
+    for key in adata.layers:
+        assert mem.layers[key] is adata.layers[key]
+    for key in adata.obsm:
+        assert mem.obsm[key] is adata.obsm[key]
+    for key in adata.varm:
+        assert mem.varm[key] is adata.varm[key]
+    for key in adata.obsp:
+        assert mem.obsp[key] is adata.obsp[key]
+    for key in adata.varp:
+        assert mem.varp[key] is adata.varp[key]

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -208,7 +208,7 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
     # Value equivalent
     assert_equal(mem_v, backed_v)
     # Type and value equivalent
-    assert_equal(mem_v.copy(), backed_v.to_memory(), exact=True)
+    assert_equal(mem_v.copy(), backed_v.to_memory(copy=True), exact=True)
     assert backed_v.is_view
     assert backed_v.isbacked
 


### PR DESCRIPTION
Change I meant to make before the release, glad I caught it at release candidate.

Reasoning being: while copy=True is safer, this is meant to be used in low memory situations.