### PR TITLE
Fix adata.raw.to_adata() not having obs, obsm from the parent 

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -758,7 +758,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             if self.is_view:
                 self._init_as_actual(self.copy())
-            self._raw = Raw(value)
+            self._raw = Raw(self, X=value.X, var=value.var, varm=value.varm)
 
     @raw.deleter
     def raw(self):

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -147,3 +147,18 @@ def test_to_adata():
     del adata.layers, adata.varp
 
     assert_equal(adata, with_raw.raw.to_adata())
+
+
+def test_to_adata_populates_obs():
+    adata = gen_adata((20, 10), **GEN_ADATA_DASK_ARGS)
+
+    del adata.layers, adata.uns, adata.varp
+    adata_w_raw = adata.copy()
+
+    raw = adata.copy()
+    del raw.obs, raw.obsm, raw.obsp, raw.uns
+
+    adata_w_raw.raw = raw
+    from_raw = adata_w_raw.raw.to_adata()
+
+    assert_equal(adata, from_raw)

--- a/docs/release-notes/0.9.0.md
+++ b/docs/release-notes/0.9.0.md
@@ -51,3 +51,4 @@
 - Fixed order dependent outer concatenation bug {pr}`904` {user}`ivirshup`, reported by {user}`szalata`
 - Fixed bug in renaming categories {pr}`790` {user}`ivirshup`, reported by {user}`perrin-isir`
 - Fixed IO bug when keys in `uns` ended in `_categories` {pr}`806` {user}`ivirshup`, reported by {user}`Hrovatin`
+- Fixed `raw.to_adata` not populating `obs` aligned values when `raw` was assigned through the setter {pr}`939` {user}`ivirshup`


### PR DESCRIPTION
Only occurred when set like `adata.raw = raw`, not when set through constructor.