### PR TITLE
Use mmread from fast_matrix_market if it's installed

### DIFF
--- a/anndata/_io/read.py
+++ b/anndata/_io/read.py
@@ -310,7 +310,10 @@ def read_mtx(filename: PathLike, dtype: str = "float32") -> AnnData:
     dtype
         Numpy data type.
     """
-    from scipy.io import mmread
+    try:
+        from fast_matrix_market import mmread
+    except ImportError:
+        from scipy.io import mmread
 
     # could be rewritten accounting for dtype to be more performant
     X = mmread(fspath(filename)).astype(dtype)


### PR DESCRIPTION
I tried out https://pypi.org/project/fast-matrix-market and it works really well and is by 1-2 orders or magnitude faster on big matrices. It would be nice to support it as an optional dependency. 

WDYT @ivirshup ? 