### PR TITLE
Fix README image alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <img
   src="https://raw.githubusercontent.com/scverse/anndata/main/docs/_static/img/anndata_schema.svg"
-  class="align-right" width="350" alt="image"
+  align="right" width="350" alt="image"
 />
 
 # anndata - Annotated data


### PR DESCRIPTION
Seems like `align="right"` gets converted into `class="align-right"` by MyST, and is still respected by GitHub

GH | RTD
--- | ---
![grafik](https://github.com/scverse/anndata/assets/291575/671ee3af-1d2b-4799-95dd-474b2ab1264e) | ![grafik](https://github.com/scverse/anndata/assets/291575/f2ffa68a-f7ad-4ca2-80ce-d13e0d661fd4)
