### PR TITLE
Fix view setitem warnings (alt)

### DIFF
--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -136,8 +136,6 @@ class AlignedViewMixin(_SetItemMixin):
     parent_mapping: Mapping[str, V]
     """The object this is a view of."""
 
-    _view_args: ElementRef
-
     is_view = True
 
     def __getitem__(self, key: str) -> V:
@@ -165,6 +163,10 @@ class AlignedViewMixin(_SetItemMixin):
 
     def __len__(self) -> int:
         return len(self.parent_mapping)
+
+    @property
+    def _view_args(self) -> ElementRef:
+        return ElementRef(self.parent, self.attrname)
 
 
 class AlignedActualMixin:
@@ -275,9 +277,6 @@ class AxisArraysView(AlignedViewMixin, AxisArraysBase):
         self._parent = parent_view
         self.subset_idx = subset_idx
         self._axis = parent_mapping._axis
-
-    def _view_args(self) -> ElementRef:
-        return ElementRef(self._parent, self._axis, (self.attrname,))
 
 
 AxisArraysBase._view_class = AxisArraysView

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -12,7 +12,7 @@ from scipy.sparse import spmatrix
 
 from ..utils import deprecated, ensure_df_homogeneous, dim_len
 from . import raw, anndata
-from .views import _SetItemMixin, as_view
+from .views import as_view
 from .access import ElementRef
 from .index import _subset
 from anndata.compat import AwkArray

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -12,7 +12,7 @@ from scipy.sparse import spmatrix
 
 from ..utils import deprecated, ensure_df_homogeneous, dim_len
 from . import raw, anndata
-from .views import as_view
+from .views import _SetItemMixin, as_view
 from .access import ElementRef
 from .index import _subset
 from anndata.compat import AwkArray
@@ -126,7 +126,7 @@ class AlignedMapping(cabc.MutableMapping, ABC):
         return dict(self)
 
 
-class AlignedViewMixin:
+class AlignedViewMixin(_SetItemMixin):
     parent: "anndata.AnnData"
     """Reference to parent AnnData view"""
 
@@ -135,6 +135,8 @@ class AlignedViewMixin:
 
     parent_mapping: Mapping[str, V]
     """The object this is a view of."""
+
+    _view_args: ElementRef
 
     is_view = True
 
@@ -146,10 +148,7 @@ class AlignedViewMixin:
 
     def __setitem__(self, key: str, value: V):
         value = self._validate_value(value, key)  # Validate before mutating
-        adata = self.parent.copy()
-        new_mapping = getattr(adata, self.attrname)
-        new_mapping[key] = value
-        self.parent._init_as_actual(adata)
+        super().__setitem__(key, value)
 
     def __delitem__(self, key: str):
         self[key]  # Make sure it exists before bothering with a copy
@@ -276,6 +275,9 @@ class AxisArraysView(AlignedViewMixin, AxisArraysBase):
         self._parent = parent_view
         self.subset_idx = subset_idx
         self._axis = parent_mapping._axis
+
+    def _view_args(self) -> ElementRef:
+        return ElementRef(self._parent, self._axis, (self.attrname,))
 
 
 AxisArraysBase._view_class = AxisArraysView

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -16,7 +16,7 @@ from .views import _SetItemMixin, as_view
 from .access import ElementRef
 from .index import _subset
 from anndata.compat import AwkArray
-from anndata._warnings import ExperimentalFeatureWarning
+from anndata._warnings import ExperimentalFeatureWarning, ImplicitModificationWarning
 
 
 OneDIdx = Union[Sequence[int], Sequence[bool], slice]
@@ -126,7 +126,7 @@ class AlignedMapping(cabc.MutableMapping, ABC):
         return dict(self)
 
 
-class AlignedViewMixin(_SetItemMixin):
+class AlignedViewMixin:
     parent: "anndata.AnnData"
     """Reference to parent AnnData view"""
 
@@ -146,10 +146,25 @@ class AlignedViewMixin(_SetItemMixin):
 
     def __setitem__(self, key: str, value: V):
         value = self._validate_value(value, key)  # Validate before mutating
-        super().__setitem__(key, value)
+        warnings.warn(
+            f"Setting element `.{self.attrname}['{key}']` of view, "
+            "initializing view as actual.",
+            ImplicitModificationWarning,
+            stacklevel=2,
+        )
+        adata = self.parent.copy()
+        new_mapping = getattr(adata, self.attrname)
+        new_mapping[key] = value
+        self.parent._init_as_actual(adata)
 
     def __delitem__(self, key: str):
-        self[key]  # Make sure it exists before bothering with a copy
+        _ = key in self  # Make sure it exists before bothering with a copy
+        warnings.warn(
+            f"Removing element `.{self.attrname}['{key}']` of view, "
+            "initializing view as actual.",
+            ImplicitModificationWarning,
+            stacklevel=2,
+        )
         adata = self.parent.copy()
         new_mapping = getattr(adata, self.attrname)
         del new_mapping[key]
@@ -163,10 +178,6 @@ class AlignedViewMixin(_SetItemMixin):
 
     def __len__(self) -> int:
         return len(self.parent_mapping)
-
-    @property
-    def _view_args(self) -> ElementRef:
-        return ElementRef(self.parent, self.attrname)
 
 
 class AlignedActualMixin:

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -137,9 +137,11 @@ def test_set_obsm_key(adata, axis):
     orig_val = getattr(adata, axis)["o"].copy()
     subset = adata[:50] if axis == "obsm" else adata[:, :50]
     assert subset.is_view
-    getattr(subset, axis)["o"] = np.ones((50, 20))
+    with pytest.warns(ad.ImplicitModificationWarning):
+        getattr(subset, axis)["o"] = new_val = np.ones((50, 20))
     assert not subset.is_view
     assert np.all(getattr(adata, axis)["o"] == orig_val)
+    assert np.any(getattr(subset, axis)["o"] == new_val)
 
     assert init_hash == joblib.hash(adata)
 

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -130,30 +130,16 @@ def test_modify_view_component(matrix_type, mapping_name):
     assert init_hash == joblib.hash(adata)
 
 
-# TODO: These tests could probably be condensed into a fixture
-#       based test for obsm and varm
-def test_set_obsm_key(adata):
+@pytest.mark.parametrize("axis", ["obsm", "varm"])
+def test_set_obsm_key(adata, axis):
     init_hash = joblib.hash(adata)
 
-    orig_obsm_val = adata.obsm["o"].copy()
-    subset_obsm = adata[:50]
-    assert subset_obsm.is_view
-    subset_obsm.obsm["o"] = np.ones((50, 20))
-    assert not subset_obsm.is_view
-    assert np.all(adata.obsm["o"] == orig_obsm_val)
-
-    assert init_hash == joblib.hash(adata)
-
-
-def test_set_varm_key(adata):
-    init_hash = joblib.hash(adata)
-
-    orig_varm_val = adata.varm["o"].copy()
-    subset_varm = adata[:, :50]
-    assert subset_varm.is_view
-    subset_varm.varm["o"] = np.ones((50, 20))
-    assert not subset_varm.is_view
-    assert np.all(adata.varm["o"] == orig_varm_val)
+    orig_val = getattr(adata, axis)["o"].copy()
+    subset = adata[:50] if axis == "obsm" else adata[:, :50]
+    assert subset.is_view
+    getattr(subset, axis)["o"] = np.ones((50, 20))
+    assert not subset.is_view
+    assert np.all(getattr(adata, axis)["o"] == orig_val)
 
     assert init_hash == joblib.hash(adata)
 


### PR DESCRIPTION
Fixes https://github.com/scverse/anndata/issues/1011

Supersedes https://github.com/scverse/anndata/pull/1015

Alternative to #1015

* Adds a warning for `delitem` as well as `setitem`
* Doesn't subclass from views code
* Improved tests (check that the right element is mentioned.
* Improved warnings (now reports which element was changed)