### PR TITLE
Fix typo in release-notes.md

### DIFF
--- a/docs/release-notes/release-latest.md
+++ b/docs/release-notes/release-latest.md
@@ -4,7 +4,7 @@
 ```
 ## Version 0.9
 
-```{include}/release-notes/0.9.2.md
+```{include} /release-notes/0.9.2.md
 ```
 
 ```{include} /release-notes/0.9.1.md


### PR DESCRIPTION
Weirdly, only threw an error for the backport branch.