### PR TITLE
Fix for awkward 2.3

### DIFF
--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -255,7 +255,7 @@ try:
             array = self
             # makes a shallow copy and removes the reference to the original AnnData object
             array = ak.with_parameter(self, _PARAM_NAME, None)
-            array = ak.with_parameter(array, "__array__", None)
+            array = ak.with_parameter(array, "__list__", None)
             return array
 
     @as_view.register(AwkArray)
@@ -273,7 +273,7 @@ try:
                 "Please open an issue in the AnnData repo and describe your use-case."
             )
         array = ak.with_parameter(array, _PARAM_NAME, (parent_key, attrname, keys))
-        array = ak.with_parameter(array, "__array__", "AwkwardArrayView")
+        array = ak.with_parameter(array, "__list__", "AwkwardArrayView")
         return array
 
     ak.behavior["AwkwardArrayView"] = AwkwardArrayView

--- a/anndata/tests/test_awkward.py
+++ b/anndata/tests/test_awkward.py
@@ -147,8 +147,20 @@ def test_view(key):
 def test_view_of_awkward_array_with_custom_behavior():
     """Currently can't create view of arrays with custom __name__ (in this case "string")
     See https://github.com/scverse/anndata/pull/647#discussion_r963494798_"""
+
+    from uuid import uuid4
+
+    BEHAVIOUR_ID = str(uuid4())
+
+    class ReversibleArray(ak.Array):
+        def reversed(self):
+            return self[..., ::-1]
+
+    ak.behavior[BEHAVIOUR_ID] = ReversibleArray
     adata = gen_adata((3, 3), varm_types=(), obsm_types=(), layers_types=())
-    adata.obsm["awk_string"] = ak.Array(["AAA", "BBB", "CCC"])
+    adata.obsm["awk_string"] = ak.with_parameter(
+        ak.Array(["AAA", "BBB", "CCC"]), "__list__", BEHAVIOUR_ID
+    )
     adata_view = adata[:2]
 
     with pytest.raises(NotImplementedError):

--- a/docs/release-notes/0.9.2.md
+++ b/docs/release-notes/0.9.2.md
@@ -2,3 +2,5 @@
 
 ```{rubric} Bugfix
 ```
+
+* Views of `awkward.Array`s now work with `awkward>=2.3` {pr}`1040` {user}`ivirshup`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test = [
     "boltons",
     "scanpy",
     "dask[array]",
-    "awkward>=2.0.8,<2.3",
+    "awkward>=2.3",
     "pytest_memray",
 ]
 


### PR DESCRIPTION
TODO

- [x] Closes #1035 (or at least addresses it)
- [x] Tests ~~added~~ refactored
- [x] Release note added
- [x] Bump awkward array version or have backward compatibility
- [ ] Figure out right way to fix this, e.g. `with_parameter`, `with_name`