### PR TITLE
Use __notes__ for IO exceptions

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -62,6 +62,5 @@ __all__ = [
     "WriteWarning",
     "ImplicitModificationWarning",
     "ExperimentalFeatureWarning",
-    "read",
     "experimental",
 ]

--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -12,6 +12,12 @@ except (ImportError, LookupError):
             "anndata is not correctly installed. Please install it, e.g. with pip."
         )
 
+# Allowing notes to be added to exceptions. See: https://github.com/scverse/anndata/issues/868
+import sys
+
+if sys.version_info < (3, 11):
+    import exceptiongroup
+
 from ._core.anndata import AnnData
 from ._core.merge import concat
 from ._core.raw import Raw
@@ -35,3 +41,23 @@ from ._warnings import (
 
 # backwards compat / shortcut for default format
 from ._io import read_h5ad as read
+
+__all__ = [
+    "__version__",
+    "AnnData",
+    "concat",
+    "read_h5ad",
+    "read_loom",
+    "read_hdf",
+    "read_excel",
+    "read_umi_tools",
+    "read_csv",
+    "read_text",
+    "read_mtx",
+    "read_zarr",
+    "OldFormatWarning",
+    "WriteWarning",
+    "ImplicitModificationWarning",
+    "ExperimentalFeatureWarning",
+    "read",
+]

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -256,7 +256,7 @@ def read_anndata(elem, _reader):
 @_REGISTRY.register_write(H5Group, Raw, IOSpec("raw", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, Raw, IOSpec("raw", "0.1.0"))
 def write_raw(f, k, raw, _writer, dataset_kwargs=MappingProxyType({})):
-    g = f.create_group(k)
+    g = f.require_group(k)
     _writer.write_elem(g, "X", raw.X, dataset_kwargs=dataset_kwargs)
     _writer.write_elem(g, "var", raw.var, dataset_kwargs=dataset_kwargs)
     _writer.write_elem(g, "varm", dict(raw.varm), dataset_kwargs=dataset_kwargs)
@@ -276,7 +276,7 @@ def read_mapping(elem, _reader):
 @_REGISTRY.register_write(H5Group, dict, IOSpec("dict", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, dict, IOSpec("dict", "0.1.0"))
 def write_mapping(f, k, v, _writer, dataset_kwargs=MappingProxyType({})):
-    g = f.create_group(k)
+    g = f.require_group(k)
     for sub_k, sub_v in v.items():
         _writer.write_elem(g, sub_k, sub_v, dataset_kwargs=dataset_kwargs)
 
@@ -436,7 +436,7 @@ def write_sparse_compressed(
     fmt: Literal["csr", "csc"],
     dataset_kwargs=MappingProxyType({}),
 ):
-    g = f.create_group(key)
+    g = f.require_group(key)
     g.attrs["shape"] = value.shape
 
     # Allow resizing for hdf5
@@ -524,7 +524,7 @@ def read_sparse_partial(elem, *, items=None, indices=(slice(None), slice(None)))
 def write_awkward(f, k, v, _writer, dataset_kwargs=MappingProxyType({})):
     from anndata.compat import awkward as ak
 
-    group = f.create_group(k)
+    group = f.require_group(k)
     form, length, container = ak.to_buffers(ak.to_packed(v))
     group.attrs["length"] = length
     group.attrs["form"] = form.to_json()
@@ -558,7 +558,7 @@ def write_dataframe(f, key, df, _writer, dataset_kwargs=MappingProxyType({})):
     for reserved in ("_index",):
         if reserved in df.columns:
             raise ValueError(f"{reserved!r} is a reserved name for dataframe columns.")
-    group = f.create_group(key)
+    group = f.require_group(key)
     col_names = [check_key(c) for c in df.columns]
     group.attrs["column-order"] = col_names
 
@@ -677,7 +677,7 @@ def read_partial_dataframe_0_1_0(
 @_REGISTRY.register_write(H5Group, pd.Categorical, IOSpec("categorical", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, pd.Categorical, IOSpec("categorical", "0.2.0"))
 def write_categorical(f, k, v, _writer, dataset_kwargs=MappingProxyType({})):
-    g = f.create_group(k)
+    g = f.require_group(k)
     g.attrs["ordered"] = bool(v.ordered)
 
     _writer.write_elem(g, "codes", v.codes, dataset_kwargs=dataset_kwargs)
@@ -724,7 +724,7 @@ def read_partial_categorical(elem, *, items=None, indices=(slice(None),)):
     ZarrGroup, pd.arrays.BooleanArray, IOSpec("nullable-boolean", "0.1.0")
 )
 def write_nullable_integer(f, k, v, _writer, dataset_kwargs=MappingProxyType({})):
-    g = f.create_group(k)
+    g = f.require_group(k)
     if v._mask is not None:
         _writer.write_elem(g, "mask", v._mask, dataset_kwargs=dataset_kwargs)
     _writer.write_elem(g, "values", v._data, dataset_kwargs=dataset_kwargs)

--- a/anndata/_io/utils.py
+++ b/anndata/_io/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import wraps, singledispatch
-from typing import Callable
+from typing import Callable, Literal
 from warnings import warn
 
 from packaging import version
@@ -165,6 +165,22 @@ def _get_parent(elem):
     return parent
 
 
+def re_raise_error(e, elem, key, op=Literal["read", "writ"]):
+    if any(
+        f"Above error raised while {op}ing key" in note
+        for note in getattr(e, "__notes__", [])
+    ):
+        raise
+    else:
+        parent = _get_parent(elem)
+        add_note(
+            e,
+            f"Above error raised while {op}ing key {key!r} of {type(elem)} to "
+            f"{parent}",
+        )
+        raise e
+
+
 def report_read_key_on_error(func):
     """\
     A decorator for zarr element reading which makes keys involved in errors get reported.
@@ -180,16 +196,6 @@ def report_read_key_on_error(func):
     >>> read_arr(z["X"])  # doctest: +SKIP
     """
 
-    def re_raise_error(e, elem):
-        if isinstance(e, AnnDataReadError):
-            raise e
-        else:
-            parent = _get_parent(elem)
-            raise AnnDataReadError(
-                f"Above error raised while reading key {elem.name!r} of "
-                f"type {type(elem)} from {parent}."
-            ) from e
-
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         from anndata._io.specs import Reader
@@ -201,7 +207,7 @@ def report_read_key_on_error(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            re_raise_error(e, elem)
+            re_raise_error(e, elem, elem.name, "read")
 
     return func_wrapper
 
@@ -221,18 +227,6 @@ def report_write_key_on_error(func):
     >>> write_arr(z, "X", X)  # doctest: +SKIP
     """
 
-    def re_raise_error(e, elem, key):
-        if "Above error raised while writing key" in format(e):
-            raise
-        else:
-            parent = _get_parent(elem)
-            add_note(
-                e,
-                f"Above error raised while writing key {key!r} of {type(elem)} to "
-                f"{parent}",
-            )
-            raise e
-
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         from anndata._io.specs import Writer
@@ -246,7 +240,7 @@ def report_write_key_on_error(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            re_raise_error(e, elem, key)
+            re_raise_error(e, elem, key, "writ")
 
     return func_wrapper
 

--- a/anndata/_io/utils.py
+++ b/anndata/_io/utils.py
@@ -167,7 +167,7 @@ def _get_parent(elem):
 
 def re_raise_error(e, elem, key, op=Literal["read", "writ"]):
     if any(
-        f"Above error raised while {op}ing key" in note
+        f"Error raised while {op}ing key" in note
         for note in getattr(e, "__notes__", [])
     ):
         raise
@@ -175,8 +175,7 @@ def re_raise_error(e, elem, key, op=Literal["read", "writ"]):
         parent = _get_parent(elem)
         add_note(
             e,
-            f"Above error raised while {op}ing key {key!r} of {type(elem)} to "
-            f"{parent}",
+            f"Error raised while {op}ing key {key!r} of {type(elem)} to " f"{parent}",
         )
         raise e
 

--- a/anndata/_io/utils.py
+++ b/anndata/_io/utils.py
@@ -9,7 +9,7 @@ from packaging import version
 import h5py
 
 from .._core.sparse_dataset import SparseDataset
-from anndata.compat import H5Group, ZarrGroup
+from anndata.compat import H5Group, ZarrGroup, add_note
 
 # For allowing h5py v3
 # https://github.com/scverse/anndata/issues/442
@@ -226,11 +226,12 @@ def report_write_key_on_error(func):
             raise
         else:
             parent = _get_parent(elem)
-            raise type(e)(
-                f"{e}\n\n"
-                f"Above error raised while writing key {key!r} of {type(elem)} "
-                f"to {parent}"
-            ) from e
+            add_note(
+                e,
+                f"Above error raised while writing key {key!r} of {type(elem)} to "
+                f"{parent}",
+            )
+            raise e
 
     @wraps(func)
     def func_wrapper(*args, **kwargs):

--- a/anndata/compat/__init__.py
+++ b/anndata/compat/__init__.py
@@ -12,6 +12,8 @@ from scipy.sparse import spmatrix
 import numpy as np
 import pandas as pd
 
+from .exceptiongroups import add_note
+
 
 class Empty:
     pass

--- a/anndata/compat/exceptiongroups.py
+++ b/anndata/compat/exceptiongroups.py
@@ -1,0 +1,8 @@
+import sys
+
+
+def add_note(err: BaseException, msg: str) -> None:
+    if sys.version_info < (3, 11):
+        err.__notes__ = getattr(err, "__notes__", []) + [msg]
+    else:
+        err.add_note(msg)

--- a/anndata/compat/exceptiongroups.py
+++ b/anndata/compat/exceptiongroups.py
@@ -1,8 +1,12 @@
 import sys
 
 
-def add_note(err: BaseException, msg: str) -> None:
+def add_note(err: BaseException, msg: str) -> BaseException:
+    """
+    Adds a note to an exception inplace and returns it.
+    """
     if sys.version_info < (3, 11):
         err.__notes__ = getattr(err, "__notes__", []) + [msg]
     else:
         err.add_note(msg)
+    return err

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -588,4 +588,6 @@ def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str):
     import traceback
 
     message = "".join(traceback.format_exception_only(e.type, e.value))
-    assert re.search(pattern, message)
+    assert re.search(
+        pattern, message
+    ), f"Could not find pattern: '{pattern}' in error:\n\n{message}\n"

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -579,7 +579,7 @@ def _(a):
     return as_dense_dask_array(a.toarray())
 
 
-def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str):
+def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str | re.Pattern):
     """
     Checks whether the printed error message or the notes contains the given pattern.
 

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -1,4 +1,5 @@
 from functools import singledispatch, wraps
+import re
 from string import ascii_letters
 from typing import Tuple, Optional, Type
 from collections.abc import Mapping, Collection
@@ -576,3 +577,15 @@ def as_dense_dask_array(a):
 @as_dense_dask_array.register(sparse.spmatrix)
 def _(a):
     return as_dense_dask_array(a.toarray())
+
+
+def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str):
+    """
+    Checks whether the printed error message or the notes contains the given pattern.
+
+    DOES NOT WORK IN IPYTHON - because of the way IPython handles exceptions
+    """
+    import traceback
+
+    message = "".join(traceback.format_exception_only(e.type, e.value))
+    assert re.search(pattern, message)

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from functools import singledispatch, wraps, partial
 import re
 from string import ascii_letters
@@ -602,6 +603,25 @@ def as_dense_dask_array(a):
 @as_dense_dask_array.register(sparse.spmatrix)
 def _(a):
     return as_dense_dask_array(a.toarray())
+
+
+@contextmanager
+def pytest_8_raises(exc_cls, *, match: str | re.Pattern):
+    """Error handling using pytest 8's support for __notes__.
+
+    See: https://github.com/pytest-dev/pytest/pull/11227
+
+    Remove once pytest 8 is out!
+    """
+    import traceback
+
+    with pytest.raises(exc_cls) as exc_info:
+        yield
+
+    message = "".join(traceback.format_exception_only(exc_info.type, exc_info.value))
+    assert re.search(
+        match, message
+    ), f"Could not find pattern: '{match}' in error:\n\n{message}\n"
 
 
 def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str | re.Pattern):

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -606,22 +606,18 @@ def _(a):
 
 
 @contextmanager
-def pytest_8_raises(exc_cls, *, match: str | re.Pattern):
+def pytest_8_raises(exc_cls, *, match: str | re.Pattern = None):
     """Error handling using pytest 8's support for __notes__.
 
     See: https://github.com/pytest-dev/pytest/pull/11227
 
     Remove once pytest 8 is out!
     """
-    import traceback
 
     with pytest.raises(exc_cls) as exc_info:
-        yield
+        yield exc_info
 
-    message = "".join(traceback.format_exception_only(exc_info.type, exc_info.value))
-    assert re.search(
-        match, message
-    ), f"Could not find pattern: '{match}' in error:\n\n{message}\n"
+    check_error_or_notes_match(exc_info, match)
 
 
 def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str | re.Pattern):

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import singledispatch, wraps
 import re
 from string import ascii_letters

--- a/anndata/tests/test_helpers.py
+++ b/anndata/tests/test_helpers.py
@@ -12,8 +12,10 @@ from anndata.tests.helpers import (
     report_name,
     gen_adata,
     asarray,
+    check_error_or_notes_match,
 )
 from anndata.utils import dim_len
+from anndata.compat import add_note
 
 # Testing to see if all error types can have the key name appended.
 # Currently fails for 22/118 since they have required arguments. Not sure what to do about that.
@@ -246,3 +248,32 @@ def test_assert_equal_dask_sparse_arrays():
 
     assert_equal(x, y)
     assert_equal(y, x)
+
+
+@pytest.mark.parametrize(
+    "error, match",
+    [
+        (Exception("test"), "test"),
+        (add_note(AssertionError("foo"), "bar"), "bar"),
+        (add_note(add_note(AssertionError("foo"), "bar"), "baz"), "bar"),
+        (add_note(add_note(AssertionError("foo"), "bar"), "baz"), "baz"),
+    ],
+)
+def test_check_error_notes_success(error, match):
+    with pytest.raises(Exception) as exc_info:
+        raise error
+    check_error_or_notes_match(exc_info, match)
+
+
+@pytest.mark.parametrize(
+    "error, match",
+    [
+        (Exception("test"), "foo"),
+        (add_note(AssertionError("foo"), "bar"), "baz"),
+    ],
+)
+def test_check_error_notes_failure(error, match):
+    with pytest.raises(Exception) as exc_info:
+        raise error
+    with pytest.raises(AssertionError):
+        check_error_or_notes_match(exc_info, match)

--- a/anndata/tests/test_helpers.py
+++ b/anndata/tests/test_helpers.py
@@ -12,7 +12,7 @@ from anndata.tests.helpers import (
     report_name,
     gen_adata,
     asarray,
-    check_error_or_notes_match,
+    pytest_8_raises,
 )
 from anndata.utils import dim_len
 from anndata.compat import add_note
@@ -260,9 +260,8 @@ def test_assert_equal_dask_sparse_arrays():
     ],
 )
 def test_check_error_notes_success(error, match):
-    with pytest.raises(Exception) as exc_info:
+    with pytest_8_raises(Exception, match=match):
         raise error
-    check_error_or_notes_match(exc_info, match)
 
 
 @pytest.mark.parametrize(
@@ -273,7 +272,6 @@ def test_check_error_notes_success(error, match):
     ],
 )
 def test_check_error_notes_failure(error, match):
-    with pytest.raises(Exception) as exc_info:
-        raise error
     with pytest.raises(AssertionError):
-        check_error_or_notes_match(exc_info, match)
+        with pytest_8_raises(Exception, match=match):
+            raise error

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -129,11 +129,9 @@ def test_read_iospec_not_found(store, attribute, value):
     write_elem(store, "/", adata)
     store["obs"].attrs.update({attribute: value})
 
-    with pytest.raises(
-        AnnDataReadError, match=r"while reading key '/(obs)?'"
-    ) as exc_info:
+    with pytest.raises(IORegistryError) as exc_info:
         read_elem(store)
-    msg = str(exc_info.value.__cause__)
+    msg = str(exc_info.value)
 
     assert "No read method registered for IOSpec" in msg
     assert f"{attribute.replace('-', '_')}='{value}'" in msg

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -17,7 +17,7 @@ from anndata._io.specs.registry import IORegistryError, _REGISTRY, get_spec, IOS
 from anndata._io.utils import AnnDataReadError
 from anndata.compat import _read_attr, H5Group, ZarrGroup
 from anndata._io.specs import write_elem, read_elem
-from anndata.tests.helpers import assert_equal, gen_adata
+from anndata.tests.helpers import assert_equal, gen_adata, check_error_or_notes_match
 
 
 @pytest.fixture(params=["h5ad", "zarr"])
@@ -147,9 +147,13 @@ def test_write_io_error(store, obj):
     full_pattern = re.compile(
         rf"No method registered for writing {type(obj)} into .*Group"
     )
-    with pytest.raises(IORegistryError, match=r"while writing key '/el'") as exc_info:
+
+    with pytest.raises(IORegistryError) as exc_info:
         write_elem(store, "/el", obj)
-    msg = str(exc_info.value.__cause__)
+
+    msg = str(exc_info.value)
+    check_error_or_notes_match(exc_info, r"while writing key '/el'")
+
     assert re.search(full_pattern, msg)
 
 

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -20,7 +20,7 @@ from anndata._io.specs import write_elem, read_elem
 from anndata.tests.helpers import (
     assert_equal,
     as_cupy_type,
-    check_error_or_notes_match,
+    pytest_8_raises,
     gen_adata,
 )
 
@@ -178,12 +178,10 @@ def test_write_io_error(store, obj):
         rf"No method registered for writing {type(obj)} into .*Group"
     )
 
-    with pytest.raises(IORegistryError) as exc_info:
+    with pytest_8_raises(IORegistryError, match=r"while writing key '/el'") as exc_info:
         write_elem(store, "/el", obj)
 
     msg = str(exc_info.value)
-    check_error_or_notes_match(exc_info, r"while writing key '/el'")
-
     assert re.search(full_pattern, msg)
 
 

--- a/anndata/tests/test_io_utils.py
+++ b/anndata/tests/test_io_utils.py
@@ -10,7 +10,6 @@ from anndata._io.specs.registry import IORegistryError
 from anndata.compat import _clean_uns
 from anndata._io.utils import (
     report_read_key_on_error,
-    AnnDataReadError,
 )
 from anndata.experimental import read_elem, write_elem
 from anndata.tests.helpers import check_error_or_notes_match

--- a/anndata/tests/test_io_utils.py
+++ b/anndata/tests/test_io_utils.py
@@ -12,6 +12,7 @@ from anndata._io.utils import (
     report_read_key_on_error,
     AnnDataReadError,
 )
+from anndata.tests.helpers import check_error_or_notes_match
 
 
 @pytest.fixture(params=["h5ad", "zarr"])
@@ -50,10 +51,10 @@ def test_write_error_info(diskfmt, tmp_path):
     # Assuming we don't define a writer for tuples
     a = ad.AnnData(uns={"a": {"b": {"c": (1, 2, 3)}}})
 
-    with pytest.raises(
-        IORegistryError, match=r"Above error raised while writing key 'c'"
-    ):
+    with pytest.raises(IORegistryError) as exc_info:
         write(a)
+
+    check_error_or_notes_match(exc_info, r"Above error raised while writing key 'c'")
 
 
 def test_clean_uns():

--- a/anndata/tests/test_io_utils.py
+++ b/anndata/tests/test_io_utils.py
@@ -36,12 +36,16 @@ def test_key_error(tmp_path, group_fn):
     with group if hasattr(group, "__enter__") else suppress():
         group["X"] = [1, 2, 3]
         group.create_group("group")
-        with pytest.raises(AnnDataReadError) as e:
+
+        with pytest.raises(NotImplementedError) as exc_info:
             read_attr(group["X"])
-        assert "'/X'" in str(e.value)
-        with pytest.raises(AnnDataReadError) as e:
+
+        check_error_or_notes_match(exc_info, r"/X")
+
+        with pytest.raises(NotImplementedError) as exc_info:
             read_attr(group["group"])
-        assert "'/group'" in str(e.value)
+
+        check_error_or_notes_match(exc_info, r"/group")
 
 
 def test_write_error_info(diskfmt, tmp_path):

--- a/anndata/tests/test_io_utils.py
+++ b/anndata/tests/test_io_utils.py
@@ -59,7 +59,7 @@ def test_write_error_info(diskfmt, tmp_path):
     with pytest.raises(IORegistryError) as exc_info:
         write(a)
 
-    check_error_or_notes_match(exc_info, r"Above error raised while writing key 'c'")
+    check_error_or_notes_match(exc_info, r"Error raised while writing key 'c'")
 
 
 def test_clean_uns():
@@ -94,9 +94,7 @@ def test_only_child_key_reported_on_failure(tmp_path, group_fn):
         write_elem(group, "/", {"a": {"b": Foo()}})
 
     with pytest.raises(AssertionError):
-        check_error_or_notes_match(
-            exc_info, r"Above error raised while writing key '/?a'"
-        )
+        check_error_or_notes_match(exc_info, r"Error raised while writing key '/?a'")
 
     write_elem(group, "/", {"a": {"b": [1, 2, 3]}})
     group["a/b"].attrs["encoding-type"] = "not a real encoding type"
@@ -105,6 +103,4 @@ def test_only_child_key_reported_on_failure(tmp_path, group_fn):
         read_elem(group)
 
     with pytest.raises(AssertionError):
-        check_error_or_notes_match(
-            exc_info, r"Above error raised while reading key '/?a'"
-        )
+        check_error_or_notes_match(exc_info, r"Error raised while reading key '/?a'")

--- a/anndata/tests/test_io_utils.py
+++ b/anndata/tests/test_io_utils.py
@@ -12,7 +12,7 @@ from anndata._io.utils import (
     report_read_key_on_error,
 )
 from anndata.experimental import read_elem, write_elem
-from anndata.tests.helpers import check_error_or_notes_match
+from anndata.tests.helpers import pytest_8_raises
 
 
 @pytest.fixture(params=["h5ad", "zarr"])
@@ -37,15 +37,11 @@ def test_key_error(tmp_path, group_fn):
         group["X"] = [1, 2, 3]
         group.create_group("group")
 
-        with pytest.raises(NotImplementedError) as exc_info:
+        with pytest_8_raises(NotImplementedError, match=r"/X"):
             read_attr(group["X"])
 
-        check_error_or_notes_match(exc_info, r"/X")
-
-        with pytest.raises(NotImplementedError) as exc_info:
+        with pytest_8_raises(NotImplementedError, match=r"/group"):
             read_attr(group["group"])
-
-        check_error_or_notes_match(exc_info, r"/group")
 
 
 def test_write_error_info(diskfmt, tmp_path):
@@ -55,10 +51,8 @@ def test_write_error_info(diskfmt, tmp_path):
     # Assuming we don't define a writer for tuples
     a = ad.AnnData(uns={"a": {"b": {"c": (1, 2, 3)}}})
 
-    with pytest.raises(IORegistryError) as exc_info:
+    with pytest_8_raises(IORegistryError, match=r"Error raised while writing key 'c'"):
         write(a)
-
-    check_error_or_notes_match(exc_info, r"Error raised while writing key 'c'")
 
 
 def test_clean_uns():
@@ -89,17 +83,17 @@ def test_only_child_key_reported_on_failure(tmp_path, group_fn):
 
     group = group_fn(tmp_path)
 
-    with pytest.raises(IORegistryError) as exc_info:
-        write_elem(group, "/", {"a": {"b": Foo()}})
+    # This regex checks that the pattern inside the (?!...) group does not exist in the string
+    # (?!...) is a negative lookahead
+    # (?s) enables the dot to match newlines
+    # https://stackoverflow.com/a/406408/130164 <- copilot suggested lol
+    pattern = r"(?s)((?!Error raised while writing key '/?a').)*$"
 
-    with pytest.raises(AssertionError):
-        check_error_or_notes_match(exc_info, r"Error raised while writing key '/?a'")
+    with pytest_8_raises(IORegistryError, match=pattern):
+        write_elem(group, "/", {"a": {"b": Foo()}})
 
     write_elem(group, "/", {"a": {"b": [1, 2, 3]}})
     group["a/b"].attrs["encoding-type"] = "not a real encoding type"
 
-    with pytest.raises(IORegistryError) as exc_info:
+    with pytest_8_raises(IORegistryError, match=pattern):
         read_elem(group)
-
-    with pytest.raises(AssertionError):
-        check_error_or_notes_match(exc_info, r"Error raised while reading key '/?a'")

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -303,13 +303,11 @@ def test_read_full_io_error(tmp_path, name, read, write):
     with store_context(path) as store:
         store["obs"].attrs["encoding-type"] = "invalid"
     with pytest.raises(
-        AnnDataReadError, match=r"raised while reading key '/obs'"
+        IORegistryError,
+        match=r"No read method registered for IOSpec\(encoding_type='invalid', encoding_version='0.2.0'\)",
     ) as exc_info:
         read(path)
-    assert re.search(
-        r"No read method registered for IOSpec\(encoding_type='invalid', encoding_version='0.2.0'\)",
-        str(exc_info.value.__cause__),
-    )
+    check_error_or_notes_match(exc_info, r"raised while reading key '/obs'")
 
 
 @pytest.mark.parametrize(

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -7,6 +7,7 @@
 
 * Improved error messages when combining dataframes with duplicated column names {pr}`1029` {user}`ivirshup`
 * Improved warnings when modifying views of `AlingedMappings` {pr}`1016` {user}`flying-sheep` {user}`ivirshup`
+* `AnnDataReadError`s have been removed. The original error is now thrown with additional information in a note {pr}`1055` {user}`ivirshup`
 
 
 ```{rubric} Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "numpy>=1.16.5",  # required by pandas 1.x
     "scipy>1.4",
     "h5py>=3",
+    "exceptiongroup; python_version<'3.11'",
     "natsort",
     "packaging>=20",
 ]


### PR DESCRIPTION
- [x] Closes #868
- [x] Tests added
- [x] Release note added (or unnecessary)

**TODO**

- [x] Read errors as well
- [x] Check that we're not also adding notes for parent elements
- [x] Test change from `create_group` to `requires_group` (bug where `write_elem(f, "/", x)` only actually worked for `AnnData`)