### PR TITLE
Fix `read_zarr` for consolidated metadata and use directly on zarr.Group

### DIFF
--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -62,7 +62,10 @@ def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]) -> AnnData:
     if isinstance(store, Path):
         store = str(store)
 
-    f = zarr.open(store, mode="r")
+    if isinstance(store, zarr.Group):
+        f = store
+    else:
+        f = zarr.open(store, mode="r")
 
     # Read with handling for backwards compat
     def callback(func, elem_name: str, elem, iospec):

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -200,4 +200,4 @@ def test_read_zarr_from_group(tmp_path, consolidated):
         read_func = zarr.open
 
     with read_func(pth) as z:
-        assert_equal(read_elem(z["table/table"]), adata)
+        assert_equal(ad.read_zarr(z["table/table"]), adata)

--- a/docs/release-notes/0.9.2.md
+++ b/docs/release-notes/0.9.2.md
@@ -5,3 +5,4 @@
 
 * Fix ufuncs of views like `adata.X[:10].cov(axis=0)` returning views {pr}`1043` {user}`flying-sheep`
 * Fix instantiating AnnData where `.X` is a `DataFrame` with an integer valued index  {pr}`1002` {user}`flying-sheep`
+* Fix {func}`~anndata.read_zarr` when used on `zarr.Group` {pr}`1057` {user}`ivirshup`


### PR DESCRIPTION
- [x] Closes #1056
- [x] Tests added
- [x] Release note added (or unnecessary)
