### PR TITLE
`.raw` copys from VRAM to RAM

### DIFF
--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -5,11 +5,23 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 from scipy.sparse import issparse
+from enum import Enum
 
 from . import anndata
 from .index import _normalize_index, _subset, unpack_index, get_vector
 from .aligned_mapping import AxisArrays, AxisArraysView
 from .sparse_dataset import SparseDataset
+
+from ..compat import CupyArray, CupySparseMatrix
+
+
+class CPType(Enum):
+    CupyArray = CupyArray
+    CupySparseMatrix = CupySparseMatrix
+
+    @classmethod
+    def classes(cls):
+        return tuple(c.value for c in cls.__members__.values())
 
 
 # TODO: Implement views for Raw
@@ -31,7 +43,10 @@ class Raw:
             self._var = _gen_dataframe(var, self.X.shape[1], ["var_names"])
             self._varm = AxisArrays(self, 1, varm)
         elif X is None:  # construct from adata
-            self._X = adata.X.copy()
+            if isinstance(adata.X, CPType.classes()):
+                self._X = adata.X.get()
+            else:
+                self._X = adata.X.copy()
             self._var = adata.var.copy()
             self._varm = AxisArrays(self, 1, adata.varm.copy())
         elif adata.isbacked:

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 from scipy.sparse import issparse
-from enum import Enum
 
 from . import anndata
 from .index import _normalize_index, _subset, unpack_index, get_vector

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -15,7 +15,6 @@ from .sparse_dataset import SparseDataset
 from ..compat import CupyArray, CupySparseMatrix
 
 
-
 # TODO: Implement views for Raw
 class Raw:
     def __init__(

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -15,14 +15,6 @@ from .sparse_dataset import SparseDataset
 from ..compat import CupyArray, CupySparseMatrix
 
 
-class CPType(Enum):
-    CupyArray = CupyArray
-    CupySparseMatrix = CupySparseMatrix
-
-    @classmethod
-    def classes(cls):
-        return tuple(c.value for c in cls.__members__.values())
-
 
 # TODO: Implement views for Raw
 class Raw:

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -35,7 +35,8 @@ class Raw:
             self._var = _gen_dataframe(var, self.X.shape[1], ["var_names"])
             self._varm = AxisArrays(self, 1, varm)
         elif X is None:  # construct from adata
-            if isinstance(adata.X, CPType.classes()):
+            # Move from GPU to CPU since it's large and not always used
+            if isinstance(adata.X, (CupyArray, CupySparseMatrix)):
                 self._X = adata.X.get()
             else:
                 self._X = adata.X.copy()


### PR DESCRIPTION
Moves `.X` for `.raw` from GPU to RAM. This will save a lot of VRAM