### PR TITLE
Dask Distributed Write Fix For Zarr

### DIFF
--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -343,12 +343,27 @@ _REGISTRY.register_write(ZarrGroup, CupyArray, IOSpec("array", "0.2.0"))(
 
 
 @_REGISTRY.register_write(ZarrGroup, DaskArray, IOSpec("array", "0.2.0"))
-@_REGISTRY.register_write(H5Group, DaskArray, IOSpec("array", "0.2.0"))
-def write_basic_dask(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
+def write_basic_dask_zarr(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
     import dask.array as da
 
     g = f.require_dataset(k, shape=elem.shape, dtype=elem.dtype, **dataset_kwargs)
     da.store(elem, g, lock=GLOBAL_LOCK)
+
+
+# Adding this seperately because h5py isn't serializable
+# https://github.com/pydata/xarray/issues/4242
+@_REGISTRY.register_write(H5Group, DaskArray, IOSpec("array", "0.2.0"))
+def write_basic_dask_h5(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
+    import dask.array as da
+    import dask.config as dc
+
+    if dc.get("scheduler", None) == "dask.distributed":
+        raise ValueError(
+            "Cannot write dask arrays to hdf5 when using distributed scheduler"
+        )
+
+    g = f.require_dataset(k, shape=elem.shape, dtype=elem.dtype, **dataset_kwargs)
+    da.store(elem, g)
 
 
 @_REGISTRY.register_read(H5Array, IOSpec("array", "0.2.0"))

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -45,6 +45,18 @@ H5File = h5py.File
 
 
 ####################
+# Dask utils       #
+####################
+
+try:
+    from dask.utils import SerializableLock as Lock
+except ImportError:
+    from threading import Lock
+
+# to fix https://github.com/dask/distributed/issues/780
+GLOBAL_LOCK = Lock()
+
+####################
 # Dispatch methods #
 ####################
 
@@ -314,7 +326,7 @@ def write_basic_dask(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
     import dask.array as da
 
     g = f.require_dataset(k, shape=elem.shape, dtype=elem.dtype, **dataset_kwargs)
-    da.store(elem, g)
+    da.store(elem, g, lock=GLOBAL_LOCK)
 
 
 @_REGISTRY.register_read(H5Array, IOSpec("array", "0.2.0"))

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -96,10 +96,12 @@ def test_dask_write(adata, tmp_path, diskfmt):
     assert isinstance(orig.varm["a"], DaskArray)
 
 
+@pytest.mark.dependency(depends=[""])
 def test_dask_distributed_write(adata, tmp_path, diskfmt):
     import dask.array as da
     import numpy as np
-    import dask.distributed as dd
+
+    dd = pytest.importorskip("dask.distributed")
 
     pth = tmp_path / f"test_write.{diskfmt}"
     g = as_group(pth, mode="w")

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -96,7 +96,6 @@ def test_dask_write(adata, tmp_path, diskfmt):
     assert isinstance(orig.varm["a"], DaskArray)
 
 
-@pytest.mark.needs("dask.distributed")
 def test_dask_distributed_write(adata, tmp_path, diskfmt):
     import dask.array as da
     import dask.distributed as dd

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -111,6 +111,12 @@ def test_dask_distributed_write(adata, tmp_path, diskfmt):
             adata.obsm["b"] = da.random.random((M, 10))
             adata.varm["a"] = da.random.random((N, 10))
             orig = adata
+            if diskfmt == "h5ad":
+                with pytest.raises(
+                    ValueError, match="Cannot write dask arrays to hdf5"
+                ):
+                    write_elem(g, "", orig)
+                return
             write_elem(g, "", orig)
             curr = read_elem(g)
 

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -96,7 +96,6 @@ def test_dask_write(adata, tmp_path, diskfmt):
     assert isinstance(orig.varm["a"], DaskArray)
 
 
-@pytest.mark.dependency(depends=[""])
 def test_dask_distributed_write(adata, tmp_path, diskfmt):
     import dask.array as da
     import numpy as np

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -11,6 +11,8 @@ from anndata.tests.helpers import (
     gen_adata,
     assert_equal,
 )
+from anndata.experimental import write_elem, read_elem
+from anndata.experimental.merge import as_group
 from anndata.compat import DaskArray
 
 pytest.importorskip("dask.array")
@@ -79,6 +81,38 @@ def test_dask_write(adata, tmp_path, diskfmt):
     orig = adata
     write(orig, pth)
     curr = read(pth)
+
+    with pytest.raises(Exception):
+        assert_equal(curr.obsm["a"], curr.obsm["b"])
+
+    assert_equal(curr.varm["a"], orig.varm["a"])
+    assert_equal(curr.obsm["a"], orig.obsm["a"])
+
+    assert isinstance(curr.X, np.ndarray)
+    assert isinstance(curr.obsm["a"], np.ndarray)
+    assert isinstance(curr.varm["a"], np.ndarray)
+    assert isinstance(orig.X, DaskArray)
+    assert isinstance(orig.obsm["a"], DaskArray)
+    assert isinstance(orig.varm["a"], DaskArray)
+
+
+def test_dask_distributed_write(adata, tmp_path, diskfmt):
+    import dask.array as da
+    import numpy as np
+    import dask.distributed as dd
+
+    pth = tmp_path / f"test_write.{diskfmt}"
+    g = as_group(pth, mode="w")
+
+    with dd.LocalCluster(n_workers=1, threads_per_worker=1, processes=False) as cluster:
+        with dd.Client(cluster):
+            M, N = adata.X.shape
+            adata.obsm["a"] = da.random.random((M, 10))
+            adata.obsm["b"] = da.random.random((M, 10))
+            adata.varm["a"] = da.random.random((N, 10))
+            orig = adata
+            write_elem(g, "", orig)
+            curr = read_elem(g)
 
     with pytest.raises(Exception):
         assert_equal(curr.obsm["a"], curr.obsm["b"])

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -96,11 +96,11 @@ def test_dask_write(adata, tmp_path, diskfmt):
     assert isinstance(orig.varm["a"], DaskArray)
 
 
+@pytest.mark.needs("dask.distributed")
 def test_dask_distributed_write(adata, tmp_path, diskfmt):
     import dask.array as da
+    import dask.distributed as dd
     import numpy as np
-
-    dd = pytest.importorskip("dask.distributed")
 
     pth = tmp_path / f"test_write.{diskfmt}"
     g = as_group(pth, mode="w")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ test = [
     "boltons",
     "scanpy",
     "dask[array]",
+    "dask[distributed]",
     "awkward>=2.3",
     "pytest_memray",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,7 @@ test = [
     "joblib",
     "boltons",
     "scanpy",
-    "dask[array]",
-    "dask[distributed]",
+    "dask[array,distributed]",
     "awkward>=2.3",
     "pytest_memray",
 ]


### PR DESCRIPTION
Hi,
This issue appears when one tries to use dask distributed then write https://github.com/dask/distributed/issues/780.
I did what xarray does for this https://github.com/pydata/xarray/pull/1179/files.

Not sure why the lock is global though for now.

Ping @ivirshup @flying-sheep 