### PR TITLE
Fix mandatory GPU tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- Please:
+1. Fill in the following check boxes
+2. Make sure checks pass (Ignore “Triage” ones)
+-->
+
 - [ ] Closes #
 - [ ] Tests added
 - [ ] Release note added (or unnecessary)

--- a/.github/workflows/check-pr-milestoned.yml
+++ b/.github/workflows/check-pr-milestoned.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   check-milestone:
-    name: 'Triage: Check Milestone'
+    name: "Triage: Check Milestone"
     runs-on: ubuntu-latest
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false

--- a/.github/workflows/check-pr-milestoned.yml
+++ b/.github/workflows/check-pr-milestoned.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   check-milestone:
-    name: Check Milestone
+    name: 'Triage: Check Milestone'
     runs-on: ubuntu-latest
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -15,7 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# There are two jobs:
+# 1. `check` determines if the second job (`test`) will be run (through a job dependency).
+# 2. `test` runs on an AWS runner and executes the GPU tests.
 jobs:
+  # If the `skip-gpu-ci` label is set, this job is skipped, and consequently the `test` job too.
+  # If the `run-gpu-ci` label is set or we reacted to a `push` event, this job succeeds (and `test` is run).
+  # If neither is set, this job fails, `test` is skipped, and the whole workflow fails.
   check:
     name: Check if GPU tests are allowed to run
     if: (!contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci'))
@@ -24,6 +30,7 @@ jobs:
       - uses: flying-sheep/check@v1
         with:
           success: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-gpu-ci') }}
+  # If `check` wasn’t skipped or failed, start an AWS runner and run the GPU tests on it.
   test:
     name: GPU Tests
     needs: check

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -16,9 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check:
+    name: Check if GPU tests are allowed to run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: flying-sheep/check@v1
+        with:
+          success: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-gpu-ci') }}
   test:
     name: GPU Tests
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-gpu-ci') }}
+    needs: check
     runs-on: "cirun-aws-gpu--${{ github.run_id }}"
     defaults:
       run:

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -23,7 +23,7 @@ jobs:
   # If the `run-gpu-ci` label is set or we reacted to a `push` event, this job succeeds (and `test` is run).
   # If neither is set, this job fails, `test` is skipped, and the whole workflow fails.
   check:
-    name: Check if GPU tests are allowed to run
+    name: 'Triage: Check if GPU tests are allowed to run'
     if: (!contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -18,12 +18,12 @@ concurrency:
 jobs:
   check:
     name: Check if GPU tests are allowed to run
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci'))
     runs-on: ubuntu-latest
     steps:
       - uses: flying-sheep/check@v1
         with:
           success: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-gpu-ci') }}
-    if: ! contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci')
   test:
     name: GPU Tests
     needs: check

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: flying-sheep/check@v1
         with:
           success: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-gpu-ci') }}
+    if: ! contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci')
   test:
     name: GPU Tests
     needs: check

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -23,7 +23,7 @@ jobs:
   # If the `run-gpu-ci` label is set or we reacted to a `push` event, this job succeeds (and `test` is run).
   # If neither is set, this job fails, `test` is skipped, and the whole workflow fails.
   check:
-    name: 'Triage: Check if GPU tests are allowed to run'
+    name: "Triage: Check if GPU tests are allowed to run"
     if: (!contains(github.event.pull_request.labels.*.name, 'skip-gpu-ci'))
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently when the `run-gpu-ci` label is not set (or it’s a push), the job just get skipped, which counts as success:

> <img width="905" alt="image" src="https://github.com/scverse/anndata/assets/291575/b19e9f53-8847-482a-aa99-d64d1a4883cc">

This adds a second job (on a default runner), which simply fails if the conditions aren’t met.

This PR ensures that there’s always a fail outcome unless the GPU job is successfully run, and merging is blocked when it should be.