### PR TITLE
Fix benchmarks and pandas compat

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,16 +6,12 @@ on:
   pull_request:
     branches: [main]
 
-defaults:
-  run:
-    shell: bash -el {0}
-
 jobs:
   benchmark:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash -e {0} # -e to fail on error
+        shell: bash -el {0} # -e to fail on error, -l for mamba
 
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,12 +33,15 @@ jobs:
         if: ${{ github.ref_name != 'main' }}
         # Errors on main branch
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ matrix.python }}
-          cache: "pip"
-          cache-dependency-path: "**/pyproject.toml"
+          environment-name: asv
+          cache-environment: true
+          create-args: >-
+            python=3.10
+            asv
+            mamba
+            packaging
 
       - name: Cache datasets
         uses: actions/cache@v3
@@ -46,10 +49,6 @@ jobs:
           path: |
             ~/.cache
           key: benchmark-state-${{ hashFiles('benchmarks/**') }}
-
-      - name: Install dependencies
-        run: |
-          pip install asv packaging
 
       - name: Quick benchmark run
         working-directory: ${{ env.ASV_DIR }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10"]
+        python: ["3.11"]
         os: [ubuntu-latest]
 
     env:
@@ -55,4 +55,5 @@ jobs:
         working-directory: ${{ env.ASV_DIR }}
         run: |
           asv machine --yes
-          asv run -qev --strict
+          asv run --quick --show-stderr --verbose
+          # asv continuous ... --strict

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 jobs:
   benchmark:
     runs-on: ${{ matrix.os }}
@@ -38,7 +42,7 @@ jobs:
           environment-name: asv
           cache-environment: true
           create-args: >-
-            python=3.10
+            python=3.11
             asv
             mamba
             packaging

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,4 +55,4 @@ jobs:
         working-directory: ${{ env.ASV_DIR }}
         run: |
           asv machine --yes
-          asv run --quick --show-stderr --verbose --strict
+          asv run --quick --show-stderr --verbose

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,11 +49,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install asv
+          pip install asv packaging
 
       - name: Quick benchmark run
         working-directory: ${{ env.ASV_DIR }}
         run: |
           asv machine --yes
-          asv run --quick --show-stderr --verbose
-          # asv continuous ... --strict
+          asv run --quick --show-stderr --verbose --strict

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -108,6 +108,14 @@ def test_views():
     assert adata_subset.obs["foo"].tolist() == list(range(2))
 
 
+def test_view_subset_shapes():
+    adata = gen_adata((20, 10), **GEN_ADATA_DASK_ARGS)
+
+    view = adata[:, ::2]
+    assert view.var.shape == (5, 8)
+    assert {k: v.shape[0] for k, v in view.varm.items()} == {k: 5 for k in view.varm}
+
+
 def test_modify_view_component(matrix_type, mapping_name):
     adata = ad.AnnData(
         np.zeros((10, 10)),

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -44,7 +44,7 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "conda",
+    "environment_type": "mamba",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
@@ -117,7 +117,7 @@
     //     // additional env for python2.7
     //     {"python": "2.7", "numpy": "1.8"},
     //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    //     {"platform": "win32", "environment_type": "mamba", "python": "2.7", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "pandas>=1.1.1",  # pandas <1.1.1 has pandas/issues/35446
+    # pandas <1.1.1 has pandas/issues/35446
+    # pandas 2.1.0rc0 has pandas/issues/54622
+    "pandas >=1.1.1, !=2.1.0rc0",
     "numpy>=1.16.5",  # required by pandas 1.x
     "scipy>1.4",
     "h5py>=3",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- ASV 0.6.0 has some changes that make it loudly complain when `mamba` isn’t installed, so we might just as well switch to mamba. Side effect: Runs in 1 1/2 min instead of 5 1/2 min
- pandas will fix their bug in the next RC, so let’s just skip this one

----

- [x] Closes #1098
- [x] Tests added
- [x] Release note added (or unnecessary)
