### PR TITLE
Fix shape inference for X=None

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -111,8 +111,8 @@ def _mk_df_error(
     if source == "X":
         what = "row" if attr == "obs" else "column"
         msg = (
-            f"Observations annot. `{attr}` must have number of {what}s of `X`"
-            f" ({expected}), but has {actual} {what}s."
+            f"Observations annot. `{attr}` must have as many rows as `X` has {what}s "
+            f"({expected}), but has {actual} rows."
         )
     else:
         msg = (

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -133,22 +133,26 @@ def _gen_dataframe(
 ) -> pd.DataFrame:
     if anno is None or len(anno) == 0:
         anno = {}
-    for index_name in index_names:
-        if index_name in anno:
-            return pd.DataFrame(
-                anno,
-                index=anno[index_name],
-                columns=[k for k in anno.keys() if k != index_name],
-            )
 
     def mk_index(l: int) -> pd.Index:
         return pd.RangeIndex(0, l, name=None).astype(str)
 
-    df = pd.DataFrame(
-        anno,
-        index=None if length is None else mk_index(length),
-        columns=None if len(anno) else [],
-    )
+    for index_name in index_names:
+        if index_name not in anno:
+            continue
+        df = pd.DataFrame(
+            anno,
+            index=anno[index_name],
+            columns=[k for k in anno.keys() if k != index_name],
+        )
+        break
+    else:
+        df = pd.DataFrame(
+            anno,
+            index=None if length is None else mk_index(length),
+            columns=None if len(anno) else [],
+        )
+
     if length is None:
         df.index = mk_index(len(df))
     elif length != len(df):

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -527,7 +527,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X
-            n_obs, n_vars = self._X.shape
+            n_obs, n_vars = X.shape
             source = "X"
         else:
             self._X = None
@@ -830,12 +830,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     @property
     def n_obs(self) -> int:
         """Number of observations."""
-        return len(self.obs)
+        return len(self.obs_names)
 
     @property
     def n_vars(self) -> int:
         """Number of variables/features."""
-        return len(self.var)
+        return len(self.var_names)
 
     def _set_dim_df(self, value: pd.DataFrame, attr: str):
         if not isinstance(value, pd.DataFrame):

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -34,8 +34,9 @@ class Raw:
                 self._X = X.get()
             else:
                 self._X = X
+            n_var = None if self._X is None else self._X.shape[1]
             self._var = _gen_dataframe(
-                var, ["var_names"], source="X", attr="var", length=self.X.shape[1]
+                var, ["var_names"], source="X", attr="var", length=n_var
             )
             self._varm = AxisArrays(self, 1, varm)
         elif X is None:  # construct from adata

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -34,7 +34,9 @@ class Raw:
                 self._X = X.get()
             else:
                 self._X = X
-            self._var = _gen_dataframe(var, ["var_names"], self.X.shape[1])
+            self._var = _gen_dataframe(
+                var, ["var_names"], source="X", attr="var", length=self.X.shape[1]
+            )
             self._varm = AxisArrays(self, 1, varm)
         elif X is None:  # construct from adata
             # Move from GPU to CPU since it's large and not always used

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -34,7 +34,7 @@ class Raw:
                 self._X = X.get()
             else:
                 self._X = X
-            self._var = _gen_dataframe(var, self.X.shape[1], ["var_names"])
+            self._var = _gen_dataframe(var, ["var_names"], self.X.shape[1])
             self._varm = AxisArrays(self, 1, varm)
         elif X is None:  # construct from adata
             # Move from GPU to CPU since it's large and not always used

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -77,8 +77,8 @@ def test_creation():
     ],
 )
 def test_creation_error(src, src_arg, dim_msg, dim, dim_arg, msg: str | None):
-    mat_dim = "row" if dim == "obs" else "column"
     if msg is None:
+        mat_dim = "row" if dim == "obs" else "column"
         msg = dim_msg.format(dim=dim, mat_dim=mat_dim)
     with pytest.raises(ValueError, match=re.escape(msg)):
         AnnData(**{src: src_arg, dim: dim_arg(dim)})

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -54,7 +54,10 @@ def test_creation():
     ("src", "src_arg", "dim_msg"),
     [
         pytest.param(
-            "X", adata_dense.X, "`{dim}` must have number of {mat_dim}s of `X`", id="x"
+            "X",
+            adata_dense.X,
+            "`{dim}` must have as many rows as `X` has {mat_dim}s",
+            id="x",
         ),
         pytest.param(
             "shape", (2, 2), "`shape` is inconsistent with `{dim}`", id="shape"

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -49,15 +49,15 @@ def test_creation():
 
 
 @pytest.mark.parametrize(
-    "src_kw",
+    ("src", "src_arg"),
     [
-        pytest.param(dict(X=adata_dense.X), id="x"),
-        pytest.param(dict(shape=(2, 2)), id="shape"),
+        pytest.param("X", adata_dense.X, id="x"),
+        pytest.param("shape", (2, 2), id="shape"),
     ],
 )
 @pytest.mark.parametrize("dim", ["obs", "var"])
 @pytest.mark.parametrize(
-    ("dim_arg", "msg_template"),
+    ("dim_arg", "msg"),
     [
         pytest.param(
             lambda _: dict(TooLong=[1, 2, 3, 4]),
@@ -65,22 +65,22 @@ def test_creation():
             id="too_long_col",
         ),
         pytest.param(
-            lambda dim: {f"{dim}_names": ["a", "b", "c"]},
-            "`{dim}` must have number of {mat_dim}s of `X`",
-            id="too_many_names",
+            lambda dim: {f"{dim}_names": ["a", "b", "c"]}, None, id="too_many_names"
         ),
         pytest.param(
-            lambda _: pd.DataFrame(index=["a", "b", "c"]),
-            "`{dim}` must have number of {mat_dim}s of `X`",
-            id="too_long_df",
+            lambda _: pd.DataFrame(index=["a", "b", "c"]), None, id="too_long_df"
         ),
     ],
 )
-def test_creation_error(src_kw, dim, dim_arg, msg_template: str):
+def test_creation_error(src, src_arg, dim, dim_arg, msg: str | None):
     mat_dim = "row" if dim == "obs" else "column"
-    msg = msg_template.format(dim=dim, mat_dim=mat_dim)
+    if msg is None:
+        msg = dict(
+            X=f"`{dim}` must have number of {mat_dim}s of `X`",
+            shape=f"`shape` is inconsistent with `{dim}`",
+        )[src]
     with pytest.raises(ValueError, match=re.escape(msg)):
-        AnnData(**src_kw, **{dim: dim_arg(dim)})
+        AnnData(**{src: src_arg, dim: dim_arg(dim)})
 
 
 def test_create_with_dfs():

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from itertools import product
 import re
 import warnings

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -49,10 +49,14 @@ def test_creation():
 
 
 @pytest.mark.parametrize(
-    ("src", "src_arg"),
+    ("src", "src_arg", "dim_msg"),
     [
-        pytest.param("X", adata_dense.X, id="x"),
-        pytest.param("shape", (2, 2), id="shape"),
+        pytest.param(
+            "X", adata_dense.X, "`{dim}` must have number of {mat_dim}s of `X`", id="x"
+        ),
+        pytest.param(
+            "shape", (2, 2), "`shape` is inconsistent with `{dim}`", id="shape"
+        ),
     ],
 )
 @pytest.mark.parametrize("dim", ["obs", "var"])
@@ -72,13 +76,10 @@ def test_creation():
         ),
     ],
 )
-def test_creation_error(src, src_arg, dim, dim_arg, msg: str | None):
+def test_creation_error(src, src_arg, dim_msg, dim, dim_arg, msg: str | None):
     mat_dim = "row" if dim == "obs" else "column"
     if msg is None:
-        msg = dict(
-            X=f"`{dim}` must have number of {mat_dim}s of `X`",
-            shape=f"`shape` is inconsistent with `{dim}`",
-        )[src]
+        msg = dim_msg.format(dim=dim, mat_dim=mat_dim)
     with pytest.raises(ValueError, match=re.escape(msg)):
         AnnData(**{src: src_arg, dim: dim_arg(dim)})
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -60,17 +60,17 @@ def test_creation():
     ("dim_arg", "msg_template"),
     [
         pytest.param(
-            dict(TooLong=[1, 2, 3, 4]),
+            lambda _: dict(TooLong=[1, 2, 3, 4]),
             "Length of values (4) does not match length of index (2)",
             id="too_long_col",
         ),
         pytest.param(
-            dict(obs_names=["a", "b", "c"]),
+            lambda dim: {f"{dim}_names": ["a", "b", "c"]},
             "`{dim}` must have number of {mat_dim}s of `X`",
             id="too_many_names",
         ),
         pytest.param(
-            pd.DataFrame(index=["a", "b", "c"]),
+            lambda _: pd.DataFrame(index=["a", "b", "c"]),
             "`{dim}` must have number of {mat_dim}s of `X`",
             id="too_long_df",
         ),
@@ -80,7 +80,7 @@ def test_creation_error(src_kw, dim, dim_arg, msg_template: str):
     mat_dim = "row" if dim == "obs" else "column"
     msg = msg_template.format(dim=dim, mat_dim=mat_dim)
     with pytest.raises(ValueError, match=re.escape(msg)):
-        AnnData(**src_kw, **{dim: dim_arg})
+        AnnData(**src_kw, **{dim: dim_arg(dim)})
 
 
 def test_create_with_dfs():

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -33,7 +33,7 @@ uns_dict = dict(  # unstructured annotation
 
 
 @pytest.fixture
-def adata_raw():
+def adata_raw() -> ad.AnnData:
     adata = ad.AnnData(
         np.array(data, dtype="int32"), obs=obs_dict, var=var_dict, uns=uns_dict
     )
@@ -48,18 +48,18 @@ def adata_raw():
 # -------------------------------------------------------------------------------
 
 
-def test_raw_init(adata_raw):
+def test_raw_init(adata_raw: ad.AnnData):
     assert adata_raw.var_names.tolist() == ["var1", "var2"]
     assert adata_raw.raw.var_names.tolist() == ["var1", "var2", "var3"]
     assert adata_raw.raw[:, 0].X.tolist() == [[1], [4], [7]]
 
 
-def test_raw_del(adata_raw):
+def test_raw_del(adata_raw: ad.AnnData):
     del adata_raw.raw
     assert adata_raw.raw is None
 
 
-def test_raw_set_as_none(adata_raw):
+def test_raw_set_as_none(adata_raw: ad.AnnData):
     # Test for scverse/anndata#445
     a = adata_raw
     b = adata_raw.copy()
@@ -70,7 +70,7 @@ def test_raw_set_as_none(adata_raw):
     assert_equal(a, b)
 
 
-def test_raw_of_view(adata_raw):
+def test_raw_of_view(adata_raw: ad.AnnData):
     adata_view = adata_raw[adata_raw.obs["oanno1"] == "cat2"]
     assert adata_view.raw.X.tolist() == [
         [4, 5, 6],
@@ -78,7 +78,7 @@ def test_raw_of_view(adata_raw):
     ]
 
 
-def test_raw_rw(adata_raw, backing_h5ad):
+def test_raw_rw(adata_raw: ad.AnnData, backing_h5ad):
     adata_raw.write(backing_h5ad)
     adata_read = ad.read(backing_h5ad)
 
@@ -89,7 +89,7 @@ def test_raw_rw(adata_raw, backing_h5ad):
     assert adata_raw.raw[:, 0].X.tolist() == [[1], [4], [7]]
 
 
-def test_raw_view_rw(adata_raw, backing_h5ad):
+def test_raw_view_rw(adata_raw: ad.AnnData, backing_h5ad):
     # Make sure it still writes correctly if the object is a view
     adata_raw_view = adata_raw[:, adata_raw.var_names]
     assert_equal(adata_raw_view, adata_raw)
@@ -104,7 +104,7 @@ def test_raw_view_rw(adata_raw, backing_h5ad):
     assert adata_raw.raw[:, 0].X.tolist() == [[1], [4], [7]]
 
 
-def test_raw_backed(adata_raw, backing_h5ad):
+def test_raw_backed(adata_raw: ad.AnnData, backing_h5ad):
     adata_raw.filename = backing_h5ad
 
     assert adata_raw.var_names.tolist() == ["var1", "var2"]
@@ -114,7 +114,7 @@ def test_raw_backed(adata_raw, backing_h5ad):
     assert adata_raw.raw[:, 0].X[:].tolist() == [[1], [4], [7]]
 
 
-def test_raw_view_backed(adata_raw, backing_h5ad):
+def test_raw_view_backed(adata_raw: ad.AnnData, backing_h5ad):
     adata_raw.filename = backing_h5ad
 
     assert adata_raw.var_names.tolist() == ["var1", "var2"]

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -659,3 +659,14 @@ def test_copy_X_dtype():
     adata = ad.AnnData(sparse.eye(50, dtype=np.float64, format="csr"))
     adata_c = adata[::2].copy()
     assert adata_c.X.dtype == adata.X.dtype
+
+
+def test_x_none():
+    orig = ad.AnnData(obs=pd.DataFrame(index=np.arange(50)))
+    assert orig.shape == (50, 0)
+    view = orig[2:4]
+    assert view.shape == (2, 0)
+    assert view.obs_names.tolist() == ["2", "3"]
+    new = view.copy()
+    assert new.shape == (2, 0)
+    assert new.obs_names.tolist() == ["2", "3"]

--- a/anndata/tests/test_x.py
+++ b/anndata/tests/test_x.py
@@ -66,7 +66,7 @@ def test_del_set_equiv_X():
 
 
 @pytest.mark.parametrize(
-    ("obs", "var", "shape"),
+    ("obs", "var", "shape_expected"),
     [
         pytest.param(dict(obs_names=["1", "2"]), None, (2, 0), id="obs"),
         pytest.param(None, dict(var_names=["a", "b"]), (0, 2), id="var"),
@@ -78,10 +78,10 @@ def test_del_set_equiv_X():
         ),
     ],
 )
-def test_init_x_as_none_shape_from_obs_var(obs, var, shape):
+def test_init_x_as_none_shape_from_obs_var(obs, var, shape_expected):
     adata = AnnData(None, obs, var)
     assert adata.X is None
-    assert adata.shape == shape
+    assert adata.shape == shape_expected
 
 
 def test_init_x_as_none_explicit_shape():

--- a/anndata/tests/test_x.py
+++ b/anndata/tests/test_x.py
@@ -65,8 +65,26 @@ def test_del_set_equiv_X():
     assert orig.X is None
 
 
-def test_init_X_as_none():
-    # test initialiser
+@pytest.mark.parametrize(
+    ("obs", "var", "shape"),
+    [
+        pytest.param(dict(obs_names=["1", "2"]), None, (2, 0), id="obs"),
+        pytest.param(None, dict(var_names=["a", "b"]), (0, 2), id="var"),
+        pytest.param(
+            dict(obs_names=["1", "2", "3"]),
+            dict(var_names=["a", "b"]),
+            (3, 2),
+            id="both",
+        ),
+    ],
+)
+def test_init_x_as_none_shape_from_obs_var(obs, var, shape):
+    adata = AnnData(None, obs, var)
+    assert adata.X is None
+    assert adata.shape == shape
+
+
+def test_init_x_as_none_explicit_shape():
     shape = (3, 5)
     adata = AnnData(None, uns=dict(test=np.array((3, 3))), shape=shape)
     assert adata.X is None

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -31,3 +31,5 @@
 
 ```{rubric} Bug fixes
 ```
+
+* Fix shape inference on initialization when `X=None` is specified {pr}`1121` {user}`flying-sheep`

--- a/docs/release-notes/0.10.1.md
+++ b/docs/release-notes/0.10.1.md
@@ -1,0 +1,4 @@
+### 0.10.1 {small}`the future`
+
+```{rubric} Bugfix
+```

--- a/docs/release-notes/0.10.1.md
+++ b/docs/release-notes/0.10.1.md
@@ -1,4 +1,0 @@
-### 0.10.1 {small}`the future`
-
-```{rubric} Bugfix
-```

--- a/docs/release-notes/0.9.3.md
+++ b/docs/release-notes/0.9.3.md
@@ -1,4 +1,0 @@
-### 0.9.3 {small}`the future`
-
-```{rubric} Bugfix
-```

--- a/docs/release-notes/release-latest.md
+++ b/docs/release-notes/release-latest.md
@@ -1,12 +1,12 @@
 ## Version 0.10
 
+```{include} /release-notes/0.10.1.md
+```
+
 ```{include} /release-notes/0.10.0.md
 ```
 
 ## Version 0.9
-
-```{include} /release-notes/0.9.3.md
-```
 
 ```{include} /release-notes/0.9.2.md
 ```

--- a/docs/release-notes/release-latest.md
+++ b/docs/release-notes/release-latest.md
@@ -1,8 +1,5 @@
 ## Version 0.10
 
-```{include} /release-notes/0.10.1.md
-```
-
 ```{include} /release-notes/0.10.0.md
 ```
 


### PR DESCRIPTION
- [x] Fixes parts of #467
- [x] Tests added
- [x] Release note added (or unnecessary)

TODO:

- [x] Views (basically just check that .X = None doesn't change other view behavior, a[idx].X doesn't do anything weird, and copying views still works)
  *unclear if that’s covered* @ivirshup can you clarify the scope of this?
- [x] Figure out inference of AnnData shape when X is None

Later:
- [ ] Backed mode
- [ ] Concatenation 
- [ ] IO tests
- [ ] Specialized writers like `to_csvs`
- [ ] Raw