### PR TITLE
Remove deprecated type argument to anndata constructor

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -342,12 +342,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         layers: Mapping[str, np.ndarray | sparse.spmatrix] | None = None,
         raw: Mapping[str, Any] | None = None,
-        dtype: np.dtype | type | str | None = None,
+        *,
         shape: tuple[int, int] | None = None,
         filename: PathLike | None = None,
         filemode: Literal["r", "r+"] | None = None,
         asview: bool = False,
-        *,
         obsp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         oidx: Index1D = None,
@@ -367,7 +366,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 varm=varm,
                 raw=raw,
                 layers=layers,
-                dtype=dtype,
                 shape=shape,
                 obsp=obsp,
                 varp=varp,
@@ -443,7 +441,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obsp=None,
         raw=None,
         layers=None,
-        dtype=None,
+        *,
         shape=None,
         filename=None,
         filemode=None,
@@ -516,21 +514,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if shape is not None:
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
             _check_2d_shape(X)
-            # if type doesn’t match, a copy is made, otherwise, use a view
-            if dtype is not None:
-                warnings.warn(
-                    "The dtype argument will be deprecated in anndata 0.10.0",
-                    PendingDeprecationWarning,
-                )
-                if issparse(X) or isinstance(X, ma.MaskedArray):
-                    # TODO: maybe use view on data attribute of sparse matrix
-                    #       as in readwrite.read_10x_h5
-                    if X.dtype != np.dtype(dtype):
-                        X = X.astype(dtype)
-                elif isinstance(X, (ZarrArray, DaskArray)):
-                    X = X.astype(dtype)
-                else:  # is np.ndarray or a subclass, convert to true np.ndarray
-                    X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X
             n_obs, n_vars = X.shape

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -75,30 +75,6 @@ def test_obsvar_vector_Xlayer(adata):
         adata.obs_vector("a", layer="X")
 
 
-# This should break in 0.9
-def test_dtype_warning():
-    # Tests a warning is thrown
-    with pytest.warns(PendingDeprecationWarning):
-        a = AnnData(np.ones((3, 3)), dtype=np.float32)
-    assert a.X.dtype == np.float32
-
-    # This shouldn't warn, shouldn't copy
-    with warnings.catch_warnings(record=True) as record:
-        b_X = np.ones((3, 3), dtype=np.float64)
-        b = AnnData(b_X)
-        assert not record
-    assert b_X is b.X
-    assert b.X.dtype == np.float64
-
-    # Should warn, should copy
-    with pytest.warns(PendingDeprecationWarning):
-        c_X = np.ones((3, 3), dtype=np.float32)
-        c = AnnData(c_X, dtype=np.float64)
-        assert not record
-    assert c_X is not c.X
-    assert c.X.dtype == np.float64
-
-
 def test_deprecated_write_attribute(tmp_path):
     pth = tmp_path / "file.h5"
     A = np.random.randn(20, 10)

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -27,6 +27,7 @@
 ```
 
 * {meth}`anndata.AnnData.transpose` no longer copies unnecessarily. If you rely on the copying behavior, call `.copy` on the resulting object. {pr}`1114` {user}`ivirshup`
+* Removal of deprecated `dtype` argument to `AnnData` constructor {pr}`1126` {user}`ivirshup`
 
 ```{rubric} Other updates
 ```


### PR DESCRIPTION
Anndata's dtype argument is scheduled for removal in 0.10.0, this PR does that.

Scanpy will need a bug fix release around this:

* https://github.com/scverse/scanpy/pull/2658

- [x] Release note added (or unnecessary)
