### PR TITLE
Optimize contiguous sparse slicing

### DIFF
--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -105,6 +105,25 @@ def _normalize_index(
         raise IndexError(f"Unknown indexer {indexer!r} of type {type(indexer)}")
 
 
+def _normalize_slice(s: slice, length: int):
+    """Normalize a slice for a given length.
+
+    This means that the slice will be clipped to the length of the object, and the step won't be None.
+    """
+    step = s.step if s.step is not None else 1
+
+    # slice constructor would have errored if step was 0
+    if step > 0:
+        start = s.start if s.start is not None else 0
+        stop = s.stop if s.stop is not None else length
+    elif step < 0:
+        # Reverse
+        start = s.start if s.start is not None else length
+        stop = s.stop if s.stop is not None else 0
+
+    return slice(start, stop, step)
+
+
 def unpack_index(index: Index) -> tuple[Index1D, Index1D]:
     if not isinstance(index, tuple):
         return index, slice(None)

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -105,10 +105,10 @@ def _normalize_index(
         raise IndexError(f"Unknown indexer {indexer!r} of type {type(indexer)}")
 
 
-def _normalize_slice(s: slice, length: int):
-    """Normalize a slice for a given length.
+def _fix_slice_bounds(s: slice, length: int) -> slice:
+    """The slice will be clipped to length, and the step won't be None.
 
-    This means that the slice will be clipped to the length of the object, and the step won't be None.
+    E.g. infer None valued attributes.
     """
     step = s.step if s.step is not None else 1
 

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -23,7 +23,7 @@ import numpy as np
 import scipy.sparse as ss
 from scipy.sparse import _sparsetools
 
-from anndata._core.index import _normalize_slice
+from anndata._core.index import _fix_slice_bounds
 from anndata.compat import H5Group, ZarrGroup
 
 from ..compat import _read_attr
@@ -147,8 +147,8 @@ class backed_csr_matrix(BackedSparseMatrix, ss.csr_matrix):
         )[:, col]
 
     def _get_sliceXslice(self, row: slice, col: slice) -> ss.csr_matrix:
-        row = _normalize_slice(row, self.shape[0])
-        col = _normalize_slice(col, self.shape[1])
+        row = _fix_slice_bounds(row, self.shape[0])
+        col = _fix_slice_bounds(col, self.shape[1])
 
         out_shape = (
             slice_len(row, self.shape[0]),
@@ -181,8 +181,8 @@ class backed_csc_matrix(BackedSparseMatrix, ss.csc_matrix):
         )[row, :]
 
     def _get_sliceXslice(self, row: slice, col: slice) -> ss.csc_matrix:
-        row = _normalize_slice(row, self.shape[0])
-        col = _normalize_slice(col, self.shape[1])
+        row = _fix_slice_bounds(row, self.shape[0])
+        col = _fix_slice_bounds(col, self.shape[1])
 
         out_shape = (
             slice_len(row, self.shape[0]),

--- a/benchmarks/benchmarks/sparse_dataset.py
+++ b/benchmarks/benchmarks/sparse_dataset.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import numpy as np
+import zarr
+from scipy import sparse
+
+from anndata.experimental import sparse_dataset, write_elem
+
+
+class SparseCSRContiguousSlice:
+    params = (
+        [
+            (10_000, 10_000),
+            # (10_000, 500)
+        ],
+        [slice(0, 1000), slice(0, 9000), slice(None, 9000, -1), slice(None, None, 2)],
+    )
+    param_names = ["shape", "slice"]
+
+    def setup(self, shape, slice):
+        X = sparse.random(
+            *shape, density=0.01, format="csr", random_state=np.random.default_rng(42)
+        )
+        self.slice = slice
+        g = zarr.group()
+        write_elem(g, "X", X)
+        self.x = sparse_dataset(g["X"])
+
+    def time_getitem(self, shape, slice):
+        self.x[self.slice]
+
+    def peakmem_getitem(self, shape, slice):
+        self.x[self.slice]

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -24,6 +24,7 @@ We expect to make a full release by October.
 * Concatenate on-disk anndata objects with {func}`anndata.experimental.concat_on_disk` {pr}`955` {user}`selmanozleyen`
 * AnnData can now hold dask arrays with `scipy.sparse.spmatrix` chunks {pr}`1114` {user}`ivirshup`
 * Public API for interacting with on disk sparse arrays: {func}`~anndata.experimental.sparse_dataset`, {class}`~anndata.experimental.CSRDataset`, and {class}`~anndata.experimental.CSCDataset` {pr}`765` {user}`ilan-gold` {user}`ivirshup`
+* Improved performance for simple slices of OOC sparse arrays {pr}`1131` {user}`ivirshup`
 
 **Improved errors and warnings**
 


### PR DESCRIPTION
Significant speed up for contiguous slices

I had totally thought this was already implemented...

TODO:

- [x] Benchmarks

* deferred
  - ~[ ] Reverse slicing~
  - ~[ ] Steps other that 1?~

It's probably optimal to do this up to pretty large step sizes. So long as two adjacent rows are in the same slice we should probably take this approach.

cc: @ilan-gold

Benchmark:

```python
from anndata.experimental import write_elem, sparse_dataset
from scipy import sparse
import numpy as np
import zarr

z = zarr.open("test.zarr")
write_elem(
    z,
    "/",
    sparse.random(
        100_000,
        10_000,
        format="csr",
        random_state=np.random.default_rng(),
    )
)

x = sparse_dataset(z["/"])
%time x[10000:20000]
```

This PR:

```
CPU times: user 9.57 ms, sys: 5.09 ms, total: 14.7 ms
Wall time: 14.4 ms
<10000x10000 sparse matrix of type '<class 'numpy.float64'>'
	with 999208 stored elements in Compressed Sparse Row format>
```

Main:

```
CPU times: user 9.35 s, sys: 5.14 s, total: 14.5 s
Wall time: 14.8 s
<10000x10000 sparse matrix of type '<class 'numpy.float64'>'
	with 999208 stored elements in Compressed Sparse Row format>
```