### PR TITLE
Remove unsupported param from `.cirun.yml`

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -7,6 +7,5 @@ runners:
     preemptible:
       - true
       - false
-    workflow: .github/workflows/test-gpu.yml
     labels:
       - cirun-aws-gpu


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

`workflow` param is not supported and it's misleading. Runner matching is done only via labels.

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
