### PR TITLE
Just deprecate dtype argument

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -520,8 +520,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             # if type doesn’t match, a copy is made, otherwise, use a view
             if dtype is not None:
                 warnings.warn(
-                    "The dtype argument will be deprecated in anndata 0.10.0",
-                    PendingDeprecationWarning,
+                    "The dtype argument is deprecated and will be removed in late 2024.",
+                    FutureWarning,
                 )
                 if issparse(X) or isinstance(X, ma.MaskedArray):
                     # TODO: maybe use view on data attribute of sparse matrix

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -343,11 +343,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         layers: Mapping[str, np.ndarray | sparse.spmatrix] | None = None,
         raw: Mapping[str, Any] | None = None,
-        *,
+        dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
         filename: PathLike | None = None,
         filemode: Literal["r", "r+"] | None = None,
         asview: bool = False,
+        *,
         obsp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         oidx: Index1D = None,
@@ -367,6 +368,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 varm=varm,
                 raw=raw,
                 layers=layers,
+                dtype=dtype,
                 shape=shape,
                 obsp=obsp,
                 varp=varp,
@@ -442,7 +444,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obsp=None,
         raw=None,
         layers=None,
-        *,
+        dtype=None,
         shape=None,
         filename=None,
         filemode=None,
@@ -515,6 +517,21 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if shape is not None:
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
             _check_2d_shape(X)
+            # if type doesn’t match, a copy is made, otherwise, use a view
+            if dtype is not None:
+                warnings.warn(
+                    "The dtype argument will be deprecated in anndata 0.10.0",
+                    PendingDeprecationWarning,
+                )
+                if issparse(X) or isinstance(X, ma.MaskedArray):
+                    # TODO: maybe use view on data attribute of sparse matrix
+                    #       as in readwrite.read_10x_h5
+                    if X.dtype != np.dtype(dtype):
+                        X = X.astype(dtype)
+                elif isinstance(X, (ZarrArray, DaskArray)):
+                    X = X.astype(dtype)
+                else:  # is np.ndarray or a subclass, convert to true np.ndarray
+                    X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X
             n_obs, n_vars = X.shape

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -75,6 +75,30 @@ def test_obsvar_vector_Xlayer(adata):
         adata.obs_vector("a", layer="X")
 
 
+# This should break in 0.9
+def test_dtype_warning():
+    # Tests a warning is thrown
+    with pytest.warns(PendingDeprecationWarning):
+        a = AnnData(np.ones((3, 3)), dtype=np.float32)
+    assert a.X.dtype == np.float32
+
+    # This shouldn't warn, shouldn't copy
+    with warnings.catch_warnings(record=True) as record:
+        b_X = np.ones((3, 3), dtype=np.float64)
+        b = AnnData(b_X)
+        assert not record
+    assert b_X is b.X
+    assert b.X.dtype == np.float64
+
+    # Should warn, should copy
+    with pytest.warns(PendingDeprecationWarning):
+        c_X = np.ones((3, 3), dtype=np.float32)
+        c = AnnData(c_X, dtype=np.float64)
+        assert not record
+    assert c_X is not c.X
+    assert c.X.dtype == np.float64
+
+
 def test_deprecated_write_attribute(tmp_path):
     pth = tmp_path / "file.h5"
     A = np.random.randn(20, 10)

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -78,7 +78,7 @@ def test_obsvar_vector_Xlayer(adata):
 # This should break in 0.9
 def test_dtype_warning():
     # Tests a warning is thrown
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(FutureWarning):
         a = AnnData(np.ones((3, 3)), dtype=np.float32)
     assert a.X.dtype == np.float32
 
@@ -91,7 +91,7 @@ def test_dtype_warning():
     assert b.X.dtype == np.float64
 
     # Should warn, should copy
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(FutureWarning):
         c_X = np.ones((3, 3), dtype=np.float32)
         c = AnnData(c_X, dtype=np.float64)
         assert not record

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -50,6 +50,7 @@ We expect to make a full release by October.
 ```
 
 * Deprecate `anndata.read`, which was just an alias for {func}`anndata.read_h5ad` {pr}`1108` {user}`ivirshup`.
+* `dtype` argument to `AnnData` constructor is now deprecated {pr}`1153` {user}`ivirshup`
 
 ```{rubric} Bug fixes
 ```

--- a/docs/release-notes/0.10.0.md
+++ b/docs/release-notes/0.10.0.md
@@ -40,7 +40,6 @@ We expect to make a full release by October.
 ```
 
 * {meth}`anndata.AnnData.transpose` no longer copies unnecessarily. If you rely on the copying behavior, call `.copy` on the resulting object. {pr}`1114` {user}`ivirshup`
-* Removal of deprecated `dtype` argument to `AnnData` constructor {pr}`1126` {user}`ivirshup`
 
 ```{rubric} Other updates
 ```


### PR DESCRIPTION
This reverts commit f3e9c3231887e96a23d91ad83274d872551baba6.

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1137
- [x] Tests added
- [x] Release note added (or unnecessary)
