### PR TITLE
Skip pandas release causing infinite recursion

### DIFF
--- a/docs/release-notes/0.10.3.md
+++ b/docs/release-notes/0.10.3.md
@@ -2,6 +2,7 @@
 
 ```{rubric} Bugfix
 ```
+* Prevent pandas from causing infinite recursion when setting a slice of a categorical column {pr}`1211` {user}`flying-sheep`
 
 ```{rubric} Documentation
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ classifiers = [
 dependencies = [
     # pandas <1.1.1 has pandas/issues/35446
     # pandas 2.1.0rc0 has pandas/issues/54622
-    "pandas >=1.1.1, !=2.1.0rc0",
+    # pandas 2.1.2 has pandas/issues/52927
+    "pandas >=1.1.1, !=2.1.0rc0, !=2.1.2",
     "numpy>=1.16.5",                         # required by pandas 1.x
     "scipy>1.4",
     "h5py>=3",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1210
- [x] Tests added
- [x] Release note added (or unnecessary)
