### PR TITLE
Centralize warning config

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -62,20 +62,8 @@ jobs:
         displayName: "PyTest (coverage)"
         condition: and(eq(variables['RUN_COVERAGE'], 'yes'), eq(variables['PRERELEASE_DEPENDENCIES'], 'no'))
 
-      # TODO: fix all the exceptions here
-      # TODO: Centralize, see https://github.com/scverse/anndata/issues/1204
-      - script: >
-          pytest
-          -W error
-          -W 'ignore:Support for Awkward Arrays is currently experimental'
-          -W 'ignore:Outer joins on awkward.Arrays'
-          -W 'default:Setting element:UserWarning'
-          -W 'default:Trying to modify attribute:UserWarning'
-          -W 'default:Transforming to str index:UserWarning'
-          -W 'default:Observation names are not unique. To make them unique:UserWarning'
-          -W 'default:Variable names are not unique. To make them unique:UserWarning'
-          -W 'default::scipy.sparse._base.SparseEfficiencyWarning'
-          -W 'default::dask.array.core.PerformanceWarning'
+      - script: |
+          pytest --strict-warnings
         displayName: "PyTest (treat warnings as errors)"
         condition: and(eq(variables['RUN_COVERAGE'], 'no'), eq(variables['PRERELEASE_DEPENDENCIES'], 'yes'))
 

--- a/conftest.py
+++ b/conftest.py
@@ -74,13 +74,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
-    if strs := config.getini("filterwarnings"):
-        assert isinstance(strs, list)
-        return [str(f) for f in strs]
-    return []
-
-
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: Iterable[pytest.Item]
 ):
@@ -99,3 +92,10 @@ def pytest_collection_modifyitems(
         # this ensures that markers that are applied later override these
         for mark in reversed(warning_marks):
             item.add_marker(mark, append=False)
+
+
+def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
+    if strs := config.getini(name):
+        assert isinstance(strs, list)
+        return [str(f) for f in strs]
+    return []

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,9 @@ from anndata.compat import chdir
 from anndata.utils import import_name
 
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
     from pathlib import Path
+
 
 doctest_marker = pytest.mark.usefixtures("doctest_env")
 
@@ -22,15 +24,17 @@ doctest_marker = pytest.mark.usefixtures("doctest_env")
 @pytest.fixture
 def doctest_env(
     request: pytest.FixtureRequest, cache: pytest.Cache, tmp_path: Path
-) -> None:
+) -> Generator[None, None, None]:
     from scanpy import settings
 
+    assert isinstance(request.node.parent, pytest.Module)
     # request.node.parent is either a DoctestModule or a DoctestTextFile.
     # Only DoctestModule has a .obj attribute (the imported module).
     if request.node.parent.obj:
         func = import_name(request.node.name)
+        warning_detail: tuple[type[Warning], str, bool] | None
         if warning_detail := getattr(func, "__deprecated", None):
-            cat, msg, _ = warning_detail  # type: tuple[type[Warning], str, bool]
+            cat, msg, _ = warning_detail
             warnings.filterwarnings("ignore", category=cat, message=re.escape(msg))
 
     old_dd, settings.datasetdir = settings.datasetdir, cache.mkdir("scanpy-data")
@@ -39,7 +43,7 @@ def doctest_env(
     settings.datasetdir = old_dd
 
 
-def pytest_itemcollected(item):
+def pytest_itemcollected(item: pytest.Item) -> None:
     """Define behavior of pytest.mark.gpu and doctests."""
     from importlib.util import find_spec
 
@@ -51,3 +55,41 @@ def pytest_itemcollected(item):
 
     if isinstance(item, pytest.DoctestItem):
         item.add_marker(doctest_marker)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--strict-warnings",
+        action="store_true",
+        default=False,
+        help="Turn most warnings into errors",
+    )
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: Iterable[pytest.Item]
+):
+    if not config.getoption("--strict-warnings"):
+        return
+
+    filters_from_config: list[str] = []
+    if fs := config.getini("filterwarnings"):
+        assert isinstance(fs, list)
+        filters_from_config = [str(f) for f in fs]
+
+    warning_filters = [
+        r"error",
+        *filters_from_config,
+        r"default::anndata._warnings.ImplicitModificationWarning",
+        r"default:Transforming to str index:UserWarning",
+        r"default:(Observation|Variable) names are not unique. To make them unique:UserWarning",
+        r"default::scipy.sparse.SparseEfficiencyWarning",
+        r"default::dask.array.core.PerformanceWarning",
+    ]
+    warning_marks = [pytest.mark.filterwarnings(f) for f in warning_filters]
+
+    for item in items:
+        # reverse and then prepend means essentially `marks[0:0] = warning_marks`
+        # this ensures that markers that are applied later override these
+        for mark in reversed(warning_marks):
+            item.add_marker(mark, append=False)

--- a/conftest.py
+++ b/conftest.py
@@ -66,20 +66,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Turn most warnings into errors",
     )
 
-    parser.addini(
-        "filterwarnings_when_strict",
-        "Filters to apply after `-Werror` when --strict-warnings is active",
-        type="linelist",
-        default=[],
-    )
-
-
-def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
-    if strs := config.getini("filterwarnings"):
-        assert isinstance(strs, list)
-        return [str(f) for f in strs]
-    return []
-
 
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: Iterable[pytest.Item]
@@ -90,7 +76,6 @@ def pytest_collection_modifyitems(
     warning_filters = [
         r"error",
         *_config_get_strlist(config, "filterwarnings"),
-        *_config_get_strlist(config, "filterwarnings_when_strict"),
     ]
     warning_marks = [pytest.mark.filterwarnings(f) for f in warning_filters]
 
@@ -99,3 +84,10 @@ def pytest_collection_modifyitems(
         # this ensures that markers that are applied later override these
         for mark in reversed(warning_marks):
             item.add_marker(mark, append=False)
+
+
+def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
+    if strs := config.getini(name):
+        assert isinstance(strs, list)
+        return [str(f) for f in strs]
+    return []

--- a/conftest.py
+++ b/conftest.py
@@ -66,6 +66,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Turn most warnings into errors",
     )
 
+    parser.addini(
+        "filterwarnings_when_strict",
+        "Filters to apply after `-Werror` when --strict-warnings is active",
+        type="linelist",
+        default=[],
+    )
+
+
+def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
+    if strs := config.getini("filterwarnings"):
+        assert isinstance(strs, list)
+        return [str(f) for f in strs]
+    return []
+
 
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: Iterable[pytest.Item]
@@ -76,6 +90,7 @@ def pytest_collection_modifyitems(
     warning_filters = [
         r"error",
         *_config_get_strlist(config, "filterwarnings"),
+        *_config_get_strlist(config, "filterwarnings_when_strict"),
     ]
     warning_marks = [pytest.mark.filterwarnings(f) for f in warning_filters]
 
@@ -84,10 +99,3 @@ def pytest_collection_modifyitems(
         # this ensures that markers that are applied later override these
         for mark in reversed(warning_marks):
             item.add_marker(mark, append=False)
-
-
-def _config_get_strlist(config: pytest.Config, name: str) -> list[str]:
-    if strs := config.getini(name):
-        assert isinstance(strs, list)
-        return [str(f) for f in strs]
-    return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,9 @@ addopts = [
     "--ignore=anndata/core.py",      # deprecated
     "--ignore=anndata/readwrite.py", # deprecated
 ]
+# See conftest.py for the warning filters that get applied when --strict-warnings in passed
 filterwarnings = [
-    'ignore:Support for Awkward Arrays is currently experimental',
-    'ignore:Outer joins on awkward\.Arrays',
+    'ignore::anndata._warnings.ExperimentalFeatureWarning',
 ]
 python_files = "test_*.py"
 testpaths = ["anndata", "docs/concatenation.rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,11 +114,13 @@ addopts = [
     "--doctest-modules",
 ]
 filterwarnings = [
-    # TODO: replace both `ignore` lines below with this one once we figured out how prevent ImportPathMismatchError
-    # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
     'ignore:Support for Awkward Arrays is currently experimental',
     'ignore:Outer joins on awkward\.Arrays',
-    # When `--strict-warnings` is used, all warnings are treated as errors, except those:
+    # TODO: replace both lines above with this one once we figured out how prevent ImportPathMismatchError
+    # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
+]
+# When `--strict-warnings` is used, all warnings are treated as errors, except those:
+filterwarnings_when_strict = [
     "default::anndata._warnings.ImplicitModificationWarning",
     "default:Transforming to str index:UserWarning",
     "default:(Observation|Variable) names are not unique. To make them unique:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ addopts = [
     "--ignore=anndata/core.py",      # deprecated
     "--ignore=anndata/readwrite.py", # deprecated
 ]
-# See conftest.py for the warning filters that get applied when --strict-warnings in passed
+# See conftest.py for the warning filters that get applied when --strict-warnings is passed
 filterwarnings = [
     'ignore:Support for Awkward Arrays is currently experimental',
     'ignore:Outer joins on awkward\.Arrays',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,12 +113,19 @@ addopts = [
     "--strict-markers",
     "--doctest-modules",
 ]
-# See conftest.py for the warning filters that get applied when --strict-warnings is passed
 filterwarnings = [
     'ignore:Support for Awkward Arrays is currently experimental',
     'ignore:Outer joins on awkward\.Arrays',
     # TODO: replace both lines above with this one once we figured out how prevent ImportPathMismatchError
     # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
+]
+# When `--strict-warnings` is used, all warnings are treated as errors, except those:
+filterwarnings_when_strict = [
+    "default::anndata._warnings.ImplicitModificationWarning",
+    "default:Transforming to str index:UserWarning",
+    "default:(Observation|Variable) names are not unique. To make them unique:UserWarning",
+    "default::scipy.sparse.SparseEfficiencyWarning",
+    "default::dask.array.core.PerformanceWarning",
 ]
 python_files = "test_*.py"
 testpaths = ["anndata", "docs/concatenation.rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,10 @@ addopts = [
 ]
 # See conftest.py for the warning filters that get applied when --strict-warnings in passed
 filterwarnings = [
-    'ignore::anndata._warnings.ExperimentalFeatureWarning',
+    'ignore:Support for Awkward Arrays is currently experimental',
+    'ignore:Outer joins on awkward\.Arrays',
+    # TODO: replace both lines above with this one once we figured out how prevent ImportPathMismatchError
+    # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
 ]
 python_files = "test_*.py"
 testpaths = ["anndata", "docs/concatenation.rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,13 +114,11 @@ addopts = [
     "--doctest-modules",
 ]
 filterwarnings = [
+    # TODO: replace both `ignore` lines below with this one once we figured out how prevent ImportPathMismatchError
+    # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
     'ignore:Support for Awkward Arrays is currently experimental',
     'ignore:Outer joins on awkward\.Arrays',
-    # TODO: replace both lines above with this one once we figured out how prevent ImportPathMismatchError
-    # 'ignore::anndata._warnings.ExperimentalFeatureWarning',
-]
-# When `--strict-warnings` is used, all warnings are treated as errors, except those:
-filterwarnings_when_strict = [
+    # When `--strict-warnings` is used, all warnings are treated as errors, except those:
     "default::anndata._warnings.ImplicitModificationWarning",
     "default:Transforming to str index:UserWarning",
     "default:(Observation|Variable) names are not unique. To make them unique:UserWarning",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1204
- [x] Tests added
- [x] Release note added (or unnecessary)

This makes sure nothing needs to be kept in sync manually