### PR TITLE
(fix): indexing performance in `backed` mode for `boolean` case

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -345,17 +345,13 @@ class BaseCompressedSparseDataset(ABC):
         mtx = self._to_backed()
 
         # see https://github.com/scverse/anndata/issues/1224 for special handling of boolean masks
-        def mask_to_slices_or_ints(mask):
-            slices = np.ma.extras._ezclump(mask)
-            for s in slices:
-                if s.stop - s.start < 10:
-                    yield list(range(s.start, s.stop))
-                yield s
+        def make_slices(mask):
+            return np.ma.extras._ezclump(mask)
 
         if self.format == "csr" and np.array(row).dtype == bool:
-            sub = ss.vstack([mtx[s, col] for s in mask_to_slices_or_ints(row)])
+            sub = ss.vstack([mtx[s, col] for s in make_slices(row)])
         elif self.format == "csc" and np.array(col).dtype == bool:
-            sub = ss.vstack([mtx[row, s] for s in mask_to_slices_or_ints(row)])
+            sub = ss.vstack([mtx[row, s] for s in make_slices(row)])
         else:
             sub = mtx[row, col]
         # If indexing is array x array it returns a backed_sparse_matrix

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -351,18 +351,16 @@ class BaseCompressedSparseDataset(ABC):
         def mean_slice_length(slices):
             return floor((slices[-1].stop - slices[0].start) / len(slices))
 
-        slices = make_slices(row)
-        is_mean_slice_length_large = mean_slice_length(slices) > 7  # heuristic
         if (
             self.format == "csr"
             and np.array(row).dtype == bool
-            and is_mean_slice_length_large
+            and mean_slice_length(make_slices(row)) > 7
         ):
             sub = ss.vstack([mtx[s, col] for s in make_slices(row)])
         elif (
             self.format == "csc"
             and np.array(col).dtype == bool
-            and is_mean_slice_length_large
+            and mean_slice_length(make_slices(col)) > 7
         ):
             sub = ss.vstack([mtx[row, s] for s in make_slices(col)])
         else:

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -345,6 +345,7 @@ class BaseCompressedSparseDataset(ABC):
         mtx = self._to_backed()
 
         # see https://github.com/scverse/anndata/issues/1224 for special handling of boolean masks
+        # scipy internally converts boolean masks to integer indices so this needs to occur before access to `mtx`.
         def make_slices(mask):
             return np.ma.extras._ezclump(mask)
 


### PR DESCRIPTION
Here's my shot at it.   As I explain in the comment (also in the issue), the `boolean` case is converted by `scipy` to numeric integers which is why the solution has to go before `mtx` access.  The other option would be to "solve" the `integer` case but as you point out, there are some nasty edge cases there with sorting, repeated indices etc.  So in the interest of getting something out, I have this.

I set up a little benchmarking thing.  Here's the setup:
```python
import numpy as np
import zarr
from anndata.experimental import read_elem, write_elem, sparse_dataset
from scipy import sparse
import h5py

# Create data
rng = np.random.default_rng()

X = sparse.random(100_000, 10_000, density=0.01, random_state=rng, format="csr")
group = zarr.open("demo.zarr", mode="w")
write_elem(group, "X", X)
X_zarr = sparse_dataset(group["X"])

h5_group = h5py.File("demo.h5", mode="w")
write_elem(h5_group, "X", X, dataset_kwargs={"compression": "lzf"})
X_h5 = sparse_dataset(h5_group["X"])

# randomized indices
inds = np.random.choice(X_zarr.shape[0], 100, replace=False)
inds.sort()

mask = np.zeros(X_zarr.shape[0], dtype=bool)
for i in range(0, len(inds) - 1, 2):
    mask[inds[i]:inds[i+1]] = True

# non-random indices, with alternating one false and n true
def make_alternating_mask(n):
    mask_alternating = np.zeros(X_zarr.shape[0], dtype=bool)
    for i in range(n):
        mask_alternating[i::(n + 1)] = True     
    return mask_alternating
```

Once you have this, I would set the following in order to use `make_alternating_mask` with different size `num_contiguous` contiguous slices (as opposed to random indices in `mask`):
```python
num_contiguous = 10
```

You can then profile different use cases with `X_zarr` and `X_h5`, using `np.where` on the mask to trigger "old behavior."

For example,
```python
 %prun -s cumtime X_zarr[make_alternating_mask(num_contiguous)]
```
uses the "new" behavior because `num_contiguous=10>7`, the cutoff point where the optimization is faster and
```python
 %prun -s cumtime X_zarr[np.where(make_alternating_mask(num_contiguous))]
```
 yields the old behavior.  For me, the first one is orders of magnitude faster (due to, it appears, many less `zarr` accesses).  A quick "timing" check can also be performed for different values of `num_contiguous`

```python
def timings(num_contiguous):
    print('****Proposed solution****')
    print('-------------------------')
    print('Zarr, random indices')
    print('-------------------------')
    %time X_zarr[mask]
    print('-------------------------')
    print('Zarr, alternating mask with size ', num_contiguous, ' slices')
    print('-------------------------')
    %time X_zarr[make_alternating_mask(num_contiguous)]
    print('\n****Old behavior****') # achieved using integer indices
    print('-------------------------')
    print('Zarr, random indices')
    print('-------------------------')
    %time X_zarr[np.where(mask)[0]]
    print('-------------------------')
    print('Zarr, alternating mask with size ', num_contiguous, ' slices')
    print('-------------------------')
    %time X_zarr[np.where(make_alternating_mask(num_contiguous))[0]]

    print('\n****Proposed solution****')
    print('-------------------------')
    print('h5, random indices')
    print('-------------------------')
    %time X_h5[mask]
    print('-------------------------')
    print('h5, alternating mask with size ', num_contiguous, ' slices')
    print('-------------------------')
    %time X_h5[make_alternating_mask(num_contiguous)]
    print('\n****Old behavior****') # achieved using integer indices
    print('-------------------------')
    print('h5, random indices')
    print('-------------------------')
    %time X_h5[np.where(mask)[0]]
    print('-------------------------')
    print('h5, alternating mask with size ', num_contiguous, ' slices')
    print('-------------------------')
    %time X_h5[np.where(make_alternating_mask(num_contiguous))[0]]
```


- [ ] Addresses the `boolean` type case in #1224
- [ ] Tests added
- [ ] Release note added (or unnecessary)
