### PR TITLE
Allow for specifying a tensor device in AnnLoader

### DIFF
--- a/anndata/experimental/pytorch/_annloader.py
+++ b/anndata/experimental/pytorch/_annloader.py
@@ -57,14 +57,14 @@ class BatchIndexSampler(Sampler):
 
 def default_converter(arr, device, pin_memory):
     if isinstance(arr, torch.Tensor):
-        if device != "cpu":
+        if device is not None:
             arr = arr.to(device)
         elif pin_memory:
             arr = arr.pin_memory()
     elif arr.dtype.name != "category" and np.issubdtype(arr.dtype, np.number):
         if issparse(arr):
             arr = arr.toarray()
-        if device != "cpu":
+        if device is not None:
             arr = torch.tensor(arr, device=device)
         else:
             arr = torch.tensor(arr)

--- a/docs/release-notes/0.10.4.md
+++ b/docs/release-notes/0.10.4.md
@@ -1,5 +1,9 @@
 ### 0.10.4 {small}`the future`
 
+```{rubric} New features
+```
+* `AnnLoader` now accepts a `device` argument to specify the device to load the data to {pr}`1240` {user}`austinv11`
+
 ```{rubric} Bugfix
 ```
 * Only try to use `Categorical.map(na_action=…)` in actually supported Pandas ≥2.1 {pr}`1226` {user}`flying-sheep`
@@ -10,3 +14,7 @@
 
 ```{rubric} Performance
 ```
+
+```{rubric} Deprecations
+```
+* `AnnLoader(use_cuda=…)` is deprecated in favour of `AnnLoader(device=…)` {pr}`1240` {user}`austinv11


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Currently AnnLoader only supports transferring tensors to cuda devices. However, PyTorch as of late has much improved its support of other devices such as mps (Mac GPUs) and XLA (Google TPUs). So I added a device argument that is more semantically similar to other PyTorch APIs to defer to the user to decide which accelerator device (if any) to load the data onto.

- [x] Closes N/A
- [ ] Tests added: There are currently no tests for AnnLoader. So I am not sure how to add tests for this.
- [x] Release note added (or unnecessary)
