### PR TITLE
(fix): index check for newer `numpy` versions in `sparse_dataset`

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -354,7 +354,7 @@ class BaseCompressedSparseDataset(ABC):
     def _normalize_index(
         self, index: Index | tuple[()]
     ) -> tuple[np.ndarray, np.ndarray]:
-        if index == ():
+        if isinstance(index, tuple) and not len(index):
             index = slice(None)
         row, col = unpack_index(index)
         if all(isinstance(x, cabc.Iterable) for x in (row, col)):

--- a/anndata/tests/test_backed_sparse.py
+++ b/anndata/tests/test_backed_sparse.py
@@ -91,8 +91,8 @@ def test_backed_indexing(
     assert_equal(csr_mem[obs_idx, var_idx].X, csr_disk[obs_idx, var_idx].X)
     assert_equal(csr_mem[obs_idx, var_idx].X, csc_disk[obs_idx, var_idx].X)
     assert_equal(csr_mem[obs_idx, :].X, dense_disk[obs_idx, :].X)
-    assert_equal(csr_mem[obs_idx].X, dense_disk[obs_idx].X)
-    assert_equal(csr_mem[:, var_idx].X, dense_disk[:, var_idx].X)()
+    assert_equal(csr_mem[obs_idx].X, csr_disk[obs_idx].X)
+    assert_equal(csr_mem[:, var_idx].X, dense_disk[:, var_idx].X)
 
 
 @pytest.mark.parametrize(

--- a/anndata/tests/test_backed_sparse.py
+++ b/anndata/tests/test_backed_sparse.py
@@ -91,7 +91,8 @@ def test_backed_indexing(
     assert_equal(csr_mem[obs_idx, var_idx].X, csr_disk[obs_idx, var_idx].X)
     assert_equal(csr_mem[obs_idx, var_idx].X, csc_disk[obs_idx, var_idx].X)
     assert_equal(csr_mem[obs_idx, :].X, dense_disk[obs_idx, :].X)
-    assert_equal(csr_mem[:, var_idx].X, dense_disk[:, var_idx].X)
+    assert_equal(csr_mem[obs_idx].X, dense_disk[obs_idx].X)
+    assert_equal(csr_mem[:, var_idx].X, dense_disk[:, var_idx].X)()
 
 
 @pytest.mark.parametrize(

--- a/docs/release-notes/0.10.4.md
+++ b/docs/release-notes/0.10.4.md
@@ -5,6 +5,7 @@
 * Only try to use `Categorical.map(na_action=…)` in actually supported Pandas ≥2.1 {pr}`1226` {user}`flying-sheep`
 * `AnnData.__sizeof__()` support for backed datasets {pr}`1230` {user}`Neah-Ko`
 * `adata[:, []]` now returns an `AnnData` object empty on the appropriate dimensions instead of erroring {pr}`1243` {user}`ilan-gold`
+* `adata.X[mask]` works in newer `numpy` versions when `X` is `backed` {pr}`1255` {user}`ilan-gold`
 
 ```{rubric} Documentation
 ```


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
Also, I checked that this pattern `== ()` does not appear elsewhere for things that shouldn't be doing this sort of comparison.

- [x] Closes #1254
- [x] Tests added
- [x] Release note added (or unnecessary)
