### PR TITLE
Skip type checking blocks when measuring coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: prettier
         exclude_types:
           - markdown
+        language_version: 21.5.0
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,11 @@ version-file = "anndata/_version.py"
 source = ["anndata"]
 omit = ["anndata/_version.py", "**/test_*.py"]
 
+[tool.coverage.report]
+exclude_also = [
+    "if TYPE_CHECKING:",
+]
+
 [tool.pytest.ini_options]
 addopts = [
     "--strict-markers",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

This makes the coverage diffs less noisy since it doesn't measure new type checking as new missing lines. If we include type checking as part of the test suite in future it's possible this can be removed.

Also specifies node version for prettier pre-commit because it's broken on my system due to some node shenanigans.