### PR TITLE
Fix test compatibility with Pytest 8

### DIFF
--- a/anndata/tests/test_io_warnings.py
+++ b/anndata/tests/test_io_warnings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import warnings
 from importlib.util import find_spec
 from pathlib import Path
@@ -14,9 +15,25 @@ from anndata.tests.helpers import gen_adata
 def test_old_format_warning_thrown():
     import scanpy as sc
 
-    with pytest.warns(ad._warnings.OldFormatWarning):
-        pth = Path(sc.datasets.__file__).parent / "10x_pbmc68k_reduced.h5ad"
+    pth = Path(sc.datasets.__file__).parent / "10x_pbmc68k_reduced.h5ad"
+    # TODO: with Pytest 8, all this can be a
+    #       `with pytest.warns(...), pytest.warns(...):`
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always", ad.OldFormatWarning)
+        warnings.simplefilter("always", FutureWarning)
         ad.read_h5ad(pth)
+
+    assert any(issubclass(w.category, ad.OldFormatWarning) for w in record), [
+        w.message for w in record if not issubclass(w.category, FutureWarning)
+    ]
+    assert any(
+        issubclass(w.category, FutureWarning)
+        and re.match(
+            r"Moving element from \.uns\['neighbors']\['distances'] to \.obsp\['distances']\.",
+            str(w.message),
+        )
+        for w in record
+    ), [w.message for w in record if not issubclass(w.category, ad.OldFormatWarning)]
 
 
 def test_old_format_warning_not_thrown(tmp_path):

--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _suppress_env_for_doctests(request: pytest.FixtureRequest) -> None:
-    if not isinstance(request.node, pytest.DoctestItem):
+    if isinstance(request.node, pytest.DoctestItem):
         request.getfixturevalue("_doctest_env")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ doc = [
 ]
 test = [
     "loompy>=3.0.5",
-    "pytest >=6.0, !=8.0.0rc1", # https://github.com/pytest-dev/pytest/issues/11759
+    "pytest >=6.0",
     "pytest-cov>=2.10",
     "zarr",
     "matplotlib",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes N/A
- [x] Tests added
- [x] Release note added (or unnecessary)

See https://github.com/pytest-dev/pytest/issues/11759

TODO:

- [x] make sure the PreRelease test run actually uses Pytest 8