### PR TITLE
Fix uns merge 3d

### DIFF
--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -155,7 +155,7 @@ def equal_array(a, b) -> bool:
     else:
         # For non numeric types use pandas to compare
         # Reshapeing allows us to compare inputs with >2 dimensions
-        return equal(pd.DataFrame(a.reshape(-1)), pd.DataFrame(asarray(b).reshape(-1)))
+        return equal(pd.DataFrame(a.reshape(-1)), pd.DataFrame(b.reshape(-1)))
 
 
 @equal.register(CupyArray)

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -141,21 +141,13 @@ def equal_dask_array(a, b) -> bool:
 
 @equal.register(np.ndarray)
 def equal_array(a, b) -> bool:
-    def _is_numeric_or_bool(x) -> bool:
-        """array_equal with equal_nan=True only works for these types."""
-        return np.issubdtype(x, np.number) or np.issubdtype(x, np.bool_)
-
+    # Reshaping allows us to compare inputs with >2 dimensions
+    # We cast to pandas since it will still work with non-numeric types
     b = asarray(b)
-
     if a.shape != b.shape:
         return False
 
-    if _is_numeric_or_bool(a.dtype) and _is_numeric_or_bool(b.dtype):
-        return np.array_equal(a, b, equal_nan=True)
-    else:
-        # For non numeric types use pandas to compare
-        # Reshapeing allows us to compare inputs with >2 dimensions
-        return equal(pd.DataFrame(a.reshape(-1)), pd.DataFrame(b.reshape(-1)))
+    return equal(pd.DataFrame(a.reshape(-1)), pd.DataFrame(b.reshape(-1)))
 
 
 @equal.register(CupyArray)

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -141,7 +141,21 @@ def equal_dask_array(a, b) -> bool:
 
 @equal.register(np.ndarray)
 def equal_array(a, b) -> bool:
-    return equal(pd.DataFrame(a), pd.DataFrame(asarray(b)))
+    def _is_numeric_or_bool(x) -> bool:
+        """array_equal with equal_nan=True only works for these types."""
+        return np.issubdtype(x, np.number) or np.issubdtype(x, np.bool_)
+
+    b = asarray(b)
+
+    if a.shape != b.shape:
+        return False
+
+    if _is_numeric_or_bool(a.dtype) and _is_numeric_or_bool(b.dtype):
+        return np.array_equal(a, b, equal_nan=True)
+    else:
+        # For non numeric types use pandas to compare
+        # Reshapeing allows us to compare inputs with >2 dimensions
+        return equal(pd.DataFrame(a.reshape(-1)), pd.DataFrame(asarray(b).reshape(-1)))
 
 
 @equal.register(CupyArray)

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -413,7 +413,11 @@ def assert_equal_ndarray(a, b, exact=False, elem_name=None):
         and len(a.dtype) > 1
         and len(b.dtype) > 0
     ):
-        assert_equal(pd.DataFrame(a), pd.DataFrame(b), exact, elem_name)
+        # Reshaping to allow >2d arrays
+        assert a.shape == b.shape, format_msg(elem_name)
+        assert_equal(
+            pd.DataFrame(a.reshape(-1)), pd.DataFrame(b.reshape(-1)), exact, elem_name
+        )
     else:
         assert np.all(a == b), format_msg(elem_name)
 

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -28,6 +28,7 @@ from anndata.tests.helpers import (
     as_dense_dask_array,
     assert_equal,
     gen_adata,
+    gen_vstr_recarray,
 )
 from anndata.utils import asarray
 
@@ -1018,6 +1019,15 @@ def gen_something(n):
     return np.random.choice(options)(n)
 
 
+def gen_3d_numeric_array(n):
+    return np.random.randn(n, n, n)
+
+
+def gen_3d_recarray(_):
+    # Ignoring n as it can get quite slow
+    return gen_vstr_recarray(8, 3).reshape(2, 2, 2)
+
+
 def gen_concat_params(unss, compat2result):
     value_generators = [
         lambda x: x,
@@ -1026,6 +1036,8 @@ def gen_concat_params(unss, compat2result):
         gen_list,
         gen_sparse,
         gen_something,
+        gen_3d_numeric_array,
+        gen_3d_recarray,
     ]
     for gen, (mode, result) in product(value_generators, compat2result.items()):
         yield pytest.param(unss, mode, result, gen)
@@ -1083,16 +1095,6 @@ def gen_concat_params(unss, compat2result):
         gen_concat_params(
             [{"a": 1} for i in range(10)] + [{"a": 2}],
             {None: {}, "first": {"a": 1}, "unique": {}, "same": {}, "only": {}},
-        ),
-        gen_concat_params(  # https://github.com/scverse/anndata/issues/1300
-            [{"a": np.ones((3, 3, 3))} for _ in range(2)],
-            {
-                None: {},
-                "first": {"a": np.ones((3, 3, 3))},
-                "unique": {"a": np.ones((3, 3, 3))},
-                "same": {"a": np.ones((3, 3, 3))},
-                "only": {},
-            },
         ),
     ),
 )

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -1084,6 +1084,16 @@ def gen_concat_params(unss, compat2result):
             [{"a": 1} for i in range(10)] + [{"a": 2}],
             {None: {}, "first": {"a": 1}, "unique": {}, "same": {}, "only": {}},
         ),
+        gen_concat_params(  # https://github.com/scverse/anndata/issues/1300
+            [{"a": np.ones((3, 3, 3))} for _ in range(2)],
+            {
+                None: {},
+                "first": {"a": np.ones((3, 3, 3))},
+                "unique": {"a": np.ones((3, 3, 3))},
+                "same": {"a": np.ones((3, 3, 3))},
+                "only": {},
+            },
+        ),
     ),
 )
 def test_concatenate_uns(unss, merge_strategy, result, value_gen):

--- a/docs/release-notes/0.10.5.md
+++ b/docs/release-notes/0.10.5.md
@@ -4,6 +4,7 @@
 ```
 
 * Fix outer concatenation along variables when only a subset of objects had an entry in layers {pr}`1291` {user}`ivirshup`
+* Fix comparison of >2d arrays in `uns` during concatenation {pr}`1300` {user}`ivirshup`
 
 ```{rubric} Documentation
 ```


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1300
- [x] Tests added
  - Added tests for numeric and record 3d arrays
- [x] Release note added (or unnecessary)


This was a little harder than expected due to our need to handle non-numeric dtypes. We were using dataframe comparisons to handle that.

Now we are using numpy when able, but switching to dataframes constructed from reshaped arrays when we can't.