### PR TITLE
Remove unused and wrong test

### DIFF
--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -526,15 +526,9 @@ def test_write_csv_view(typ, tmp_path):
             marks=pytest.mark.xfail(reason="Loom can’t handle 0×0 matrices"),
         ),
         pytest.param(ad.read_zarr, ad._io.write_zarr, "test_empty.zarr"),
-        pytest.param(
-            ad.read_zarr,
-            ad._io.write_zarr,
-            "test_empty.zip",
-            marks=pytest.mark.xfail(reason="Zarr zip storage doesn’t seem to work…"),
-        ),
     ],
 )
-def test_readwrite_hdf5_empty(read, write, name, tmp_path):
+def test_readwrite_empty(read, write, name, tmp_path):
     adata = ad.AnnData(uns=dict(empty=np.array([], dtype=float)))
     write(tmp_path / name, adata)
     ad_read = read(tmp_path / name)


### PR DESCRIPTION
Removed a test case that threw a bunch of warnings, didn't work (was xfailed), and isn't expected to work (we don't dispatch the `store` type for `write_zarr` based on the path).