### PR TITLE
(fix): `SparseDataset` handles boolean mask containing one group

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -262,6 +262,8 @@ def get_compressed_vectors_for_slices(
         total = (sel[0] - indptr_sels[i][-1]) + total
         offsets.append(total)
     start_indptr = indptr_sels[0] - offsets[0]
+    if len(slices) < 2:  # there is only one slice so no need to concatenate
+        return data, indices, start_indptr
     end_indptr = np.concatenate(
         [s[1:] - offsets[i + 1] for i, s in enumerate(indptr_sels[1:])]
     )

--- a/anndata/tests/test_backed_sparse.py
+++ b/anndata/tests/test_backed_sparse.py
@@ -115,6 +115,11 @@ def test_consecutive_bool(
         return mask_alternating
 
     alternating_mask = make_alternating_mask(10)
+    one_group_mask = np.zeros(csr_disk.shape[0], dtype=bool)
+    one_group_mask[csr_disk.shape[0] // 4 : csr_disk.shape[0] // 2] = True
+
+    one_elem_mask = np.zeros(csr_disk.shape[0], dtype=bool)
+    one_elem_mask[csr_disk.shape[0] // 4] = True
 
     # indexing needs to be on `X` directly to trigger the optimization.
     # `_normalize_indices`, which is used by `AnnData`, converts bools to ints with `np.where`
@@ -124,9 +129,20 @@ def test_consecutive_bool(
     assert_equal(
         csc_disk.X[:, alternating_mask], csc_disk.X[:, np.where(alternating_mask)[0]]
     )
+
     assert_equal(csr_disk.X[randomized_mask, :], csr_disk.X[np.where(randomized_mask)])
     assert_equal(
         csc_disk.X[:, randomized_mask], csc_disk.X[:, np.where(randomized_mask)[0]]
+    )
+
+    assert_equal(csr_disk.X[one_group_mask, :], csr_disk.X[np.where(one_group_mask)])
+    assert_equal(
+        csc_disk.X[:, one_group_mask], csc_disk.X[:, np.where(one_group_mask)[0]]
+    )
+
+    assert_equal(csr_disk.X[one_elem_mask, :], csr_disk.X[np.where(one_elem_mask)])
+    assert_equal(
+        csc_disk.X[:, one_elem_mask], csc_disk.X[:, np.where(one_elem_mask)[0]]
     )
 
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1316
- [x] Tests added
- [x] Release note added
