### PR TITLE
[WIP] adding an option to read file from s3

### DIFF
--- a/anndata/_core/file_backing.py
+++ b/anndata/_core/file_backing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import h5py
+import remfile
 
 from ..compat import AwkArray, DaskArray, ZarrArray, ZarrGroup
 from .sparse_dataset import BaseCompressedSparseDataset
@@ -65,7 +66,9 @@ class AnnDataFileManager:
 
     @filename.setter
     def filename(self, filename: PathLike | None):
-        self._filename = None if filename is None else Path(filename)
+        self._filename = None if filename is None \
+            else filename if isinstance(filename, remfile.RemFile.RemFile) \
+            else Path(filename)
 
     def open(
         self,

--- a/anndata/_core/file_backing.py
+++ b/anndata/_core/file_backing.py
@@ -66,9 +66,13 @@ class AnnDataFileManager:
 
     @filename.setter
     def filename(self, filename: PathLike | None):
-        self._filename = None if filename is None \
-            else filename if isinstance(filename, remfile.RemFile.RemFile) \
+        self._filename = (
+            None
+            if filename is None
+            else filename
+            if isinstance(filename, remfile.RemFile.RemFile)
             else Path(filename)
+        )
 
     def open(
         self,

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -797,3 +797,15 @@ def test_io_dtype(tmp_path, diskfmt, dtype):
     curr = read(pth)
 
     assert curr.X.dtype == dtype
+
+
+needs_remfile = pytest.mark.skipif(not find_spec("remfile"), reason="remfile is not installed")
+
+@needs_remfile
+def test_read_s3_remfile():
+    import remfile
+    # TODO: change to a different datafile?
+    url_had = "https://allen-brain-cell-atlas.s3.us-west-2.amazonaws.com/expression_matrices/WMB-10Xv2/20230630/WMB-10Xv2-TH-log2.h5ad"
+    file_had = remfile.File(url_had)
+    data = ad.read_h5ad(file_had, backed='r')
+    assert data.X.shape == (131212, 32285)

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -799,13 +799,17 @@ def test_io_dtype(tmp_path, diskfmt, dtype):
     assert curr.X.dtype == dtype
 
 
-needs_remfile = pytest.mark.skipif(not find_spec("remfile"), reason="remfile is not installed")
+needs_remfile = pytest.mark.skipif(
+    not find_spec("remfile"), reason="remfile is not installed"
+)
+
 
 @needs_remfile
 def test_read_s3_remfile():
     import remfile
+
     # TODO: change to a different datafile?
     url_had = "https://allen-brain-cell-atlas.s3.us-west-2.amazonaws.com/expression_matrices/WMB-10Xv2/20230630/WMB-10Xv2-TH-log2.h5ad"
     file_had = remfile.File(url_had)
-    data = ad.read_h5ad(file_had, backed='r')
+    data = ad.read_h5ad(file_had, backed="r")
     assert data.X.shape == (131212, 32285)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "numpy>=1.16.5",                         # required by pandas 1.x
     "scipy>1.4",
     "h5py>=3",
+    "remfile",
     "exceptiongroup; python_version<'3.11'",
     "natsort",
     "packaging>=20",


### PR DESCRIPTION
Recently I've been testing an option to access files directly from s3 using `remfile`. [remfile](https://github.com/magland/remfile/tree/main) provides a file-like object for reading a remote file over HTTP, optimized for use with h5py.

I've added a simple change to the code and a simple test that access a big file directly from s3 and is able to check the file size without reading entire content. I'd be happy to expand the tests and changes if the package maintainers say that are interested in the addition.



- [ ] Closes #634 
- [x] Tests added
- [ ] Release note added (or unnecessary)
