### PR TITLE
Fix boolean subsetting with plain list

### DIFF
--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -80,11 +80,16 @@ def _normalize_index(
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)
         if not isinstance(indexer, (np.ndarray, pd.Index)):
-            dtype = "int"
-            if (
-                all(isinstance(x, str) for x in indexer) and len(indexer) > 0
-            ):  # if not all, but any, then dtype=int will cause an error
-                dtype = "object"
+            # Likely a plain list indexer
+            dtype = int
+            if len(indexer) > 0:
+                if all(isinstance(x, bool) for x in indexer):
+                    # For boolean indexers, indexer length must match axes length,
+                    # but we cannot test here
+                    dtype = bool
+                elif all(isinstance(x, str) for x in indexer):
+                    # if not all, but any, then dtype=int will cause an error
+                    dtype = object
             try:
                 indexer = np.array(indexer, dtype=dtype)
             except ValueError as e:

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -273,6 +273,10 @@ def gen_adata(
     return adata
 
 
+def list_bool_subset(index, min_size=2):
+    return array_bool_subset(index, min_size=min_size).tolist()
+
+
 def array_bool_subset(index, min_size=2):
     b = np.zeros(len(index), dtype=bool)
     selected = np.random.choice(
@@ -297,6 +301,10 @@ def spmatrix_bool_subset(index, min_size=2):
     return sparse.csr_matrix(
         array_bool_subset(index, min_size=min_size).reshape(len(index), 1)
     )
+
+
+def list_int_subset(index, min_size=2):
+    return array_subset(index, min_size=min_size).tolist()
 
 
 def array_subset(index, min_size=2):
@@ -339,6 +347,8 @@ def single_subset(index):
         array_subset,
         slice_subset,
         single_subset,
+        list_int_subset,
+        list_bool_subset,
         array_int_subset,
         array_bool_subset,
         matrix_bool_subset,


### PR DESCRIPTION
This fixes the issue that a plain boolean list indexer was always converted to integers and thus selected no more than the first two rows with many duplicates. This was caused by fix #1243 handling only the special case of string list, not boolean list.

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1331
- [x] Tests added
- [ ] Release note added (or unnecessary)
