### PR TITLE
Error on shared column names when writing

### DIFF
--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -300,3 +300,32 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     with read_func(pth) as z:
         expected = ad.read_zarr(z["table/table"])
     assert_equal(adata, expected)
+
+
+def test_dataframe_column_uniqueness(store):
+    repeated_cols = pd.DataFrame(np.ones((3, 2)), columns=["a", "a"])
+
+    with pytest_8_raises(
+        ValueError,
+        match=r"Found repeated column names: \['a'\]\. Column names must be unique\.",
+    ):
+        write_elem(store, "repeated_cols", repeated_cols)
+
+    index_shares_col_name = pd.DataFrame(
+        {"col_name": [1, 2, 3]}, index=pd.Index([1, 3, 2], name="col_name")
+    )
+
+    with pytest_8_raises(
+        ValueError,
+        match=r"DataFrame\.index\.name \('col_name'\) is also used by a column whose values are different\.",
+    ):
+        write_elem(store, "index_shares_col_name", index_shares_col_name)
+
+    index_shared_okay = pd.DataFrame(
+        {"col_name": [1, 2, 3]}, index=pd.Index([1, 2, 3], name="col_name")
+    )
+
+    write_elem(store, "index_shared_okay", index_shared_okay)
+    result = read_elem(store["index_shared_okay"])
+
+    assert_equal(result, index_shared_okay)

--- a/docs/release-notes/0.10.6.md
+++ b/docs/release-notes/0.10.6.md
@@ -4,6 +4,7 @@
 ```
 
 * Defer import of zarr in test helpers, as scanpy CI job relies on them {pr}`1343` {user}`ilan-gold`
+* Writing a dataframe with non-unique column names now throws an error, instead of silently overwriting {pr}`1335` {user}`ivirshup`
 
 ```{rubric} Documentation
 ```


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #884
- [x] Tests added
- [x] Release note added (or unnecessary)
