### PR TITLE
Write dask arrays with 64bit indptr

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -474,9 +474,9 @@ class BaseCompressedSparseDataset(ABC):
                 f"Matrices must have same format. Currently are "
                 f"{self.format!r} and {get_format(sparse_matrix)!r}"
             )
-        indptr_offset = self.group["indptr"][-1]
-        if indptr_offset.dtype == np.int32:
-            new_nnz = int(indptr_offset) + int(sparse_matrix.indptr[-1])
+        indptr_offset = len(self.group["indices"])
+        if self.group["indptr"].dtype == np.int32:
+            new_nnz = indptr_offset + len(sparse_matrix.indices)
             if new_nnz >= np.iinfo(np.int32).max:
                 raise OverflowError(
                     "This array was written with a 32 bit intptr, but is now large "

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -476,7 +476,6 @@ class BaseCompressedSparseDataset(ABC):
             )
         indptr_offset = self.group["indptr"][-1]
         if indptr_offset.dtype == np.int32:
-            # This is difficult to test without requiring ~ 16GB of memory
             new_nnz = int(indptr_offset) + int(sparse_matrix.indptr[-1])
             if new_nnz >= np.iinfo(np.int32).max:
                 raise OverflowError(

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -479,7 +479,7 @@ class BaseCompressedSparseDataset(ABC):
             # This is difficult to test without requiring ~ 16GB of memory
             new_nnz = int(indptr_offset) + int(sparse_matrix.indptr[-1])
             if new_nnz >= np.iinfo(np.int32).max:
-                raise ValueError(
+                raise OverflowError(
                     "This array was written with a 32 bit intptr, but is now large "
                     "enough to require 64 bit values. Please recreate the array with "
                     "a 64 bit indptr."

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -474,6 +474,16 @@ class BaseCompressedSparseDataset(ABC):
                 f"Matrices must have same format. Currently are "
                 f"{self.format!r} and {get_format(sparse_matrix)!r}"
             )
+        indptr_offset = self.group["indptr"][-1]
+        if indptr_offset.dtype == np.int32:
+            # This is difficult to test without requiring ~ 16GB of memory
+            new_nnz = int(indptr_offset) + int(sparse_matrix.indptr[-1])
+            if new_nnz >= np.iinfo(np.int32).max:
+                raise ValueError(
+                    "This array was written with a 32 bit intptr, but is now large "
+                    "enough to require 64 bit values. Please recreate the array with "
+                    "a 64 bit indptr."
+                )
 
         # shape
         if self.format == "csr":
@@ -501,11 +511,13 @@ class BaseCompressedSparseDataset(ABC):
         # indptr
         indptr = self.group["indptr"]
         orig_data_size = indptr.shape[0]
-        append_offset = indptr[-1]
         indptr.resize((orig_data_size + sparse_matrix.indptr.shape[0] - 1,))
         indptr[orig_data_size:] = (
-            sparse_matrix.indptr[1:].astype(np.int64) + append_offset
+            sparse_matrix.indptr[1:].astype(np.int64) + indptr_offset
         )
+        # Clear cached property
+        if hasattr(self, "indptr"):
+            del self.indptr
 
         # indices
         indices = self.group["indices"]

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -563,11 +563,12 @@ def write_sparse_dataset(f, k, elem, _writer, dataset_kwargs=MappingProxyType({}
 def write_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
     sparse_format = elem._meta.format
 
-    def with_int64_indptr(x):
-        x.indptr = x.indptr.astype(np.int64)
+    def as_int64_indices(x):
+        x.indptr = x.indptr.astype(np.int64, copy=False)
+        x.indices = x.indices.astype(np.int64, copy=False)
         return x
 
-    elem = elem.map_blocks(with_int64_indptr, dtype=elem.dtype)
+    # elem = elem.map_blocks(with_int64_indptr, dtype=elem.dtype)
     if sparse_format == "csr":
         axis = 0
     elif sparse_format == "csc":
@@ -589,7 +590,7 @@ def write_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
     _writer.write_elem(
         f,
         k,
-        elem[chunk_slice(chunk_start, chunk_stop)].compute(),
+        as_int64_indices(elem[chunk_slice(chunk_start, chunk_stop)].compute()),
         dataset_kwargs=dataset_kwargs,
     )
 

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -568,7 +568,6 @@ def write_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
         x.indices = x.indices.astype(np.int64, copy=False)
         return x
 
-    # elem = elem.map_blocks(with_int64_indptr, dtype=elem.dtype)
     if sparse_format == "csr":
         axis = 0
     elif sparse_format == "csc":

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -562,6 +562,12 @@ def write_sparse_dataset(f, k, elem, _writer, dataset_kwargs=MappingProxyType({}
 )
 def write_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
     sparse_format = elem._meta.format
+
+    def with_int64_indptr(x):
+        x.indptr = x.indptr.astype(np.int64)
+        return x
+
+    elem = elem.map_blocks(with_int64_indptr, dtype=elem.dtype)
     if sparse_format == "csr":
         axis = 0
     elif sparse_format == "csc":

--- a/anndata/tests/test_backed_sparse.py
+++ b/anndata/tests/test_backed_sparse.py
@@ -459,5 +459,8 @@ def test_append_overflow_check(group_fn, tmpdir):
     write_elem(group, "mtx", orig_mtx)
     backed = sparse_dataset(group["mtx"])
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(
+        OverflowError,
+        match=r"This array was written with a 32 bit intptr, but is now large.*",
+    ):
         backed.append(new_mtx)

--- a/anndata/tests/test_backed_sparse.py
+++ b/anndata/tests/test_backed_sparse.py
@@ -459,8 +459,14 @@ def test_append_overflow_check(group_fn, tmpdir):
     write_elem(group, "mtx", orig_mtx)
     backed = sparse_dataset(group["mtx"])
 
+    # Checking for correct caching behaviour
+    backed.indptr
+
     with pytest.raises(
         OverflowError,
         match=r"This array was written with a 32 bit intptr, but is now large.*",
     ):
         backed.append(new_mtx)
+
+    # Check for any modification
+    assert_equal(backed, orig_mtx)

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -15,7 +15,7 @@ from scipy import sparse
 import anndata as ad
 from anndata._io.specs import _REGISTRY, IOSpec, get_spec, read_elem, write_elem
 from anndata._io.specs.registry import IORegistryError
-from anndata.compat import H5Group, ZarrGroup, _read_attr
+from anndata.compat import DaskArray, H5Group, ZarrGroup, _read_attr
 from anndata.tests.helpers import (
     as_cupy_type,
     assert_equal,
@@ -300,3 +300,71 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     with read_func(pth) as z:
         expected = ad.read_zarr(z["table/table"])
     assert_equal(adata, expected)
+
+
+# Test dask sparse array IO above int32 size limit
+
+
+class CSRCallable:
+    """Dummy class to bypass dask checks"""
+
+    def __new__(cls, shape, dtype) -> sparse.csr_matrix:
+        if len(shape) == 0:
+            shape = (0, 0)
+        if len(shape) == 1:
+            shape = (shape[0], 0)
+        elif len(shape) == 2:
+            pass
+        else:
+            raise ValueError(shape)
+        return sparse.csr_matrix(shape, dtype=dtype)
+
+
+def make_dask_chunk(
+    x: ad.experimental.SparseDataset, start: int, end: int
+) -> DaskArray:
+    import dask.array as da
+    from dask import delayed
+
+    def take_slice(x, idx):
+        return x[idx]
+
+    return da.from_delayed(
+        delayed(take_slice)(x, slice(start, end)),
+        dtype=x.dtype,
+        shape=(end - start, x.shape[1]),
+        meta=CSRCallable,
+    )
+
+
+def sparse_dataset_as_dask(x, stride: int):
+    import dask.array as da
+
+    n_chunks, rem = divmod(x.shape[0], stride)
+
+    chunks = []
+    cur_pos = 0
+    for i in range(n_chunks):
+        chunks.append(make_dask_chunk(x, cur_pos, cur_pos + stride))
+        cur_pos += stride
+    if rem:
+        chunks.append(make_dask_chunk(x, cur_pos, x.shape[0]))
+
+    return da.concatenate(chunks, axis=0)
+
+
+def test_write_big_dask():
+    import dask.array as da
+
+    z = zarr.group()
+    # This needs to be something easily compressible to avoid writing a huge file
+    dense_dask = da.ones(
+        (np.iinfo(np.int32).max + 1, 1), chunks=(10_000_000, 1), dtype=bool
+    )
+    sparse_dask = dense_dask.map_blocks(sparse.csr_matrix)
+    write_elem(z, "sparse", sparse_dask)
+    from_disk = sparse_dataset_as_dask(
+        ad.experimental.sparse_dataset(z["sparse"]), 10_000_000
+    )
+    assert_equal(from_disk[-1, :].compute(), sparse_dask[-1, :].compute())
+    # assert_equal(from_disk, sparse_dask)  # Currently reads everything into memory before comparing

--- a/docs/release-notes/0.10.6.md
+++ b/docs/release-notes/0.10.6.md
@@ -7,6 +7,7 @@
 * Writing a dataframe with non-unique column names now throws an error, instead of silently overwriting {pr}`1335` {user}`ivirshup`
 * Bring optimization from {pr}`1233` to indexing on the whole `AnnData` object, not just the sparse dataset itself {pr}`1365` {user}`ilan-gold`
 * Fix mean slice length checking to use improved performance when indexing backed sparse matrices with boolean masks along their major axis {pr}`1366` {user}`ilan-gold`
+* Fixed overflow occurring when writing dask arrays with sparse chunks by always writing dask arrays with 64 bit indptr and indices, and adding an overflow check to `.append` method of sparse on disk structures {pr}`1348` {user}`ivirshup`
 
 ```{rubric} Documentation
 ```


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Alternative to #1262 with a test

TODO:

- [x] Make sure `SparseDataset.append` throws as error if overflow would happen
- [x] Test that dask arrays always write 64 bit
- [x] Remove current test (since it will crash CI due to high memory usage)

---

- [x] Closes https://github.com/scverse/anndata/issues/1261, https://github.com/scverse/anndata/issues/1356
- [x] Tests added
- [x] Release note added (or unnecessary)
