### PR TITLE
Turn on code cov patch annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,6 @@ coverage:
       default:
         # Require 1% coverage, i.e., always succeed
         target: 1
-    patch: false
     changes: false
 
 comment:


### PR DESCRIPTION
So we can view annotations on what lines got missed in a PR

See also:

* https://github.com/scverse/scanpy/pull/2848
* https://github.com/scverse/scanpy/pull/2847