### PR TITLE
Fix BaseCompressedSparseDataset.group type annotation

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -346,7 +346,7 @@ class BaseCompressedSparseDataset(ABC):
     """Shape of the matrix."""
 
     @property
-    def group(self):
+    def group(self) -> GroupStorageType:
         """The group underlying the backed matrix."""
         return self._group
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,9 @@ nitpick_ignore = [
         for cls in "Layers AxisArrays PairwiseArrays".split()
         for kind in ["", "View"]
     ],
+    # TODO: sphinx’ builtin autodoc.typehints extension isn’t handled by `qualname_overrides` yet
+    # https://github.com/theislab/scanpydoc/issues/140
+    ("py:class", "h5py._hl.group.Group"),
 ]
 suppress_warnings = [
     "ref.citation",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1414
- [x] Tests added
- [x] Release note added (or unnecessary)

Workaround will be unnecessary once https://github.com/theislab/scanpydoc/issues/140 is fixed.