### PR TITLE
Handle numcodecs bug for encoding read-only string array

### DIFF
--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -427,6 +427,11 @@ def write_vlen_string_array_zarr(
 ):
     import numcodecs
 
+    # Workaround for https://github.com/zarr-developers/numcodecs/issues/514
+    # TODO: Warn to upgrade numcodecs if fixed
+    if not elem.flags.writeable:
+        elem = elem.copy()
+
     f.create_dataset(
         k,
         shape=elem.shape,

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -333,3 +333,13 @@ def test_dataframe_column_uniqueness(store):
     result = read_elem(store["index_shared_okay"])
 
     assert_equal(result, index_shared_okay)
+
+
+@pytest.mark.parametrize("copy_on_write", [True, False])
+def test_io_pd_cow(store, copy_on_write):
+    # https://github.com/zarr-developers/numcodecs/issues/514
+    with pd.option_context("mode.copy_on_write", copy_on_write):
+        orig = gen_adata((3, 2))
+        write_elem(store, "adata", orig)
+        from_store = read_elem(store["adata"])
+        assert_equal(orig, from_store)

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import zarr
+from packaging.version import Version
 from scipy import sparse
 
 import anndata as ad
@@ -337,6 +338,8 @@ def test_dataframe_column_uniqueness(store):
 
 @pytest.mark.parametrize("copy_on_write", [True, False])
 def test_io_pd_cow(store, copy_on_write):
+    if Version(pd.__version__) < Version("2"):
+        pytest.xfail("copy_on_write option is not available in pandas < 2")
     # https://github.com/zarr-developers/numcodecs/issues/514
     with pd.option_context("mode.copy_on_write", copy_on_write):
         orig = gen_adata((3, 2))

--- a/docs/release-notes/0.10.7.md
+++ b/docs/release-notes/0.10.7.md
@@ -1,7 +1,9 @@
-### 0.10.6 {small}`the future`
+### 0.10.7 {small}`the future`
 
 ```{rubric} Bugfix
 ```
+
+* Handle upstream `numcodecs` bug where read-only string arrays cannot be encoded {user}`ivirshup` {pr}`1421`
 
 ```{rubric} Documentation
 ```


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Workaround for:

* https://github.com/zarr-developers/numcodecs/issues/514

If and when that is resolved we should probably change the code to look more like:

```python
    # Workaround for https://github.com/zarr-developers/numcodecs/issues/514
    if Version(numcodecs.__version__) =< Version("0.12.1") and not elem.flags.writeable:
        warn(
            "Making a copy of string array as workaround for numcodecs bug, upgrade numcodecs to avoid this warning",
        )
        elem = elem.copy()
```

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary)
