### PR TITLE
(fix): use in-memory scipy sparse for non-overriden methods

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -413,6 +413,17 @@ class BaseCompressedSparseDataset(ABC):
         indices = self._normalize_index(index)
         row, col = indices
         mtx = self._to_backed()
+        row_sp_matrix_validated, col_sp_matrix_validated = mtx._validate_indices(
+            (row, col)
+        )
+
+        # Check for the overridden few methods above in our BackedSparseMatrix subclasses
+        def is_sparse_indexing_overridden(minor_indexer, major_indexer):
+            return isinstance(minor_indexer, slice) and (
+                (isinstance(major_indexer, (int, np.integer)))
+                or (isinstance(major_indexer, slice))
+                or (isinstance(major_indexer, np.ndarray) and major_indexer.ndim == 1)
+            )
 
         # Handle masked indexing along major axis
         if self.format == "csr" and np.array(row).dtype == bool:
@@ -423,6 +434,19 @@ class BaseCompressedSparseDataset(ABC):
             sub = ss.csc_matrix(
                 subset_by_major_axis_mask(mtx, col), shape=(mtx.shape[0], col.sum())
             )[row, :]
+        # read into memory data if we do not override access methods
+        elif (
+            self.format == "csc"
+            and not is_sparse_indexing_overridden(
+                row_sp_matrix_validated, col_sp_matrix_validated
+            )
+        ) or (
+            self.format == "csr"
+            and not is_sparse_indexing_overridden(
+                col_sp_matrix_validated, row_sp_matrix_validated
+            )
+        ):
+            sub = self.to_memory()[row_sp_matrix_validated, col_sp_matrix_validated]
         else:
             sub = mtx[row, col]
 

--- a/docs/release-notes/0.10.7.md
+++ b/docs/release-notes/0.10.7.md
@@ -4,6 +4,7 @@
 ```
 
 * Handle upstream `numcodecs` bug where read-only string arrays cannot be encoded {user}`ivirshup` {pr}`1421`
+* Use in-memory sparse matrix directly to fix compatibility with `scipy` `1.13` {user} `ilan-gold` {pr}`1435`
 
 ```{rubric} Documentation
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "pandas >=1.4, !=2.1.0rc0, !=2.1.2",
     "numpy>=1.23",
     # https://github.com/scverse/anndata/issues/1434
-    "scipy >1.8, <1.13.0rc1",
+    "scipy >1.8",
     "h5py>=3.1",
     "exceptiongroup; python_version<'3.11'",
     "natsort",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #1434
- [ ] Tests added
- [ ] Release note added (or unnecessary)
