### PR TITLE
lower required pytest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ doc = [
 ]
 test = [
     "loompy>=3.0.5",
-    "pytest>=8",
+    "pytest>=8.0",
     "pytest-cov>=2.10",
     "zarr",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ doc = [
 ]
 test = [
     "loompy>=3.0.5",
-    "pytest>=8.1",
+    "pytest>=8",
     "pytest-cov>=2.10",
     "zarr",
     "matplotlib",


### PR DESCRIPTION
So that we can have dev installations of scanpy and anndata in the same environment, as is often useful

See: https://github.com/scverse/scanpy/issues/2993