### PR TITLE
Dask gpu

### DIFF
--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -135,7 +135,7 @@ def equal_dask_array(a, b) -> bool:
     if isinstance(b, DaskArray):
         if tokenize(a) == tokenize(b):
             return True
-    if isinstance(a._meta, spmatrix):
+    if isinstance(a._meta, (spmatrix, CupyArray)):
         # TODO: Maybe also do this in the other case?
         return da.map_blocks(equal, a, b, drop_axis=(0, 1)).all()
     else:

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -614,6 +614,29 @@ def write_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
         disk_mtx.append(elem[chunk_slice(chunk_start, chunk_stop)].compute())
 
 
+@_REGISTRY.register_write(H5Group, (DaskArray, CupyArray), IOSpec("array", "0.2.0"))
+@_REGISTRY.register_write(ZarrGroup, (DaskArray, CupyArray), IOSpec("array", "0.2.0"))
+@_REGISTRY.register_write(
+    H5Group, (DaskArray, CupyCSRMatrix), IOSpec("csr_matrix", "0.1.0")
+)
+@_REGISTRY.register_write(
+    H5Group, (DaskArray, CupyCSCMatrix), IOSpec("csc_matrix", "0.1.0")
+)
+@_REGISTRY.register_write(
+    ZarrGroup, (DaskArray, CupyCSRMatrix), IOSpec("csr_matrix", "0.1.0")
+)
+@_REGISTRY.register_write(
+    ZarrGroup, (DaskArray, CupyCSCMatrix), IOSpec("csc_matrix", "0.1.0")
+)
+def write_cupy_dask_sparse(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
+    _writer.write_elem(
+        f,
+        k,
+        elem.map_blocks(lambda x: x.get(), dtype=elem.dtype, meta=elem._meta.get()),
+        dataset_kwargs=dataset_kwargs,
+    )
+
+
 @_REGISTRY.register_read(H5Group, IOSpec("csc_matrix", "0.1.0"))
 @_REGISTRY.register_read(H5Group, IOSpec("csr_matrix", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csc_matrix", "0.1.0"))

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -146,6 +146,14 @@ try:
     from cupyx.scipy.sparse import (
         spmatrix as CupySparseMatrix,
     )
+
+    try:
+        import dask.array as da
+
+        da.register_chunk_type(CupyCSRMatrix)
+        da.register_chunk_type(CupyCSCMatrix)
+    except ImportError:
+        pass
 except ImportError:
 
     class CupySparseMatrix:

--- a/src/anndata/tests/test_concatenate.py
+++ b/src/anndata/tests/test_concatenate.py
@@ -29,6 +29,7 @@ from anndata.tests import helpers
 from anndata.tests.helpers import (
     BASE_MATRIX_PARAMS,
     CUPY_MATRIX_PARAMS,
+    DASK_CUPY_MATRIX_PARAMS,
     DASK_MATRIX_PARAMS,
     GEN_ADATA_DASK_ARGS,
     as_dense_dask_array,
@@ -94,7 +95,12 @@ def make_idx_tuple(idx, axis):
 
 # Will call func(sparse_matrix) so these types should be sparse compatible
 # See array_type if only dense arrays are expected as input.
-@pytest.fixture(params=BASE_MATRIX_PARAMS + DASK_MATRIX_PARAMS + CUPY_MATRIX_PARAMS)
+@pytest.fixture(
+    params=BASE_MATRIX_PARAMS
+    + DASK_MATRIX_PARAMS
+    + CUPY_MATRIX_PARAMS
+    + DASK_CUPY_MATRIX_PARAMS
+)
 def array_type(request):
     return request.param
 

--- a/src/anndata/tests/test_helpers.py
+++ b/src/anndata/tests/test_helpers.py
@@ -8,8 +8,17 @@ import pytest
 from scipy import sparse
 
 import anndata as ad
-from anndata.compat import add_note
+from anndata.compat import (
+    CupyArray,
+    DaskArray,
+    add_note,
+)
 from anndata.tests.helpers import (
+    BASE_MATRIX_PARAMS,
+    CUPY_MATRIX_PARAMS,
+    DASK_MATRIX_PARAMS,
+    as_dense_cupy_dask_array,
+    as_dense_dask_array,
     asarray,
     assert_equal,
     gen_adata,
@@ -276,3 +285,33 @@ def test_check_error_notes_failure(error, match):
     with pytest.raises(AssertionError):
         with pytest.raises(Exception, match=match):
             raise error
+
+
+@pytest.mark.parametrize(
+    "input_type", BASE_MATRIX_PARAMS + DASK_MATRIX_PARAMS + CUPY_MATRIX_PARAMS
+)
+@pytest.mark.parametrize(
+    "as_dask_type,mem_type",
+    [
+        pytest.param(
+            as_dense_cupy_dask_array, CupyArray, id="cupy_dense", marks=pytest.mark.gpu
+        ),
+        pytest.param(as_dense_dask_array, np.ndarray, id="numpy_dense"),
+    ],
+)
+def test_as_dask_functions(input_type, as_dask_type, mem_type):
+    SHAPE = (1000, 100)
+
+    rng = np.random.default_rng(42)
+    X_source = rng.poisson(size=SHAPE).astype(np.float32)
+    X_input = input_type(X_source)
+    X_output = as_dask_type(X_input)
+    X_computed = X_output.compute()
+
+    assert isinstance(X_output, DaskArray)
+    assert X_output.shape == SHAPE
+    assert X_output.dtype == X_input.dtype
+
+    assert isinstance(X_computed, mem_type)
+
+    assert_equal(asarray(X_computed), X_source)

--- a/src/anndata/tests/test_helpers.py
+++ b/src/anndata/tests/test_helpers.py
@@ -10,6 +10,7 @@ from scipy import sparse
 import anndata as ad
 from anndata.compat import (
     CupyArray,
+    CupyCSRMatrix,
     DaskArray,
     add_note,
 )
@@ -17,6 +18,7 @@ from anndata.tests.helpers import (
     BASE_MATRIX_PARAMS,
     CUPY_MATRIX_PARAMS,
     DASK_MATRIX_PARAMS,
+    as_csr_cupy_dask_array,
     as_dense_cupy_dask_array,
     as_dense_dask_array,
     asarray,
@@ -297,6 +299,9 @@ def test_check_error_notes_failure(error, match):
             as_dense_cupy_dask_array, CupyArray, id="cupy_dense", marks=pytest.mark.gpu
         ),
         pytest.param(as_dense_dask_array, np.ndarray, id="numpy_dense"),
+        pytest.param(
+            as_csr_cupy_dask_array, CupyCSRMatrix, id="cupy_csr", marks=pytest.mark.gpu
+        ),
     ],
 )
 def test_as_dask_functions(input_type, as_dask_type, mem_type):

--- a/src/anndata/tests/test_io_elementwise.py
+++ b/src/anndata/tests/test_io_elementwise.py
@@ -19,7 +19,9 @@ from anndata._io.specs import _REGISTRY, IOSpec, get_spec, read_elem, write_elem
 from anndata._io.specs.registry import IORegistryError
 from anndata.compat import H5Group, ZarrGroup, _read_attr
 from anndata.tests.helpers import (
-    as_cupy_type,
+    as_cupy,
+    as_dense_dask_array,
+    as_sparse_dask_array,
     assert_equal,
     gen_adata,
 )
@@ -110,18 +112,24 @@ def test_io_spec(store, value, encoding_type):
         (sparse.random(5, 3, format="csc", density=0.5), "csc_matrix"),
     ],
 )
-def test_io_spec_cupy(store, value, encoding_type):
-    """Tests that"""
+@pytest.mark.parametrize("as_dask", [False, True])
+def test_io_spec_cupy(store, value, encoding_type, as_dask):
+    if as_dask:
+        if isinstance(value, sparse.spmatrix):
+            value = as_sparse_dask_array(value)
+        else:
+            value = as_dense_dask_array(value)
+
     key = f"key_for_{encoding_type}"
     print(type(value))
-    value = as_cupy_type(value)
+    value = as_cupy(value)
 
     print(type(value))
     write_elem(store, key, value, dataset_kwargs={})
 
     assert encoding_type == _read_attr(store[key].attrs, "encoding-type")
 
-    from_disk = as_cupy_type(read_elem(store[key]))
+    from_disk = as_cupy(read_elem(store[key]))
     assert_equal(value, from_disk)
     assert get_spec(store[key]) == _REGISTRY.get_spec(value)
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #1381
- [ ] Tests added
- [ ] Release note added (or unnecessary)

## TODO

- [x] Helper functions `as_dask_cupy_dask_array`
- [x] Helper function `as_sparse_cupy_dask_array`
- [x] Tests for helper functions
    - [x] Create set of array types to test conversion
    - [x] dense
    - [x] sparse
- [ ] Concatenation 
    - [ ] dense
    - [ ] sparse
    - Currently hitting problems with `da.block`, first the meta array is wrong, second `cupyx` returns a `coo_matrix` when block concatenating `csr_matrix`
        - https://github.com/cupy/cupy/issues/8308
- [ ] Writing
    - [x] dense
    - [ ] sparse
- [ ] test to_memory
    - [x] dense
    - [ ] sparse

