### PR TITLE
(feat): [WIP] support physical quantities via Pint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "exceptiongroup; python_version<'3.11'",
     "natsort",
     "packaging>=20.0",
+    "pint",
     # array-api-compat 1.5 has https://github.com/scverse/anndata/issues/1410
     "array_api_compat>1.4,!=1.5",
 ]

--- a/src/anndata/__init__.py
+++ b/src/anndata/__init__.py
@@ -21,7 +21,7 @@ if sys.version_info < (3, 11):
     # Backport package for exception groups
     import exceptiongroup  # noqa: F401
 
-from ._core.anndata import AnnData
+from ._core.anndata import AnnData, units
 from ._core.merge import concat
 from ._core.raw import Raw
 from ._io import (
@@ -81,4 +81,5 @@ __all__ = [
     "ExperimentalFeatureWarning",
     "experimental",
     "settings",
+    "units",
 ]

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -25,6 +25,7 @@ import pandas as pd
 from natsort import natsorted
 from numpy import ma
 from pandas.api.types import infer_dtype
+from pint import UnitRegistry
 from scipy import sparse
 from scipy.sparse import issparse
 
@@ -65,6 +66,8 @@ from .views import (
 
 if TYPE_CHECKING:
     from os import PathLike
+
+units = UnitRegistry()
 
 
 class StorageType(Enum):

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -13,7 +13,7 @@ import pandas as pd
 from scipy import sparse
 
 import anndata as ad
-from anndata import AnnData, Raw
+from anndata import AnnData, Raw, units
 from anndata._core import views
 from anndata._core.index import _normalize_indices
 from anndata._core.merge import intersect_keys
@@ -291,6 +291,27 @@ def write_raw(f, k, raw, _writer, dataset_kwargs=MappingProxyType({})):
     _writer.write_elem(g, "X", raw.X, dataset_kwargs=dataset_kwargs)
     _writer.write_elem(g, "var", raw.var, dataset_kwargs=dataset_kwargs)
     _writer.write_elem(g, "varm", dict(raw.varm), dataset_kwargs=dataset_kwargs)
+
+
+########
+# Pint #
+########
+
+
+@_REGISTRY.register_read(H5Group, IOSpec("pint.Quantity", "0.1.0"))
+@_REGISTRY.register_read(ZarrGroup, IOSpec("pint.Quantity", "0.1.0"))
+def read_quantity(elem, _reader):
+    v_magnitude = _reader.read_elem(elem["magnitude"])
+    v_units = units[_reader.read_elem(elem["units"])]
+    return v_magnitude * v_units
+
+
+@_REGISTRY.register_write(H5Group, units.Quantity, IOSpec("pint.Quantity", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, units.Quantity, IOSpec("pint.Quantity", "0.1.0"))
+def write_quantity(f, k, v, _writer, dataset_kwargs=MappingProxyType({})):
+    g = f.require_group(k)
+    _writer.write_elem(g, "magnitude", v.magnitude, dataset_kwargs=dataset_kwargs)
+    _writer.write_elem(g, "units", str(v.units), dataset_kwargs=dataset_kwargs)
 
 
 ############

--- a/src/anndata/tests/test_readwrite.py
+++ b/src/anndata/tests/test_readwrite.py
@@ -821,3 +821,17 @@ def test_io_dtype(tmp_path, diskfmt, dtype):
     curr = read(pth)
 
     assert curr.X.dtype == dtype
+
+
+def test_readwrite_units(read, write, name, tmp_path):
+    X_arr = np.array(X_list)
+    adata = ad.AnnData(
+        X=X_arr,
+        uns={"size": 100 * ad.units["um"]},
+        obsm={"X_spatial": X_arr * ad.units.mm},
+    )
+    write(tmp_path / name, adata)
+    ad_read = read(tmp_path / name)
+
+    assert adata.uns["spot_size"] == ad_read.uns["spot_size"]
+    assert (adata.obsm["X_spatial_units"] == ad_read.obsm["X_spatial_units"]).all()


### PR DESCRIPTION
Hello!

The HuBMAP Consortium makes extensive use of AnnData, writing gene expression count matrices (and more) as `.h5ad` files for public download.

As we're continuing to extend our computational pipelines to handle sequencing spatial transcriptomics with associated imaging data (e.g., Visium), with spatial coordinates registered to pixel coordinates, it's become clear that it would be very useful to store physical units directly in the AnnData/`.h5ad` structures. We've had a very pleasant experience using the Pint package in other contexts, and this package interoperates naturally with NumPy and similar (though not as nicely with SciPy sparse matrices, unfortunately).

This draft PR implements serialization of `pint.Quantity` objects to H5AD and Zarr, separately writing the magnitude and unit of each `Quantity`, and then instantiating a new `Quantity` object when reading from disk.

There are a few caveats to this -- the `pint` package allows instantiating multiple `UnitRegistry` objects, and quantities associated with one registry cannot be compared to quantities from another registry. As such, the `anndata` package instantiates a `UnitRegistry` on import, accessible at `anndata.units` and used to instantiate `Quantity` objects when loading data. Users should almost definitely use that `anndata.units` registry when creating their own `Quantity` objects, to interoperate with `Quantity` objects created by the package.

This PR adds `pint` as an unconditional requirement for `anndata`.

I added a test method which demonstrates serialization and loading of `pint.Quantity`-wrapped arrays and scalars, which works as expected. I ran the full test suite on my machine and encountered no new failures (10 tests failed on current `main` and on my branch, on macOS 14.4.1, and 29 failed on Ubuntu 22.04).

This PR does _not_ add documentation; I'm happy to do so but wanted to check whether this approach looked reasonable to everyone before expending that effort.

- [ ] Closes #
- [X] Tests added
- [ ] Release note added (or unnecessary)
