### PR TITLE
(chore): change boolean settings names to use `should`

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -325,7 +325,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._varp = adata_ref.varp._view(self, vidx)
         # fix categories
         uns = copy(adata_ref._uns)
-        if settings.remove_unused_categories:
+        if settings.should_remove_unused_categories:
             self._remove_unused_categories(adata_ref.obs, obs_sub, uns)
             self._remove_unused_categories(adata_ref.var, var_sub, uns)
         # set attributes
@@ -482,7 +482,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # Backwards compat for connectivities matrices in uns["neighbors"]
         _move_adj_mtx({"uns": self._uns, "obsp": self._obsp})
         self._check_dimensions()
-        if settings.check_uniqueness:
+        if settings.should_check_uniqueness:
             self._check_uniqueness()
 
         if self.filename:
@@ -1101,7 +1101,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 continue
             all_categories = df_full[k].cat.categories
             with pd.option_context("mode.chained_assignment", None):
-                df_sub[k] = df_sub[k].cat.remove_unused_categories()
+                df_sub[k] = df_sub[k].cat.should_remove_unused_categories()
             # also correct the colors...
             color_key = f"{k}_colors"
             if color_key not in uns:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1101,7 +1101,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 continue
             all_categories = df_full[k].cat.categories
             with pd.option_context("mode.chained_assignment", None):
-                df_sub[k] = df_sub[k].cat.should_remove_unused_categories()
+                df_sub[k] = df_sub[k].cat.remove_unused_categories()
             # also correct the colors...
             color_key = f"{k}_colors"
             if color_key not in uns:

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -352,13 +352,13 @@ settings = SettingsManager()
 ##################################################################################
 
 
-categories_option = "remove_unused_categories"
+categories_option = "should_remove_unused_categories"
 categories_default_value = True
 categories_description = (
     "Whether or not to remove unused categories with :class:`~pandas.Categorical`."
 )
 
-uniqueness_option = "check_uniqueness"
+uniqueness_option = "should_check_uniqueness"
 uniqueness_default_value = True
 uniqueness_description = "Whether or not to check uniqueness of the `obs` indices on :method:`~anndata.AnnData.__init__`."
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -414,7 +414,7 @@ def test_slicing_remove_unused_categories():
 
 
 def test_slicing_dont_remove_unused_categories():
-    with settings.override(remove_unused_categories=False):
+    with settings.override(should_remove_unused_categories=False):
         adata = AnnData(
             np.array([[1, 2], [3, 4], [5, 6], [7, 8]]), dict(k=["a", "a", "b", "b"])
         )
@@ -423,7 +423,7 @@ def test_slicing_dont_remove_unused_categories():
 
 
 def test_no_uniqueness_check_gives_repeat_indices():
-    with settings.override(check_uniqueness=False):
+    with settings.override(should_check_uniqueness=False):
         obs_names = ["0", "0", "1", "1"]
         with warnings.catch_warnings():
             warnings.simplefilter("error")


### PR DESCRIPTION
Since this is coming in 0.11 I think we should change these to use `should` verbs at the front.  I like verbs in front of booleans because it makes clear what they do.  Otherwise, I would just close them and leave them both as the action without `should`

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
