### PR TITLE
(fix): fix for new `scipy.sparse` matrix strings in `sparse_dataset` docstring tests

### DIFF
--- a/docs/release-notes/0.10.8.md
+++ b/docs/release-notes/0.10.8.md
@@ -5,7 +5,7 @@
 
 * Write out `64bit` indptr when appropriate for {func}`~anndata.experimental.concat_on_disk` {pr}`1493` {user}`ilan-gold`
 * Support for Numpy 2 {pr}`1499` {user}`flying-sheep`
-
+* `xfail` `~anndata.experimental.sparse_dataset` docstring test on account of new `~scipy` version {pr}`1514` {user}`ilan-gold`
 ```{rubric} Documentation
 ```
 

--- a/docs/release-notes/0.10.8.md
+++ b/docs/release-notes/0.10.8.md
@@ -5,7 +5,7 @@
 
 * Write out `64bit` indptr when appropriate for {func}`~anndata.experimental.concat_on_disk` {pr}`1493` {user}`ilan-gold`
 * Support for Numpy 2 {pr}`1499` {user}`flying-sheep`
-* {func}`~pytest.mark.xfail` {func}`~anndata.experimental.sparse_dataset` docstring test on account of new {mod}`scipy` version {pr}`1514` {user}`ilan-gold`
+* Fix {func}`~anndata.experimental.sparse_dataset` docstring test on account of new {mod}`scipy` version {pr}`1514` {user}`ilan-gold`
 ```{rubric} Documentation
 ```
 

--- a/docs/release-notes/0.10.8.md
+++ b/docs/release-notes/0.10.8.md
@@ -5,7 +5,7 @@
 
 * Write out `64bit` indptr when appropriate for {func}`~anndata.experimental.concat_on_disk` {pr}`1493` {user}`ilan-gold`
 * Support for Numpy 2 {pr}`1499` {user}`flying-sheep`
-* `xfail` `~anndata.experimental.sparse_dataset` docstring test on account of new `~scipy` version {pr}`1514` {user}`ilan-gold`
+* {func}`~pytest.xfail` {func}`~anndata.experimental.sparse_dataset` docstring test on account of new {mod}`scipy` version {pr}`1514` {user}`ilan-gold`
 ```{rubric} Documentation
 ```
 

--- a/docs/release-notes/0.10.8.md
+++ b/docs/release-notes/0.10.8.md
@@ -5,7 +5,7 @@
 
 * Write out `64bit` indptr when appropriate for {func}`~anndata.experimental.concat_on_disk` {pr}`1493` {user}`ilan-gold`
 * Support for Numpy 2 {pr}`1499` {user}`flying-sheep`
-* {func}`~pytest.xfail` {func}`~anndata.experimental.sparse_dataset` docstring test on account of new {mod}`scipy` version {pr}`1514` {user}`ilan-gold`
+* {func}`~pytest.mark.xfail` {func}`~anndata.experimental.sparse_dataset` docstring test on account of new {mod}`scipy` version {pr}`1514` {user}`ilan-gold`
 ```{rubric} Documentation
 ```
 

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -607,11 +607,6 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
     >>> import scanpy as sc
     >>> import h5py
     >>> from anndata.experimental import sparse_dataset, read_elem
-    >>> import scipy
-    >>> import pytest
-    >>> from packaging.version import Version
-    >>> if Version(scipy.__version__) >= Version("1.14.0rc1"):
-    ...     pytest.xfail("scipy.sparse string formatting changed in 1.14.0rc1 and up")
     >>> sc.datasets.pbmc68k_reduced().raw.to_adata().write_h5ad("pbmc.h5ad")
 
     Initialize a sparse dataset from storage
@@ -623,9 +618,8 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
 
     Indexing returns sparse matrices
 
-    >>> X[100:200]  # doctest: +NORMALIZE_WHITESPACE
-    <100x765 sparse matrix of type '<class 'numpy.float32'>'
-        with 25003 stored elements in Compressed Sparse Row format>
+    >>> X[100:200]  # doctest: +ELLIPSIS
+    <...100...765...sparse matrix of type...float32...Compressed Sparse Row...>
 
     These can also be used inside of an AnnData object, no need for backed mode
 
@@ -640,9 +634,8 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
 
     >>> adata[adata.obs["bulk_labels"] == "CD56+ NK"].layers[
     ...     "backed"
-    ... ]  # doctest: +NORMALIZE_WHITESPACE
-    <31x765 sparse matrix of type '<class 'numpy.float32'>'
-        with 7340 stored elements in Compressed Sparse Row format>
+    ... ]  # doctest: +ELLIPSIS
+    <...31...765...sparse matrix of type...float32...Compressed Sparse Row...>
     """
     encoding_type = _get_group_format(group)
     if encoding_type == "csr":

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -607,6 +607,11 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
     >>> import scanpy as sc
     >>> import h5py
     >>> from anndata.experimental import sparse_dataset, read_elem
+    >>> import scipy
+    >>> import pytest
+    >>> from packaging.version import Version
+    >>> if Version(scipy.__version__) >= Version("1.14.0rc1"):
+    ...     pytest.xfail("scipy.sparse string formatting changed in 1.14.0rc1 and up")
     >>> sc.datasets.pbmc68k_reduced().raw.to_adata().write_h5ad("pbmc.h5ad")
 
     Initialize a sparse dataset from storage

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -619,7 +619,7 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
     Indexing returns sparse matrices
 
     >>> X[100:200]  # doctest: +ELLIPSIS
-    <...100...765...sparse matrix of type...float32...Compressed Sparse Row...>
+    <...sparse matrix of...float32...with 25003 stored elements...>
 
     These can also be used inside of an AnnData object, no need for backed mode
 
@@ -635,7 +635,7 @@ def sparse_dataset(group: GroupStorageType) -> CSRDataset | CSCDataset:
     >>> adata[adata.obs["bulk_labels"] == "CD56+ NK"].layers[
     ...     "backed"
     ... ]  # doctest: +ELLIPSIS
-    <...31...765...sparse matrix of type...float32...Compressed Sparse Row...>
+    <...sparse matrix of...float32...with 7340 stored elements...>
     """
     encoding_type = _get_group_format(group)
     if encoding_type == "csr":


### PR DESCRIPTION
See https://github.com/scverse/anndata/runs/25637727260

```
Expected:
    <100x765 sparse matrix of type '<class 'numpy.float32'>'
        with 25003 stored elements in Compressed Sparse Row format>
Got:
    <Compressed Sparse Row sparse matrix of dtype 'float32'
    	with 25003 stored elements and shape (100, 765)>
```

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary)
