### PR TITLE
Coerce np.matrix instances to np.ndarray

### DIFF
--- a/docs/release-notes/0.10.8.md
+++ b/docs/release-notes/0.10.8.md
@@ -5,6 +5,7 @@
 
 * Write out `64bit` indptr when appropriate for {func}`~anndata.experimental.concat_on_disk` {pr}`1493` {user}`ilan-gold`
 * Support for Numpy 2 {pr}`1499` {user}`flying-sheep`
+* Coerce {class}`numpy.matrix` classes to arrays when trying to store them in `AnnData` {pr}`1516` {user}`flying-sheep`
 
 ```{rubric} Documentation
 ```

--- a/src/anndata/_core/aligned_mapping.py
+++ b/src/anndata/_core/aligned_mapping.py
@@ -17,12 +17,12 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import spmatrix
 
-from anndata._warnings import ExperimentalFeatureWarning, ImplicitModificationWarning
-from anndata.compat import AwkArray
-
-from ..utils import axis_len, deprecated, ensure_df_homogeneous, warn_once
+from .._warnings import ExperimentalFeatureWarning, ImplicitModificationWarning
+from ..compat import AwkArray
+from ..utils import axis_len, deprecated, warn_once
 from .access import ElementRef
 from .index import _subset
+from .storage import coerce_array
 from .views import as_view, view_update
 
 if TYPE_CHECKING:
@@ -88,10 +88,8 @@ class AlignedMapping(cabc.MutableMapping, ABC):
                 )
             raise ValueError(msg)
 
-        if not self._allow_df and isinstance(val, pd.DataFrame):
-            name = self.attrname.title().rstrip("s")
-            val = ensure_df_homogeneous(val, f"{name} {key!r}")
-        return val
+        name = f"{self.attrname.title().rstrip('s')} {key!r}"
+        return coerce_array(val, name=name, allow_df=self._allow_df)
 
     @property
     @abstractmethod

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -42,7 +42,7 @@ from .file_backing import AnnDataFileManager, to_memory
 from .index import Index, Index1D, _normalize_indices, _subset, get_vector
 from .raw import Raw
 from .sparse_dataset import BaseCompressedSparseDataset, sparse_dataset
-from .storage import StorageType, coerce_array
+from .storage import coerce_array
 from .views import (
     ArrayView,
     DataFrameView,
@@ -390,13 +390,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         # check data type of X
         if X is not None:
-            if not isinstance(X, StorageType.classes()):
-                raise ValueError(
-                    "X needs to be of one of numpy.ndarray, numpy.ma.core.MaskedArray, "
-                    "scipy.sparse.spmatrix, h5py.Dataset, zarr.Array, "
-                    "anndata.experimental.[CSC,CSR]Dataset, dask.array.Array, "
-                    f"cupy.ndarray, cupyx.scipy.sparse.spmatrix, not {type(X)}."
-                )
+            X = coerce_array(X, name="X")
             if shape is not None:
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
             _check_2d_shape(X)
@@ -416,7 +410,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 else:  # is np.ndarray or a subclass, convert to true np.ndarray
                     X = np.asarray(X, dtype)
             # data matrix and shape
-            self._X = coerce_array(X, name="X")
+            self._X = X
             n_obs, n_vars = X.shape
             source = "X"
         else:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -582,7 +582,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 self._init_as_actual(self.copy())
             self._X = None
             return
-        value = coerce_array(value, name="X")
+        value = coerce_array(value, name="X", allow_array_like=True)
 
         # If indices are both arrays, we need to modify them
         # so we don’t set values like coordinates

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -9,15 +9,10 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from copy import copy, deepcopy
-from enum import Enum
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import (  # Meta  # Generic ABCs  # Generic
-    TYPE_CHECKING,
-    Any,
-    Literal,
-)
+from typing import TYPE_CHECKING, Any, Literal
 
 import h5py
 import numpy as np
@@ -30,15 +25,7 @@ from scipy.sparse import issparse
 
 from .. import utils
 from .._settings import settings
-from ..compat import (
-    CupyArray,
-    CupySparseMatrix,
-    DaskArray,
-    SpArray,
-    ZappyArray,
-    ZarrArray,
-    _move_adj_mtx,
-)
+from ..compat import DaskArray, SpArray, ZarrArray, _move_adj_mtx
 from ..logging import anndata_logger as logger
 from ..utils import axis_len, convert_to_dict, deprecated, ensure_df_homogeneous
 from .access import ElementRef
@@ -55,6 +42,7 @@ from .file_backing import AnnDataFileManager, to_memory
 from .index import Index, Index1D, _normalize_indices, _subset, get_vector
 from .raw import Raw
 from .sparse_dataset import BaseCompressedSparseDataset, sparse_dataset
+from .storage import StorageType, coerce_array
 from .views import (
     ArrayView,
     DataFrameView,
@@ -65,23 +53,6 @@ from .views import (
 
 if TYPE_CHECKING:
     from os import PathLike
-
-
-class StorageType(Enum):
-    Array = np.ndarray
-    Masked = ma.MaskedArray
-    Sparse = sparse.spmatrix
-    ZarrArray = ZarrArray
-    ZappyArray = ZappyArray
-    DaskArray = DaskArray
-    CupyArray = CupyArray
-    CupySparseMatrix = CupySparseMatrix
-    BackedSparseMatrix = BaseCompressedSparseDataset
-    SparseArray = SpArray
-
-    @classmethod
-    def classes(cls):
-        return tuple(c.value for c in cls.__members__.values())
 
 
 # for backwards compat
@@ -419,12 +390,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         # check data type of X
         if X is not None:
-            for s_type in StorageType:
-                if isinstance(X, s_type.value):
-                    break
-            else:
+            if not isinstance(X, StorageType.classes()):
                 raise ValueError(
-                    f"X needs to be of one of numpy.ndarray, numpy.ma.core.MaskedArray, scipy.sparse.spmatrix, h5py.Dataset, zarr.Array, anndata.experimental.[CSC,CSR]Dataset, dask.array.Array, cupy.ndarray, cupyx.scipy.sparse.spmatrix, not {type(X)}."
+                    "X needs to be of one of numpy.ndarray, numpy.ma.core.MaskedArray, "
+                    "scipy.sparse.spmatrix, h5py.Dataset, zarr.Array, "
+                    "anndata.experimental.[CSC,CSR]Dataset, dask.array.Array, "
+                    f"cupy.ndarray, cupyx.scipy.sparse.spmatrix, not {type(X)}."
                 )
             if shape is not None:
                 raise ValueError("`shape` needs to be `None` if `X` is not `None`.")
@@ -445,7 +416,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 else:  # is np.ndarray or a subclass, convert to true np.ndarray
                     X = np.asarray(X, dtype)
             # data matrix and shape
-            self._X = X
+            self._X = coerce_array(X, name="X")
             n_obs, n_vars = X.shape
             source = "X"
         else:
@@ -617,11 +588,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 self._init_as_actual(self.copy())
             self._X = None
             return
-        if not isinstance(value, StorageType.classes()) and not np.isscalar(value):
-            if hasattr(value, "to_numpy") and hasattr(value, "dtypes"):
-                value = ensure_df_homogeneous(value, "X")
-            else:  # TODO: asarray? asanyarray?
-                value = np.array(value)
+        value = coerce_array(value, name="X")
 
         # If indices are both arrays, we need to modify them
         # so we don’t set values like coordinates

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -17,26 +17,44 @@ from ..compat import (
     ZappyArray,
     ZarrArray,
 )
-from ..utils import ensure_df_homogeneous
+from ..utils import ensure_df_homogeneous, join_english
 from .sparse_dataset import BaseCompressedSparseDataset
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class StorageType(Enum):
-    Array = np.ndarray
-    Masked = ma.MaskedArray
-    Sparse = sparse.spmatrix
-    ZarrArray = ZarrArray
-    ZappyArray = ZappyArray
-    DaskArray = DaskArray
-    CupyArray = CupyArray
-    CupySparseMatrix = CupySparseMatrix
-    BackedSparseMatrix = BaseCompressedSparseDataset
-    SparseArray = SpArray
-    AwkArray = AwkArray
+    Array = (np.ndarray, "np.ndarray")
+    Masked = (ma.MaskedArray, "numpy.ma.core.MaskedArray")
+    Sparse = (sparse.spmatrix, "scipy.sparse.spmatrix")
+    ZarrArray = (ZarrArray, "zarr.Array")
+    ZappyArray = (ZappyArray, "zappy.base.ZappyArray")
+    DaskArray = (DaskArray, "dask.array.Array")
+    CupyArray = (CupyArray, "cupy.ndarray")
+    CupySparseMatrix = (CupySparseMatrix, "cupyx.scipy.sparse.spmatrix")
+    BackedSparseMatrix = (
+        BaseCompressedSparseDataset,
+        "anndata.experimental.[CSC,CSR]Dataset",
+    )
+    SparseArray = (SpArray, "scipy.sparse.sparray")
+    AwkArray = (AwkArray, "awkward.Array")
+
+    @property
+    def cls(self):
+        return self.value[0]
+
+    @property
+    def qualname(self):
+        return self.value[1]
 
     @classmethod
-    def classes(cls):
-        return tuple(c.value for c in cls.__members__.values())
+    def classes(cls) -> tuple[type, ...]:
+        return tuple(v.cls for v in cls)
+
+    @classmethod
+    def qualnames(cls) -> Generator[str, None, None]:
+        yield from (v.qualname for v in cls)
 
 
 def coerce_array(value: Any, *, name: str, allow_df: bool = False):
@@ -47,5 +65,9 @@ def coerce_array(value: Any, *, name: str, allow_df: bool = False):
         return value
     if isinstance(value, pd.DataFrame):
         return value if allow_df else ensure_df_homogeneous(value, name)
+    if not isinstance(value, StorageType.classes()):
+        raise ValueError(
+            f"X needs to be of one of {join_english(StorageType.qualnames())}, not {type(value)}."
+        )
     # TODO: asarray? asanyarray?
     return np.array(value)

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from numpy import ma
+from scipy import sparse
+
+from ..compat import (
+    CupyArray,
+    CupySparseMatrix,
+    DaskArray,
+    SpArray,
+    ZappyArray,
+    ZarrArray,
+)
+from ..utils import ensure_df_homogeneous
+from .sparse_dataset import BaseCompressedSparseDataset
+
+
+class StorageType(Enum):
+    Array = np.ndarray
+    Masked = ma.MaskedArray
+    Sparse = sparse.spmatrix
+    ZarrArray = ZarrArray
+    ZappyArray = ZappyArray
+    DaskArray = DaskArray
+    CupyArray = CupyArray
+    CupySparseMatrix = CupySparseMatrix
+    BackedSparseMatrix = BaseCompressedSparseDataset
+    SparseArray = SpArray
+
+    @classmethod
+    def classes(cls):
+        return tuple(c.value for c in cls.__members__.values())
+
+
+def coerce_array(value: Any, *, name: str, allow_df: bool = True):
+    """Coerce arrays stored in layers/X, and aligned arrays ({obs,var}{m,p})."""
+    if (
+        isinstance(value, StorageType.classes()) or np.isscalar(value)
+    ) and not isinstance(value, np.matrix):
+        return value
+    if not allow_df and isinstance(value, pd.DataFrame):
+        return ensure_df_homogeneous(value, name)
+    # TODO: asarray? asanyarray?
+    return np.array(value)

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -9,6 +9,7 @@ from numpy import ma
 from scipy import sparse
 
 from ..compat import (
+    AwkArray,
     CupyArray,
     CupySparseMatrix,
     DaskArray,
@@ -31,6 +32,7 @@ class StorageType(Enum):
     CupySparseMatrix = CupySparseMatrix
     BackedSparseMatrix = BaseCompressedSparseDataset
     SparseArray = SpArray
+    AwkArray = AwkArray
 
     @classmethod
     def classes(cls):

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -39,13 +39,13 @@ class StorageType(Enum):
         return tuple(c.value for c in cls.__members__.values())
 
 
-def coerce_array(value: Any, *, name: str, allow_df: bool = True):
+def coerce_array(value: Any, *, name: str, allow_df: bool = False):
     """Coerce arrays stored in layers/X, and aligned arrays ({obs,var}{m,p})."""
     if (
         isinstance(value, StorageType.classes()) or np.isscalar(value)
     ) and not isinstance(value, np.matrix):
         return value
-    if not allow_df and isinstance(value, pd.DataFrame):
-        return ensure_df_homogeneous(value, name)
+    if isinstance(value, pd.DataFrame):
+        return value if allow_df else ensure_df_homogeneous(value, name)
     # TODO: asarray? asanyarray?
     return np.array(value)

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -89,4 +89,6 @@ def coerce_array(
             e = _e
     # if value isn’t the right type or convertible, raise an error
     msg = f"{name} needs to be of one of {join_english(StorageType.qualnames())}, not {type(value)}."
+    if e is not None:
+        msg += " (Failed to convert it to an array, see above for details.)"
     raise ValueError(msg) from e

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -15,7 +15,7 @@ from .compat import CupyArray, CupySparseMatrix, DaskArray, SpArray
 from .logging import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
 logger = get_logger(__name__)
 
@@ -269,6 +269,17 @@ def make_index_unique(index: pd.Index, join: str = "-"):
     values[indices_dup] = values_dup
     index = pd.Index(values, name=index.name)
     return index
+
+
+def join_english(words: Iterable[str], conjunction: str = "or") -> str:
+    words = list(words)  # no need to be efficient
+    if len(words) == 0:
+        return ""
+    if len(words) == 1:
+        return words[0]
+    if len(words) == 2:
+        return f"{words[0]} {conjunction} {words[1]}"
+    return ", ".join(words[:-1]) + f", {conjunction} {words[-1]}"
 
 
 def warn_names_duplicates(attr: str):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -195,8 +195,8 @@ def test_convert_matrix(attr, when):
 
     # with pytest.warns(ImplicitModificationWarning, match=r"np\.ndarray"):
     arr = getattr(adata, attr) if direct else getattr(adata, attr)["a"]
-    assert isinstance(arr, np.ndarray), "it’s not even an array"
-    assert not isinstance(arr, np.matrix), "it’s still a matrix"
+    assert isinstance(arr, np.ndarray), f"{arr} is not an array"
+    assert not isinstance(arr, np.matrix), f"{arr} is still a matrix"
 
 
 def test_attr_deletion():

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -95,9 +95,7 @@ def test_creation_error(src, src_arg, dim_msg, dim, dim_arg, msg: str | None):
 def test_invalid_X():
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "X needs to be of one of numpy.ndarray, numpy.ma.core.MaskedArray, scipy.sparse.spmatrix, h5py.Dataset, zarr.Array, anndata.experimental.[CSC,CSR]Dataset, dask.array.Array, cupy.ndarray, cupyx.scipy.sparse.spmatrix, not <class 'str'>."
-        ),
+        match=r"X needs to be of one of np\.ndarray.*not <class 'str'>\.",
     ):
         AnnData("string is not a valid X")
 

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -48,44 +48,64 @@ def store(request, tmp_path) -> H5Group | ZarrGroup:
 
 
 @pytest.mark.parametrize(
-    "value,encoding_type",
+    ("value", "encoding_type"),
     [
-        ("hello world", "string"),
-        (np.str_("hello world"), "string"),
-        (np.array([1, 2, 3]), "array"),
-        (np.array(["hello", "world"], dtype=object), "string-array"),
-        (1, "numeric-scalar"),
-        (True, "numeric-scalar"),
-        (1.0, "numeric-scalar"),
-        ({"a": 1}, "dict"),
-        (gen_adata((3, 2)), "anndata"),
-        (sparse.random(5, 3, format="csr", density=0.5), "csr_matrix"),
-        (sparse.random(5, 3, format="csc", density=0.5), "csc_matrix"),
-        (pd.DataFrame({"a": [1, 2, 3]}), "dataframe"),
-        (pd.Categorical(list("aabccedd")), "categorical"),
-        (pd.Categorical(list("aabccedd"), ordered=True), "categorical"),
-        (pd.Categorical([1, 2, 1, 3], ordered=True), "categorical"),
-        (
+        pytest.param("hello world", "string", id="py_str"),
+        pytest.param(np.str_("hello world"), "string", id="np_str"),
+        pytest.param(np.array([1, 2, 3]), "array", id="np_arr_int"),
+        pytest.param(
+            np.array(["hello", "world"], dtype=object), "string-array", id="np_arr_str"
+        ),
+        pytest.param(1, "numeric-scalar", id="py_int"),
+        pytest.param(True, "numeric-scalar", id="py_bool"),
+        pytest.param(1.0, "numeric-scalar", id="py_float"),
+        pytest.param({"a": 1}, "dict", id="py_dict"),
+        pytest.param(gen_adata((3, 2)), "anndata", id="anndata"),
+        pytest.param(
+            sparse.random(5, 3, format="csr", density=0.5),
+            "csr_matrix",
+            id="sp_mat_csr",
+        ),
+        pytest.param(
+            sparse.random(5, 3, format="csc", density=0.5),
+            "csc_matrix",
+            id="sp_mat_csc",
+        ),
+        pytest.param(pd.DataFrame({"a": [1, 2, 3]}), "dataframe", id="pd_df"),
+        pytest.param(pd.Categorical(list("aabccedd")), "categorical", id="pd_cat"),
+        pytest.param(
+            pd.Categorical(list("aabccedd"), ordered=True),
+            "categorical",
+            id="pd_cat_ord",
+        ),
+        pytest.param(
+            pd.Categorical([1, 2, 1, 3], ordered=True), "categorical", id="pd_cat_num"
+        ),
+        pytest.param(
             pd.arrays.IntegerArray(
                 np.ones(5, dtype=int), mask=np.array([True, False, True, False, True])
             ),
             "nullable-integer",
+            id="pd_arr_int_mask",
         ),
-        (pd.array([1, 2, 3]), "nullable-integer"),
-        (
+        pytest.param(pd.array([1, 2, 3]), "nullable-integer", id="pd_arr_int"),
+        pytest.param(
             pd.arrays.BooleanArray(
                 np.random.randint(0, 2, size=5, dtype=bool),
                 mask=np.random.randint(0, 2, size=5, dtype=bool),
             ),
             "nullable-boolean",
+            id="pd_arr_bool_mask",
         ),
-        (pd.array([True, False, True, True]), "nullable-boolean"),
-        # (bytes, b"some bytes", "bytes"), # Does not work for zarr
+        pytest.param(
+            pd.array([True, False, True, True]), "nullable-boolean", id="pd_arr_bool"
+        ),
+        # pytest.param(bytes, b"some bytes", "bytes", id="py_bytes"), # Does not work for zarr
         # TODO consider how specific encodings should be. Should we be fully describing the written type?
         # Currently the info we add is: "what you wouldn't be able to figure out yourself"
         # but that's not really a solid rule.
-        # (bool, True, "bool"),
-        # (bool, np.bool_(False), "bool"),
+        # pytest.param(bool, True, "bool", id="py_bool"),
+        # pytest.param(bool, np.bool_(False), "bool", id="np_bool"),
     ],
 )
 def test_io_spec(store, value, encoding_type):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
 from copy import deepcopy
 from operator import mul
 
@@ -8,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from dask.base import tokenize
+from packaging.version import Version
 from scipy import sparse
 
 import anndata as ad
@@ -124,7 +126,20 @@ def test_convert_error():
     adata = ad.AnnData(np.array([[1, 2], [3, 0]]))
     no_array = [[1], []]
 
-    with pytest.raises(ValueError, match=r"Failed to convert"):
+    if Version(np.__version__) >= Version("1.24"):
+        stack = pytest.raises(ValueError, match=r"Failed to convert")
+    else:
+        stack = ExitStack()
+        stack.enter_context(
+            pytest.warns(
+                np.VisibleDeprecationWarning,
+                match=r"ndarray from ragged.*is deprecated",
+            )
+        )
+        stack.enter_context(
+            pytest.raises(ValueError, match=r"setting an array element with a sequence")
+        )
+    with stack:
         adata[:, 0].X = no_array
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,6 +120,14 @@ def test_views():
     assert adata_subset.obs["foo"].tolist() == list(range(2))
 
 
+def test_convert_error():
+    adata = ad.AnnData(np.array([[1, 2], [3, 0]]))
+    no_array = [[1], []]
+
+    with pytest.raises(ValueError, match=r"Failed to convert"):
+        adata[:, 0].X = no_array
+
+
 def test_view_subset_shapes():
     adata = gen_adata((20, 10), **GEN_ADATA_DASK_ARGS)
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1431
- [x] Tests added
- [x] Release note added (or unnecessary)

This unifies the array type coercion, which used to work differently betwen `X` and `AlignedMapping`s.

@ilan-gold, does it make sense to add AwkwardArray there or should we special-case it so it’s only valid in {obs,var}m, not in X and layers?
