### PR TITLE
Remove upper version bound on zarr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test = [
     "loompy>=3.0.5",
     "pytest>=8.2",
     "pytest-cov>=2.10",
-    "zarr<3.0.0a0",
+    "zarr",
     "matplotlib",
     "scikit-learn",
     "openpyxl",

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -70,13 +70,12 @@ class BackedSparseMatrix(_cs_matrix):
         if isinstance(self.data, ZarrArray):
             import zarr
 
-            return sparse_dataset(
-                zarr.open(
-                    store=self.data.store,
-                    mode="r",
-                    chunk_store=self.data.chunk_store,  # chunk_store is needed, not clear why
-                )[Path(self.data.path).parent]
-            ).to_memory()
+            grp = zarr.open_group(
+                store=self.data.store,
+                mode="r",
+                chunk_store=self.data.chunk_store,  # chunk_store is needed, not clear why
+            )
+            return sparse_dataset(grp[Path(self.data.path).parent]).to_memory()
         return super().copy()
 
     def _set_many(self, i: Iterable[int], j: Iterable[int], x):

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -296,7 +296,11 @@ class Writer:
             k = str(PurePosixPath(store.name) / k)
 
         if k == "/":
-            store.clear()
+            if hasattr(store, "clear"):
+                store.clear()
+            else:
+                for name, _ in store.members:
+                    del store[name]
         elif k in store:
             del store[k]
 

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -187,7 +187,7 @@ def report_read_key_on_error(func):
     >>> @report_read_key_on_error
     ... def read_arr(group):
     ...     raise NotImplementedError()
-    >>> z = zarr.open("tmp.zarr")
+    >>> z = zarr.open_group(store="tmp.zarr", mode="w")
     >>> z["X"] = [1, 2, 3]
     >>> read_arr(z["X"])  # doctest: +SKIP
     """
@@ -223,7 +223,7 @@ def report_write_key_on_error(func):
     >>> @report_write_key_on_error
     ... def write_arr(group, key, val):
     ...     raise NotImplementedError()
-    >>> z = zarr.open("tmp.zarr")
+    >>> z = zarr.open(store="tmp.zarr")
     >>> X = [1, 2, 3]
     >>> write_arr(z, "X", X)  # doctest: +SKIP
     """

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -35,7 +35,7 @@ def write_zarr(
     if adata.raw is not None:
         adata.strings_to_categoricals(adata.raw.var)
     # TODO: Use spec writing system for this
-    f = zarr.open(store, mode="w")
+    f = zarr.open_group(store=store, mode="w")
     f.attrs.setdefault("encoding-type", "anndata")
     f.attrs.setdefault("encoding-version", "0.1.0")
 
@@ -63,7 +63,7 @@ def read_zarr(store: str | Path | MutableMapping | zarr.Group) -> AnnData:
     if isinstance(store, zarr.Group):
         f = store
     else:
-        f = zarr.open(store, mode="r")
+        f = zarr.open(store=store, mode="r")
 
     # Read with handling for backwards compat
     def callback(func, elem_name: str, elem, iospec):

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -87,19 +87,29 @@ else:
 #############################
 
 try:
-    from zarr.core import Array as ZarrArray
-    from zarr.hierarchy import Group as ZarrGroup
+    from zarr.array import Array as ZarrArray
 except ImportError:
+    try:
+        from zarr.core import Array as ZarrArray
+    except ImportError:
 
-    class ZarrArray:
-        @staticmethod
-        def __repr__():
-            return "mock zarr.core.Array"
+        class ZarrArray:
+            @staticmethod
+            def __repr__():
+                return "mock zarr.core.Array"
 
-    class ZarrGroup:
-        @staticmethod
-        def __repr__():
-            return "mock zarr.core.Group"
+
+try:
+    from zarr.group import Group as ZarrGroup
+except ImportError:
+    try:
+        from zarr.hierarchy import Group as ZarrGroup
+    except ImportError:
+
+        class ZarrGroup:
+            @staticmethod
+            def __repr__():
+                return "mock zarr.core.Group"
 
 
 try:

--- a/src/anndata/experimental/merge.py
+++ b/src/anndata/experimental/merge.py
@@ -110,7 +110,7 @@ def _(store: os.PathLike | str, *args, **kwargs) -> ZarrGroup | H5Group:
         return h5py.File(store, *args, **kwargs)
     import zarr
 
-    return zarr.open_group(store, *args, **kwargs)
+    return zarr.open_group(store=store, *args, **kwargs)
 
 
 @as_group.register(ZarrGroup)

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -853,9 +853,9 @@ CUPY_MATRIX_PARAMS = [
 ]
 
 try:
-    import zarr
+    import zarr.storage
 
-    class AccessTrackingStore(zarr.DirectoryStore):
+    class AccessTrackingStore(zarr.storage.DirectoryStore):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self._access_count = {}

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -61,7 +61,7 @@ def ondisk_equivalent_adata(
         def read_zarr_backed(path):
             path = str(path)
 
-            f = zarr.open(path, mode="r")
+            f = zarr.open(store=path, mode="r")
 
             # Read with handling for backwards compat
             def callback(func, elem_name, elem, iospec):
@@ -249,7 +249,7 @@ def test_dataset_append_memory(
     a = sparse_format(sparse.random(100, 100))
     b = sparse_format(sparse.random(100, 100))
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
     ad._io.specs.write_elem(f, "mtx", a)
@@ -281,7 +281,7 @@ def test_dataset_append_disk(
     b = sparse_format(sparse.random(10, 10))
 
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
     ad._io.specs.write_elem(f, "a", a)
@@ -304,11 +304,11 @@ def test_indptr_cache(
 ):
     path = tmp_path / "test.zarr"  # diskfmt is either h5ad or zarr
     a = sparse_format(sparse.random(10, 10))
-    f = zarr.open_group(path, "a")
+    f = zarr.open_group(store=path, mode="a")
     ad._io.specs.write_elem(f, "X", a)
     store = AccessTrackingStore(path)
     store.initialize_key_trackers(["X/indptr"])
-    f = zarr.open_group(store, "a")
+    f = zarr.open_group(store=store, mode="a")
     a_disk = sparse_dataset(f["X"])
     a_disk[:1]
     a_disk[3:5]
@@ -325,7 +325,7 @@ def test_data_access(
 ):
     path = tmp_path / "test.zarr"  # diskfmt is either h5ad or zarr
     a = sparse_format(np.eye(10, 10))
-    f = zarr.open_group(path, "a")
+    f = zarr.open_group(store=path, mode="a")
     ad._io.specs.write_elem(f, "X", a)
     data = f["X/data"][...]
     del f["X/data"]
@@ -333,7 +333,7 @@ def test_data_access(
     zarr.array(data, store=path / "X" / "data", chunks=(1,))
     store = AccessTrackingStore(path)
     store.initialize_key_trackers(["X/data"])
-    f = zarr.open_group(store)
+    f = zarr.open_group(store=store)
     a_disk = sparse_dataset(f["X"])
     for idx in [slice(0, 1), 0, np.array([0]), np.array([True] + [False] * 9)]:
         store.reset_key_trackers()
@@ -368,7 +368,7 @@ def test_wrong_shape(
     b_mem = sparse.random(*b_shape, format=sparse_format)
 
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
 
@@ -386,7 +386,7 @@ def test_reset_group(tmp_path: Path):
     base = sparse.random(100, 100, format="csr")
 
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
 
@@ -401,7 +401,7 @@ def test_wrong_formats(tmp_path: Path, diskfmt: Literal["h5ad", "zarr"]):
     base = sparse.random(100, 100, format="csr")
 
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
 
@@ -430,7 +430,7 @@ def test_anndata_sparse_compat(tmp_path: Path, diskfmt: Literal["h5ad", "zarr"])
     base = sparse.random(100, 100, format="csr")
 
     if diskfmt == "zarr":
-        f = zarr.open_group(path, "a")
+        f = zarr.open_group(store=path, mode="a")
     else:
         f = h5py.File(path, "a")
 

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -176,7 +176,7 @@ def test_io_dispatched_keys(tmp_path):
         write_dispatched(f, "/", adata, callback=h5ad_writer)
         _ = read_dispatched(f, h5ad_reader)
 
-    with zarr.open_group(zarr_path, "w") as f:
+    with zarr.open_group(store=zarr_path, mode="w") as f:
         write_dispatched(f, "/", adata, callback=zarr_writer)
         _ = read_dispatched(f, zarr_reader)
 

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -36,7 +36,7 @@ def store(request, tmp_path) -> H5Group | ZarrGroup:
         file = h5py.File(tmp_path / "test.h5", "w")
         store = file["/"]
     elif request.param == "zarr":
-        store = zarr.open(tmp_path / "test.zarr", "w")
+        store = zarr.open(store=tmp_path / "test.zarr", mode="w")
     else:
         pytest.fail(f"Unknown store type: {request.param}")
 
@@ -307,7 +307,7 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     pth = tmp_path / "test.zarr"
     adata = gen_adata((3, 2))
 
-    with zarr.open(pth, mode="w") as z:
+    with zarr.open(store=pth, mode="w") as z:
         write_elem(z, "table/table", adata)
 
         if consolidated:
@@ -318,7 +318,7 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     else:
         read_func = zarr.open
 
-    with read_func(pth) as z:
+    with read_func(store=pth) as z:
         expected = ad.read_zarr(z["table/table"])
     assert_equal(adata, expected)
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -255,7 +255,7 @@ def test_readwrite_equivalent_h5ad_zarr(tmp_path, typ):
 @contextmanager
 def store_context(path: Path):
     if path.suffix == ".zarr":
-        store = zarr.open(path, "r+")
+        store = zarr.open(store=path, mode="r+")
     else:
         file = h5py.File(path, "r+")
         store = file["/"]
@@ -334,7 +334,7 @@ def test_hdf5_compression_opts(tmp_path, compression, compression_opts):
 def test_zarr_compression(tmp_path):
     from numcodecs import Blosc
 
-    pth = str(Path(tmp_path) / "adata.zarr")
+    pth = Path(tmp_path) / "adata.zarr"
     adata = gen_adata((10, 8))
     compressor = Blosc(cname="zstd", clevel=3, shuffle=Blosc.BITSHUFFLE)
     not_compressed = []
@@ -346,7 +346,7 @@ def test_zarr_compression(tmp_path):
             if value.compressor != compressor:
                 not_compressed.append(key)
 
-    with zarr.open(str(pth), "r") as f:
+    with zarr.open(store=pth, mode="r") as f:
         f.visititems(check_compressed)
 
     if not_compressed:
@@ -712,7 +712,7 @@ def test_zarr_chunk_X(tmp_path):
     adata = gen_adata((100, 100), X_type=np.array)
     adata.write_zarr(zarr_pth, chunks=(10, 10))
 
-    z = zarr.open(str(zarr_pth))  # As of v2.3.2 zarr won’t take a Path
+    z = zarr.open(store=zarr_pth)
     assert z["X"].chunks == (10, 10)
     from_zarr = ad.read_zarr(zarr_pth)
     assert_equal(from_zarr, adata)


### PR DESCRIPTION
zarr 3 looks like it’s still in a pretty rough state, see e.g. the bug list on https://github.com/cubed-dev/cubed/issues/295