### PR TITLE
Backport PR #1532 on branch 0.10.x ((fix): allow setting X as sparse when X is dense view)

### DIFF
--- a/docs/release-notes/0.10.9.md
+++ b/docs/release-notes/0.10.9.md
@@ -4,6 +4,7 @@
 ```
 
 * Coerce {class}`numpy.matrix` classes to arrays when trying to store them in `AnnData` {pr}`1516` {user}`flying-sheep`
+* Fix for setting a dense `X` view with a sparse matrix {pr}`1532` {user}`ilan-gold`
 
 ```{rubric} Documentation
 ```

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -621,6 +621,16 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                         value, np.ndarray
                     ):
                         value = sparse.coo_matrix(value)
+                    elif sparse.issparse(value) and isinstance(
+                        self._adata_ref._X, np.ndarray
+                    ):
+                        warnings.warn(
+                            "Trying to set a dense array with a sparse array on a view."
+                            "Densifying the sparse array."
+                            "This may incur excessive memory usage",
+                            stacklevel=2,
+                        )
+                        value = value.toarray()
                     self._adata_ref._X[oidx, vidx] = value
                 else:
                     self._X = value

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -137,3 +137,18 @@ def test_io_missing_X(tmp_path, diskfmt):
     from_disk = read(file_pth)
 
     assert_equal(from_disk, adata)
+
+
+def test_set_dense_x_view_from_sparse():
+    x = np.zeros((100, 30))
+    x1 = np.ones((100, 30))
+    orig = ad.AnnData(x)
+    view = orig[:30]
+    with pytest.warns(
+        UserWarning,
+        match=r"Trying to set a dense array with a sparse array on a view",
+    ):
+        view.X = sparse.csr_matrix(x1[:30])
+    assert_equal(view.X, x1[:30])
+    assert_equal(orig.X[:30], x1[:30])  # change propagates through
+    assert_equal(orig.X[30:], x[30:])  # change propagates through


### PR DESCRIPTION


<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
