### PR TITLE
Backport PR #1501 on branch 0.10.x ((fix): add warning for setting X on view with repeat indices)

### DIFF
--- a/docs/release-notes/0.10.9.md
+++ b/docs/release-notes/0.10.9.md
@@ -3,6 +3,7 @@
 
 #### Bugfix
 
+* Add warning for setting `X` on a view with repeated indices {pr}`1501` {user}`ilan-gold`
 * Coerce {class}`numpy.matrix` classes to arrays when trying to store them in `AnnData` {pr}`1516` {user}`flying-sheep`
 * Fix for setting a dense `X` view with a sparse matrix {pr}`1532` {user}`ilan-gold`
 * Upper bound {mod}`numpy` for `gpu` installation on account of https://github.com/cupy/cupy/issues/8391 {pr}`1540` {user}`ilan-gold`

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -37,6 +37,17 @@ def test_setter_singular_dim(shape, orig_array_type, new_array_type):
     np.testing.assert_equal(asarray(adata.X), 1)
 
 
+def test_repeat_indices_view():
+    adata = gen_adata((10, 10), X_type=np.asarray)
+    subset = adata[[0, 0, 1, 1], :]
+    mat = np.array([np.ones(adata.shape[1]) * i for i in range(4)])
+    with pytest.warns(
+        FutureWarning,
+        match=r"You are attempting to set `X` to a matrix on a view which has non-unique indices",
+    ):
+        subset.X = mat
+
+
 ###############################
 # Tests for `adata.X is None` #
 ###############################


### PR DESCRIPTION
…peat indices

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
