### PR TITLE
Fix links

### DIFF
--- a/docs/extensions/patch_sphinx_toolbox_autoprotocol.py
+++ b/docs/extensions/patch_sphinx_toolbox_autoprotocol.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sphinx.ext.autodoc import ObjectMember
+from sphinx_toolbox.more_autodoc.autoprotocol import ProtocolDocumenter
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from sphinx.application import Sphinx
+
+
+def patch_sphinx_toolbox_autoprotocol():
+    """Compat hack: https://github.com/sphinx-toolbox/sphinx-toolbox/issues/168"""
+
+    class ObjectMemberCompat(ObjectMember):
+        @classmethod
+        def from_other(cls, other: ObjectMember) -> Self:
+            return cls(
+                other.__name__,
+                other.object,
+                docstring=other.docstring,
+                class_=other.class_,
+                skipped=other.skipped,
+            )
+
+        def __iter__(self):
+            return iter([self.__name__, self.object])
+
+    filter_orig = ProtocolDocumenter.filter_members
+
+    def filter_members(
+        self, members: list[ObjectMember], want_all: bool
+    ) -> list[tuple[str, object, bool]]:
+        member_tuples = [ObjectMemberCompat.from_other(m) for m in members]
+        return filter_orig(self, member_tuples, want_all)
+
+    ProtocolDocumenter.filter_members = filter_members
+
+
+def setup(_app: Sphinx) -> None:
+    patch_sphinx_toolbox_autoprotocol()

--- a/docs/release-notes/0.10.9.md
+++ b/docs/release-notes/0.10.9.md
@@ -6,9 +6,9 @@
 * Add warning for setting `X` on a view with repeated indices {pr}`1501` {user}`ilan-gold`
 * Coerce {class}`numpy.matrix` classes to arrays when trying to store them in `AnnData` {pr}`1516` {user}`flying-sheep`
 * Fix for setting a dense `X` view with a sparse matrix {pr}`1532` {user}`ilan-gold`
-* Upper bound {mod}`numpy` for `gpu` installation on account of https://github.com/cupy/cupy/issues/8391 {pr}`1540` {user}`ilan-gold`
+* Upper bound {mod}`numpy` for `gpu` installation on account of {issue}`cupy/cupy#8391` {pr}`1540` {user}`ilan-gold`
 * Fix writing large number of columns for `h5` files {pr}`1147` {user}`ilan-gold` {user}`selmanozleyen`
-* Upper bound dask on account of https://github.com/scverse/anndata/issues/1579 {pr}`1580` {user}`ilan-gold`
+* Upper bound dask on account of {issue}`1579` {pr}`1580` {user}`ilan-gold`
 
 #### Documentation
 

--- a/docs/release-notes/0.11.0.md
+++ b/docs/release-notes/0.11.0.md
@@ -6,8 +6,8 @@
 * Allow `axis` parameter of e.g. :func:`anndata.concat` to accept `'obs'` and `'var` {pr}`1244` {user}`flying-sheep`
 * Add `settings` object with methods for altering internally-used options, like checking for uniqueness on `obs`' index {pr}`1270` {user}`ilan-gold`
 * `scipy.sparse.csr_array` and `scipy.sparse.csc_array` are now supported when constructing `AnnData` objects {pr}`1028` {user}`ilan-gold` {user}`isaac-virshup`
-* Add {attr}`~anndata.settings.should_remove_unused_categories` option to `anndata.settings` to override current behavior {pr}`1340` {user}`ilan-gold`
-* Add {attr}`~anndata.settings.should_check_uniqueness` option to `anndata.settings` to override current behavior {pr}`1507` {user}`ilan-gold`
+* Add {attr}`~anndata.settings.should_remove_unused_categories` option to {attr}`anndata.settings` to override current behavior {pr}`1340` {user}`ilan-gold`
+* Add {attr}`~anndata.settings.should_check_uniqueness` option to {attr}`anndata.settings` to override current behavior {pr}`1507` {user}`ilan-gold`
 * Add :func:`~anndata.experimental.read_elem_as_dask` function to handle i/o with sparse and dense arrays {pr}`1469` {user}`ilan-gold`
 * Add functionality to write from GPU {class}`dask.array.Array` to disk {pr}`1550` {user}`ilan-gold`
 

--- a/docs/release-notes/0.11.0.md
+++ b/docs/release-notes/0.11.0.md
@@ -5,9 +5,9 @@
 
 * Allow `axis` parameter of e.g. :func:`anndata.concat` to accept `'obs'` and `'var` {pr}`1244` {user}`flying-sheep`
 * Add `settings` object with methods for altering internally-used options, like checking for uniqueness on `obs`' index {pr}`1270` {user}`ilan-gold`
-* Add `should_remove_unused_categories` option to `anndata.settings` to override current behavior.  Default is `True` (i.e., previous behavior).  Please refer to the [documentation](https://anndata.readthedocs.io/en/latest/generated/anndata.settings.html) for usage.  {pr}`1340` {user}`ilan-gold`
 * `scipy.sparse.csr_array` and `scipy.sparse.csc_array` are now supported when constructing `AnnData` objects {pr}`1028` {user}`ilan-gold` {user}`isaac-virshup`
-* Add `should_check_uniqueness` option to `anndata.settings` to override current behavior.  Default is `True` (i.e., previous behavior).  Please refer to the [documentation](https://anndata.readthedocs.io/en/latest/generated/anndata.settings.html) for usage.  {pr}`1507` {user}`ilan-gold`
+* Add {attr}`~anndata.settings.should_remove_unused_categories` option to `anndata.settings` to override current behavior {pr}`1340` {user}`ilan-gold`
+* Add {attr}`~anndata.settings.should_check_uniqueness` option to `anndata.settings` to override current behavior {pr}`1507` {user}`ilan-gold`
 * Add :func:`~anndata.experimental.read_elem_as_dask` function to handle i/o with sparse and dense arrays {pr}`1469` {user}`ilan-gold`
 * Add functionality to write from GPU {class}`dask.array.Array` to disk {pr}`1550` {user}`ilan-gold`
 

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -118,7 +118,7 @@ def check_and_get_environ_var(
 
 def check_and_get_bool(option, default_value):
     return check_and_get_environ_var(
-        "ANNDATA_" + option.upper(),
+        f"ANNDATA_{option.upper()}",
         str(int(default_value)),
         ["0", "1"],
         lambda x: bool(int(x)),
@@ -176,7 +176,7 @@ class SettingsManager:
         if option in self._deprecated_options:
             opt = self._deprecated_options[option]
             if opt.message is not None:
-                doc += " *" + opt.message
+                doc += f" *{opt.message}"
             doc += f" {option} will be removed in {opt.removal_version}.*"
         if print_description:
             print(doc)

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -150,7 +150,7 @@ class SettingsManager:
         self,
         option: str | Iterable[str] | None = None,
         *,
-        print_description: bool = True,
+        should_print_description: bool = True,
         rst: bool = False,
     ) -> str:
         """Print and/or return a (string) description of the option(s).
@@ -159,14 +159,16 @@ class SettingsManager:
         ----------
         option
             Option(s) to be described, by default None (i.e., do all option)
-        print_description
+        should_print_description
             Whether or not to print the description in addition to returning it.
 
         Returns
         -------
         The description.
         """
-        describe = partial(self.describe, print_description=print_description, rst=rst)
+        describe = partial(
+            self.describe, should_print_description=should_print_description, rst=rst
+        )
         if option is None:
             return describe(self._registered_options.keys())
         if isinstance(option, Iterable) and not isinstance(option, str):
@@ -178,7 +180,7 @@ class SettingsManager:
             if opt.message is not None:
                 doc += f" *{opt.message}"
             doc += f" {option} will be removed in {opt.removal_version}.*"
-        if print_description:
+        if should_print_description:
             print(doc)
         return doc
 
@@ -272,7 +274,9 @@ class SettingsManager:
         doc = cast(str, self.override.__doc__)
         insert_index = doc.find("\n        Yields")
         option_docstring = "\t" + "\t".join(
-            self.describe(option, print_description=False).splitlines(keepends=True)
+            self.describe(option, should_print_description=False).splitlines(
+                keepends=True
+            )
         )
         self.override.__func__.__doc__ = (
             f"{doc[:insert_index]}\n{option_docstring}{doc[insert_index:]}"
@@ -375,7 +379,9 @@ class SettingsManager:
     @property
     def __doc__(self):
         in_sphinx = any("/sphinx/" in frame.filename for frame in inspect.stack())
-        options_description = self.describe(print_description=False, rst=in_sphinx)
+        options_description = self.describe(
+            should_print_description=False, rst=in_sphinx
+        )
         return self.__doc_tmpl__.format(
             options_description=options_description,
         )

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -33,9 +33,9 @@ def _is_plain_type(obj: object) -> TypeGuard[type]:
     return isinstance(obj, type) and not isinstance(obj, GenericAlias)
 
 
-def describe(self: RegisteredOption, *, rst: bool = False) -> str:
+def describe(self: RegisteredOption, *, as_rst: bool = False) -> str:
     type_str = self.type.__name__ if _is_plain_type(self.type) else str(self.type)
-    if rst:
+    if as_rst:
         default_str = repr(self.default_value).replace("\\", "\\\\")
         doc = f"""\
         .. attribute:: settings.{self.option}
@@ -151,7 +151,7 @@ class SettingsManager:
         option: str | Iterable[str] | None = None,
         *,
         should_print_description: bool = True,
-        rst: bool = False,
+        as_rst: bool = False,
     ) -> str:
         """Print and/or return a (string) description of the option(s).
 
@@ -167,14 +167,16 @@ class SettingsManager:
         The description.
         """
         describe = partial(
-            self.describe, should_print_description=should_print_description, rst=rst
+            self.describe,
+            should_print_description=should_print_description,
+            as_rst=as_rst,
         )
         if option is None:
             return describe(self._registered_options.keys())
         if isinstance(option, Iterable) and not isinstance(option, str):
             return "\n".join([describe(k) for k in option])
         registered_option = self._registered_options[option]
-        doc = registered_option.describe(rst=rst).rstrip("\n")
+        doc = registered_option.describe(as_rst=as_rst).rstrip("\n")
         if option in self._deprecated_options:
             opt = self._deprecated_options[option]
             if opt.message is not None:
@@ -380,7 +382,7 @@ class SettingsManager:
     def __doc__(self):
         in_sphinx = any("/sphinx/" in frame.filename for frame in inspect.stack())
         options_description = self.describe(
-            should_print_description=False, rst=in_sphinx
+            should_print_description=False, as_rst=in_sphinx
         )
         return self.__doc_tmpl__.format(
             options_description=options_description,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -218,3 +218,28 @@ def test_check_and_get_bool_enum(monkeypatch: pytest.MonkeyPatch):
         b = True
 
     assert check_and_get_environ_var(option_env_var, "a", cast=TestEnum).value
+
+
+@pytest.mark.parametrize(
+    ("rst", "expected"),
+    [
+        pytest.param(
+            True,
+            (
+                ".. attribute:: settings.test_var_3\n"
+                "   :type: list[int]\n"
+                "   :value: [1, 2]\n"
+                "\n"
+                "   My doc string 3!"
+            ),
+            id="rst",
+        ),
+        pytest.param(
+            False,
+            "test_var_3: `list[int]`\n    My doc string 3! (default: `[1, 2]`).",
+            id="plain",
+        ),
+    ],
+)
+def test_describe(rst: bool, expected: str, settings: SettingsManager):
+    assert settings.describe("test_var_3", rst=rst) == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from enum import Enum
 
 import pytest
@@ -185,7 +186,9 @@ def test_check_and_get_environ_var(monkeypatch: pytest.MonkeyPatch):
         option_env_var, "foo", ["foo", "bar"], lambda x: hash(x)
     )
     monkeypatch.setenv(option_env_var, "Not foo or bar")
-    with pytest.warns(match=f'Value "{os.environ[option_env_var]}" is not in allowed'):
+    with pytest.warns(
+        match=f"Value '{re.escape(os.environ[option_env_var])}' is not in allowed"
+    ):
         check_and_get_environ_var(
             option_env_var, "foo", ["foo", "bar"], lambda x: hash(x)
         )
@@ -195,17 +198,19 @@ def test_check_and_get_environ_var(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_check_and_get_bool(monkeypatch: pytest.MonkeyPatch):
-    option_env_var = "ANNDATA_" + option.upper()
+    option_env_var = f"ANNDATA_{option.upper()}"
     assert not check_and_get_bool(option, default_val)
     monkeypatch.setenv(option_env_var, "1")
     assert check_and_get_bool(option, default_val)
     monkeypatch.setenv(option_env_var, "Not 0 or 1")
-    with pytest.warns(match=f'Value "{os.environ[option_env_var]}" is not in allowed'):
+    with pytest.warns(
+        match=f"Value '{re.escape(os.environ[option_env_var])}' is not in allowed"
+    ):
         check_and_get_bool(option, default_val)
 
 
 def test_check_and_get_bool_enum(monkeypatch: pytest.MonkeyPatch):
-    option_env_var = "ANNDATA_" + option.upper()
+    option_env_var = f"ANNDATA_{option.upper()}"
     monkeypatch.setenv(option_env_var, "b")
 
     class TestEnum(Enum):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -148,7 +148,7 @@ def test_deprecation(settings: SettingsManager):
     warning = "This is a deprecation warning!"
     version = "0.1.0"
     settings.deprecate(option, version, warning)
-    described_option = settings.describe(option, print_description=False)
+    described_option = settings.describe(option, should_print_description=False)
     # first line is message, second two from deprecation
     default_deprecation_message = f"{option} will be removed in {version}.*"
     assert described_option.endswith(default_deprecation_message)
@@ -166,14 +166,14 @@ def test_deprecation(settings: SettingsManager):
 def test_deprecation_no_message(settings: SettingsManager):
     version = "0.1.0"
     settings.deprecate(option, version)
-    described_option = settings.describe(option, print_description=False)
+    described_option = settings.describe(option, should_print_description=False)
     # first line is message, second from deprecation version
     assert described_option.endswith(f"{option} will be removed in {version}.*")
 
 
 def test_option_typing(settings: SettingsManager):
     assert settings._registered_options[option_3].type == type_3
-    assert str(type_3) in settings.describe(option_3, print_description=False)
+    assert str(type_3) in settings.describe(option_3, should_print_description=False)
 
 
 def test_check_and_get_environ_var(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -221,7 +221,7 @@ def test_check_and_get_bool_enum(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.parametrize(
-    ("rst", "expected"),
+    ("as_rst", "expected"),
     [
         pytest.param(
             True,
@@ -241,5 +241,5 @@ def test_check_and_get_bool_enum(monkeypatch: pytest.MonkeyPatch):
         ),
     ],
 )
-def test_describe(rst: bool, expected: str, settings: SettingsManager):
-    assert settings.describe("test_var_3", rst=rst) == expected
+def test_describe(as_rst: bool, expected: str, settings: SettingsManager):
+    assert settings.describe("test_var_3", as_rst=as_rst) == expected


### PR DESCRIPTION
Hi @ilan-gold, I fixed all the ugly URLs that ended up in the relnotes.

Please avoid them in the future and use the text roles we have available. Please:

- no plain URLs in the text (those don’t even get linkified as you see below)
- link to internal and external sphinx documentation using reference syntax: ``{mod}`anndata.settings` ``, and similarly `func`, `class`, `meth`, `attr`.
  Never `[...](https://something.readthedocs.io/...)`
- link to issues and prs using the roles `issue` and `pr`.

I also realized that the settings aren’t actually linkable and fixed that too.

<table>
<tr>
<th>before
<th>after

<tr>
<td>

![grafik](https://github.com/user-attachments/assets/955c28cd-03c0-4ea7-b367-c4b1b5d45434)

<td>

![grafik](https://github.com/user-attachments/assets/2c3fcbe8-6aa1-416e-9056-b30cb5de088a)

<tr>
<td>

![grafik](https://github.com/user-attachments/assets/28d1eff9-8426-44a1-9da0-17367fc6803a)

<td>

![grafik](https://github.com/user-attachments/assets/8adcf18a-d121-4cf9-b121-fc63cd28519e)

<tr>
<td>

![grafik](https://github.com/user-attachments/assets/e47e948d-4411-4f79-98ec-5d93ce86a234)
![grafik](https://github.com/user-attachments/assets/121810ac-969a-4164-9923-d0f62bcb77de)

<td>

![grafik](https://github.com/user-attachments/assets/e2304d7e-fbb6-49b4-9b52-e18eca283192)

</table>
