### PR TITLE
Revert "Backport PR #1474: Make `strings_to_categoricals` upon `.write()` optional (#1584)"

### DIFF
--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -47,7 +47,6 @@ def write_h5ad(
     adata: AnnData,
     *,
     as_dense: Sequence[str] = (),
-    strings_to_categoricals: bool = True,
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
     **kwargs,
 ) -> None:
@@ -63,10 +62,9 @@ def write_h5ad(
     if "raw/X" in as_dense and adata.raw is None:
         raise ValueError("Cannot specify writing `raw/X` to dense if it doesn’t exist.")
 
-    if strings_to_categoricals:
-        adata.strings_to_categoricals()
-        if adata.raw is not None:
-            adata.strings_to_categoricals(adata.raw.var)
+    adata.strings_to_categoricals()
+    if adata.raw is not None:
+        adata.strings_to_categoricals(adata.raw.var)
     dataset_kwargs = {**dataset_kwargs, **kwargs}
     filepath = Path(filepath)
     mode = "a" if adata.isbacked else "w"

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -26,17 +26,14 @@ T = TypeVar("T")
 def write_zarr(
     store: MutableMapping | str | Path,
     adata: AnnData,
-    *,
-    chunks: tuple[int, ...] | None = None,
-    strings_to_categoricals: bool = True,
+    chunks=None,
     **ds_kwargs,
 ) -> None:
     if isinstance(store, Path):
         store = str(store)
-    if strings_to_categoricals:
-        adata.strings_to_categoricals()
-        if adata.raw is not None:
-            adata.strings_to_categoricals(adata.raw.var)
+    adata.strings_to_categoricals()
+    if adata.raw is not None:
+        adata.strings_to_categoricals(adata.raw.var)
     # TODO: Use spec writing system for this
     f = zarr.open(store, mode="w")
     f.attrs.setdefault("encoding-type", "anndata")
@@ -44,8 +41,9 @@ def write_zarr(
 
     def callback(func, s, k, elem, dataset_kwargs, iospec):
         if chunks is not None and not isinstance(elem, sparse.spmatrix) and k == "/X":
-            dataset_kwargs = dict(dataset_kwargs, chunks=chunks)
-        func(s, k, elem, dataset_kwargs=dataset_kwargs)
+            func(s, k, elem, dataset_kwargs=dict(chunks=chunks, **dataset_kwargs))
+        else:
+            func(s, k, elem, dataset_kwargs=dataset_kwargs)
 
     write_dispatched(f, "/", adata, callback=callback, dataset_kwargs=ds_kwargs)
 


### PR DESCRIPTION


This reverts commit 66f9a2c303a3a91806c28ab2182e79cbc6513aa7.

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
