### PR TITLE
(fix): comment out broken benchmark

### DIFF
--- a/benchmarks/benchmarks/readwrite.py
+++ b/benchmarks/benchmarks/readwrite.py
@@ -127,8 +127,9 @@ class H5ADReadSuite:
     def peakmem_read_backed(self, *_):
         anndata.read_h5ad(self.filepath, backed="r")
 
-    def mem_read_backed_object(self, *_):
-        return anndata.read_h5ad(self.filepath, backed="r")
+    # causes benchmarking to break from: https://github.com/pympler/pympler/issues/151
+    # def mem_read_backed_object(self, *_):
+    #     return anndata.read_h5ad(self.filepath, backed="r")
 
 
 class H5ADWriteSuite:


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
Until we can actually figure out https://github.com/pympler/pympler/issues/151, I think it's better to comment this out than fail the whole suite.  Alternatively, we could change the success/failure of the job to not be dependent on individual runs, but I don't like that so much.
- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
