### PR TITLE
(fix): use `typing_extensions` for `NamedTuple`

### DIFF
--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import os
-import sys
 import textwrap
 import warnings
 from collections.abc import Iterable
@@ -12,7 +11,10 @@ from enum import Enum
 from functools import partial
 from inspect import Parameter, signature
 from types import GenericAlias
-from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
+
+# For why here and not typing: https://github.com/python/typing_extensions/pull/44
+from typing_extensions import NamedTuple
 
 from anndata.compat.exceptiongroups import add_note
 
@@ -52,27 +54,14 @@ def describe(self: RegisteredOption, *, as_rst: bool = False) -> str:
     return textwrap.dedent(doc)
 
 
-if sys.version_info >= (3, 10):
+class RegisteredOption(NamedTuple, Generic[T]):
+    option: str
+    default_value: T
+    description: str
+    validate: Callable[[T], None]
+    type: object
 
-    class RegisteredOption(NamedTuple, Generic[T]):
-        option: str
-        default_value: T
-        description: str
-        validate: Callable[[T], None]
-        type: object
-
-        describe = describe
-
-else:
-
-    class RegisteredOption(NamedTuple):
-        option: str
-        default_value: T
-        description: str
-        validate: Callable[[T], None]
-        type: object
-
-        describe = describe
+    describe = describe
 
 
 def check_and_get_environ_var(


### PR DESCRIPTION
I was off on the version in my comment or we just missed I meant "greater than": https://github.com/python/cpython/pull/92027

In any case, we can just use `typing_extensions`: https://github.com/python/typing_extensions/pull/44

Previously, this was causing issues with 3.10 as this was the case not covered (this feature broke in 3.9, but is fixed in 3.11, and we special cased <3.10).

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
