### PR TITLE
(fix): minimum `python` version `3.11` for`NamedTuple` with `Generic`

### DIFF
--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -52,7 +52,7 @@ def describe(self: RegisteredOption, *, as_rst: bool = False) -> str:
     return textwrap.dedent(doc)
 
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 11):
 
     class RegisteredOption(NamedTuple, Generic[T]):
         option: str


### PR DESCRIPTION
I was off on the version in my old comment: https://github.com/python/cpython/pull/92027

In any case, we can just use typing_extensions: https://github.com/python/typing_extensions/pull/44 but I don't think it's worth it so we'll just correct the feature version for the check.

Previously, this was causing issues with 3.10 as this was the case not covered (this feature broke in 3.9, but is fixed in 3.11, and we special cased <3.10).

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
