### PR TITLE
Backport PR #1589: (fix): disallow using dataframes with multi index columns

### DIFF
--- a/docs/release-notes/0.10.9.md
+++ b/docs/release-notes/0.10.9.md
@@ -9,6 +9,7 @@
 * Upper bound {mod}`numpy` for `gpu` installation on account of {issue}`cupy/cupy#8391` {pr}`1540` {user}`ilan-gold`
 * Fix writing large number of columns for `h5` files {pr}`1147` {user}`ilan-gold` {user}`selmanozleyen`
 * Upper bound dask on account of {issue}`1579` {pr}`1580` {user}`ilan-gold`
+* Disallow using {class}`~pandas.DataFrame`s with multi-index columns {pr}`1589` {user}`ilan-gold`
 * Ensure setting {attr}`pandas.DataFrame.index` on a view of a {class}`~anndata.AnnData` instantiates the {class}`~pandas.DataFrame` from the view {pr}`1586` {user}`ilan-gold`
 
 #### Documentation

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -19,7 +19,11 @@ from ..compat import (
     ZappyArray,
     ZarrArray,
 )
-from ..utils import ensure_df_homogeneous, join_english
+from ..utils import (
+    ensure_df_homogeneous,
+    join_english,
+    raise_value_error_if_multiindex_columns,
+)
 from .sparse_dataset import BaseCompressedSparseDataset
 
 if TYPE_CHECKING:
@@ -82,6 +86,8 @@ def coerce_array(
             value = value.A
         return value
     if isinstance(value, pd.DataFrame):
+        if allow_df:
+            raise_value_error_if_multiindex_columns(value, name)
         return value if allow_df else ensure_df_homogeneous(value, name)
     # if value is an array-like object, try to convert it
     e = None

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import random
 import re
 import warnings
@@ -785,3 +786,13 @@ except ImportError:
             raise ImportError(
                 "zarr must be imported to create an `AccessTrackingStore` instance."
             )
+
+
+def get_multiindex_columns_df(shape):
+    return pd.DataFrame(
+        np.random.rand(shape[0], shape[1]),
+        columns=pd.MultiIndex.from_tuples(
+            list(itertools.product(["a"], range(shape[1] - (shape[1] // 2))))
+            + list(itertools.product(["b"], range(shape[1] // 2)))
+        ),
+    )

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -399,3 +399,12 @@ class DeprecationMixinMeta(type):
             for item in type.__dir__(cls)
             if not is_hidden(getattr(cls, item, None))
         ]
+
+
+def raise_value_error_if_multiindex_columns(df: pd.DataFrame, attr: str):
+    if isinstance(df.columns, pd.MultiIndex):
+        msg = (
+            "MultiIndex columns are not supported in AnnData. "
+            f"Please use a single-level index for {attr}."
+        )
+        raise ValueError(msg)

--- a/tests/test_annot.py
+++ b/tests/test_annot.py
@@ -8,6 +8,7 @@ import pytest
 from natsort import natsorted
 
 import anndata as ad
+from anndata.tests.helpers import get_multiindex_columns_df
 
 
 @pytest.mark.parametrize("dtype", [object, "string"])
@@ -63,3 +64,10 @@ def test_non_str_to_not_categorical():
     result_non_transformed = adata.obs.drop(columns=["str_with_nan"])
 
     pd.testing.assert_frame_equal(expected_non_transformed, result_non_transformed)
+
+
+def test_error_multiindex():
+    adata = ad.AnnData(np.random.rand(100, 10))
+    df = get_multiindex_columns_df((adata.shape[0], 20))
+    with pytest.raises(ValueError, match=r"MultiIndex columns are not supported"):
+        adata.obs = df

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,7 +12,7 @@ from scipy import sparse as sp
 from scipy.sparse import csr_matrix, issparse
 
 from anndata import AnnData, ImplicitModificationWarning
-from anndata.tests.helpers import assert_equal, gen_adata
+from anndata.tests.helpers import assert_equal, gen_adata, get_multiindex_columns_df
 
 # some test objects that we use below
 adata_dense = AnnData(np.array([[1, 2], [3, 4]]))
@@ -111,6 +111,14 @@ def test_create_from_df():
     assert df.values.tolist() == ad.X.tolist()
     assert df.columns.tolist() == ad.var_names.tolist()
     assert df.index.tolist() == ad.obs_names.tolist()
+
+
+@pytest.mark.parametrize("attr", ["X", "obs", "obsm"])
+def test_error_create_from_multiindex_df(attr):
+    df = get_multiindex_columns_df((100, 20))
+    val = df if attr != "obsm" else {"df": df}
+    with pytest.raises(ValueError, match=r"MultiIndex columns are not supported"):
+        AnnData(**{attr: val}, shape=(100, 10))
 
 
 def test_create_from_sparse_df():

--- a/tests/test_obsmvarm.py
+++ b/tests/test_obsmvarm.py
@@ -7,6 +7,7 @@ import pytest
 from scipy import sparse
 
 from anndata import AnnData
+from anndata.tests.helpers import get_multiindex_columns_df
 
 M, N = (100, 100)
 
@@ -137,3 +138,9 @@ def test_shape_error(adata: AnnData):
         ),
     ):
         adata.obsm["b"] = np.zeros((adata.shape[0] + 1, adata.shape[0]))
+
+
+def test_error_set_multiindex_df(adata: AnnData):
+    df = get_multiindex_columns_df((adata.shape[0], 20))
+    with pytest.raises(ValueError, match=r"MultiIndex columns are not supported"):
+        adata.obsm["df"] = df


### PR DESCRIPTION


<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
