### PR TITLE
Add hatch-test env customization

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -9,3 +9,19 @@ dependencies = ["setuptools"]  # https://bitbucket.org/pybtex-devs/pybtex/issues
 [envs.docs.scripts]
 build = "sphinx-build -M html docs docs/_build -W --keep-going {args}"
 clean = "git clean -fX -- docs"
+
+[envs.hatch-test]
+default-args = []
+extra-dependencies = ["ipykernel"]
+features = ["dev", "test"]
+overrides.matrix.deps.env-vars = [
+    { key = "UV_PRERELEASE", value = "allow", if = ["pre"] },
+    { key = "UV_RESOLUTION", value = "lowest-direct", if = ["min"] },
+]
+overrides.matrix.deps.python = [
+    { if = ["min"], value = "3.9" },
+    { if = ["stable", "pre"], value = "3.12" },
+]
+
+[[envs.hatch-test.matrix]]
+deps = ["stable", "pre", "min"]

--- a/hatch.toml
+++ b/hatch.toml
@@ -6,7 +6,7 @@ features = ["dev"]
 features = ["doc"]
 extra-dependencies = ["setuptools"]  # https://bitbucket.org/pybtex-devs/pybtex/issues/169
 scripts.build = "sphinx-build -M html docs docs/_build -W --keep-going {args}"
-scripts.clean = "git clean -fX -- docs"
+scripts.clean = "git clean -fdX -- {args:docs}"
 
 [envs.towncrier]
 scripts.build = "python3 ci/scripts/towncrier_automation.py {args}"


### PR DESCRIPTION
This allows us to locally test with an approximation of our online test envs:

```console
$ hatch test # regular, stable resolution. Also `hatch test -i deps=stable`
$ hatch test -i deps=pre  # pre-releases
$ hatch test -i deps=min  # Python 3.0 and minimum possible dep versions.
$ hatch test --all
```

Approximation because `UV_RESOLUTION=lowest-direct` doesn’t directly match our min-deps ci script. Maybe we should get rid of the custom version number semantics in that one and just switch to `UV_RESOLUTION=lowest-direct`

---

I want this because I had a custom `hatch.toml` that got nuked when we added one to the branch, oops!