### PR TITLE
(fix): regex for release notes on docs build

### DIFF
--- a/docs/extensions/release_notes.py
+++ b/docs/extensions/release_notes.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
-FULL_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:\.dev.*)?$")
+FULL_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(\.dev.*)|(rc.*))?$")
 
 
 class ReleaseNotes(SphinxDirective):


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
