### PR TITLE
Fix towncrier Git CLI call

### DIFF
--- a/ci/scripts/towncrier_automation.py
+++ b/ci/scripts/towncrier_automation.py
@@ -76,7 +76,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     # push
     if not args.dry_run:
         subprocess.run(
-            ["git", "push", "--set-upstream=origin", branch_name], check=True
+            ["git", "push", "--set-upstream", "origin", branch_name], check=True
         )
     else:
         print("Dry run, not pushing")


### PR DESCRIPTION
Turns out that `--set-upstream` doesn’t have an argument and I confused it with `--set-upstream-to=...`.