### PR TITLE
Fix VCS-derived version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ dask = ["dask[array]>=2022.09.2,<2024.8.0"]
 source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/anndata/_version.py"
+raw-options.version_scheme = "release-branch-semver"
 [tool.hatch.build.targets.wheel]
 packages = ["src/anndata", "src/testing"]
 


### PR DESCRIPTION
See https://setuptools-scm.readthedocs.io/en/latest/extending/#setuptools_scmversion_scheme

> Semantic versioning for projects with release branches. The same as `guess-next-dev` (incrementing the pre-release or micro segment) however when on a release branch: a branch whose name (ignoring namespace) parses as a version that matches the most recent tag up to the minor segment. Otherwise if on a non-release branch, increments the minor segment and sets the micro segment to zero, then appends `.devN`

Apparently the “ignoring namespace” makes it work with our `<major>.<minor>.x` branch names
