### PR TITLE
Fix typing for optional imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ from importlib import metadata
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
-import zarr as _  # noqa: F401  # Makes {read,write}_zarr show up in docs.
 from docutils import nodes
 
 if TYPE_CHECKING:

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -26,12 +26,6 @@ import numpy as np
 import scipy.sparse as ss
 from scipy.sparse import _sparsetools
 
-try:
-    # Not really important, just for IDEs to be more helpful
-    from scipy.sparse._compressed import _cs_matrix
-except ImportError:
-    from scipy.sparse import spmatrix as _cs_matrix
-
 from .. import abc
 from .._settings import settings
 from ..compat import H5Group, SpArray, ZarrArray, ZarrGroup, _read_attr
@@ -41,8 +35,12 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Literal
 
+    from scipy.sparse._compressed import _cs_matrix
+
     from .._types import GroupStorageType
     from .index import Index
+else:
+    from scipy.sparse import spmatrix as _cs_matrix
 
 
 class BackedFormat(NamedTuple):

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -108,6 +108,7 @@ else:
 
 
 if find_spec("awkward") or TYPE_CHECKING:
+    import awkward  # noqa: F401
     from awkward import Array as AwkArray
 else:
 

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from functools import singledispatch, wraps
+from importlib.util import find_spec
 from inspect import Parameter, signature
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, Union
@@ -90,107 +91,89 @@ else:
 # Optional deps
 #############################
 
-if TYPE_CHECKING:
+if find_spec("zarr") or TYPE_CHECKING:
     from zarr.core import Array as ZarrArray
     from zarr.hierarchy import Group as ZarrGroup
 else:
-    try:
-        from zarr.core import Array as ZarrArray
-        from zarr.hierarchy import Group as ZarrGroup
-    except ImportError:
 
-        class ZarrArray:
-            @staticmethod
-            def __repr__():
-                return "mock zarr.core.Array"
+    class ZarrArray:
+        @staticmethod
+        def __repr__():
+            return "mock zarr.core.Array"
 
-        class ZarrGroup:
-            @staticmethod
-            def __repr__():
-                return "mock zarr.core.Group"
+    class ZarrGroup:
+        @staticmethod
+        def __repr__():
+            return "mock zarr.core.Group"
 
 
-if TYPE_CHECKING:
+if find_spec("awkward") or TYPE_CHECKING:
     from awkward import Array as AwkArray
 else:
-    try:
-        from awkward import Array as AwkArray
-    except ImportError:
 
-        class AwkArray:
-            @staticmethod
-            def __repr__():
-                return "mock awkward.highlevel.Array"
+    class AwkArray:
+        @staticmethod
+        def __repr__():
+            return "mock awkward.highlevel.Array"
 
 
-if TYPE_CHECKING:
+if find_spec("zappy") or TYPE_CHECKING:
     from zappy.base import ZappyArray
 else:
-    try:
-        from zappy.base import ZappyArray
-    except ImportError:
 
-        class ZappyArray:
-            @staticmethod
-            def __repr__():
-                return "mock zappy.base.ZappyArray"
+    class ZappyArray:
+        @staticmethod
+        def __repr__():
+            return "mock zappy.base.ZappyArray"
 
 
 if TYPE_CHECKING:
     # type checkers are confused and can only see …core.Array
     from dask.array.core import Array as DaskArray
+elif find_spec("dask"):
+    from dask.array import Array as DaskArray
 else:
-    try:
-        from dask.array import Array as DaskArray
-    except ImportError:
 
-        class DaskArray:
-            @staticmethod
-            def __repr__():
-                return "mock dask.array.core.Array"
+    class DaskArray:
+        @staticmethod
+        def __repr__():
+            return "mock dask.array.core.Array"
 
 
-if TYPE_CHECKING:
+if find_spec("cupy") or TYPE_CHECKING:
     from cupy import ndarray as CupyArray
     from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
     from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
     from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
-else:
+
     try:
-        from cupy import ndarray as CupyArray
-        from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
-        from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
-        from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
-
-        try:
-            import dask.array as da
-        except ImportError:
-            pass
-        else:
-            da.register_chunk_type(CupyCSRMatrix)
-            da.register_chunk_type(CupyCSCMatrix)
-
+        import dask.array as da
     except ImportError:
+        pass
+    else:
+        da.register_chunk_type(CupyCSRMatrix)
+        da.register_chunk_type(CupyCSCMatrix)
+else:
 
-        class CupySparseMatrix:
-            @staticmethod
-            def __repr__():
-                return "mock cupyx.scipy.sparse.spmatrix"
+    class CupySparseMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.spmatrix"
 
-        class CupyCSRMatrix:
-            @staticmethod
-            def __repr__():
-                return "mock cupyx.scipy.sparse.csr_matrix"
+    class CupyCSRMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.csr_matrix"
 
-        class CupyCSCMatrix:
-            @staticmethod
-            def __repr__():
-                return "mock cupyx.scipy.sparse.csc_matrix"
+    class CupyCSCMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.csc_matrix"
 
-        class CupyArray:
-            @staticmethod
-            def __repr__():
-                return "mock cupy.ndarray"
+    class CupyArray:
+        @staticmethod
+        def __repr__():
+            return "mock cupy.ndarray"
 
 
 #############################

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -90,96 +90,107 @@ else:
 # Optional deps
 #############################
 
-try:
+if TYPE_CHECKING:
     from zarr.core import Array as ZarrArray
     from zarr.hierarchy import Group as ZarrGroup
-except ImportError:
-
-    class ZarrArray:
-        @staticmethod
-        def __repr__():
-            return "mock zarr.core.Array"
-
-    class ZarrGroup:
-        @staticmethod
-        def __repr__():
-            return "mock zarr.core.Group"
-
-
-try:
-    import awkward
-
-    AwkArray = awkward.Array
-
-except ImportError:
-
-    class AwkArray:
-        @staticmethod
-        def __repr__():
-            return "mock awkward.highlevel.Array"
-
-
-try:
-    from zappy.base import ZappyArray
-except ImportError:
-
-    class ZappyArray:
-        @staticmethod
-        def __repr__():
-            return "mock zappy.base.ZappyArray"
-
-
-try:
-    from dask.array import Array as DaskArray
-except ImportError:
-
-    class DaskArray:
-        @staticmethod
-        def __repr__():
-            return "mock dask.array.core.Array"
-
-
-try:
-    from cupy import ndarray as CupyArray
-    from cupyx.scipy.sparse import (
-        csc_matrix as CupyCSCMatrix,
-    )
-    from cupyx.scipy.sparse import (
-        csr_matrix as CupyCSRMatrix,
-    )
-    from cupyx.scipy.sparse import (
-        spmatrix as CupySparseMatrix,
-    )
-
+else:
     try:
-        import dask.array as da
-
-        da.register_chunk_type(CupyCSRMatrix)
-        da.register_chunk_type(CupyCSCMatrix)
+        from zarr.core import Array as ZarrArray
+        from zarr.hierarchy import Group as ZarrGroup
     except ImportError:
-        pass
 
-except ImportError:
+        class ZarrArray:
+            @staticmethod
+            def __repr__():
+                return "mock zarr.core.Array"
 
-    class CupySparseMatrix:
-        @staticmethod
-        def __repr__():
-            return "mock cupyx.scipy.sparse.spmatrix"
+        class ZarrGroup:
+            @staticmethod
+            def __repr__():
+                return "mock zarr.core.Group"
 
-    class CupyCSRMatrix:
-        @staticmethod
-        def __repr__():
-            return "mock cupyx.scipy.sparse.csr_matrix"
 
-    class CupyCSCMatrix:
-        @staticmethod
-        def __repr__():
-            return "mock cupyx.scipy.sparse.csc_matrix"
+if TYPE_CHECKING:
+    from awkward import Array as AwkArray
+else:
+    try:
+        from awkward import Array as AwkArray
+    except ImportError:
 
-    class CupyArray:
-        @staticmethod
-        def __repr__():
-            return "mock cupy.ndarray"
+        class AwkArray:
+            @staticmethod
+            def __repr__():
+                return "mock awkward.highlevel.Array"
+
+
+if TYPE_CHECKING:
+    from zappy.base import ZappyArray
+else:
+    try:
+        from zappy.base import ZappyArray
+    except ImportError:
+
+        class ZappyArray:
+            @staticmethod
+            def __repr__():
+                return "mock zappy.base.ZappyArray"
+
+
+if TYPE_CHECKING:
+    # type checkers are confused and can only see …core.Array
+    from dask.array.core import Array as DaskArray
+else:
+    try:
+        from dask.array import Array as DaskArray
+    except ImportError:
+
+        class DaskArray:
+            @staticmethod
+            def __repr__():
+                return "mock dask.array.core.Array"
+
+
+if TYPE_CHECKING:
+    from cupy import ndarray as CupyArray
+    from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
+    from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
+    from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
+else:
+    try:
+        from cupy import ndarray as CupyArray
+        from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
+        from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
+        from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
+
+        try:
+            import dask.array as da
+        except ImportError:
+            pass
+        else:
+            da.register_chunk_type(CupyCSRMatrix)
+            da.register_chunk_type(CupyCSCMatrix)
+
+    except ImportError:
+
+        class CupySparseMatrix:
+            @staticmethod
+            def __repr__():
+                return "mock cupyx.scipy.sparse.spmatrix"
+
+        class CupyCSRMatrix:
+            @staticmethod
+            def __repr__():
+                return "mock cupyx.scipy.sparse.csr_matrix"
+
+        class CupyCSCMatrix:
+            @staticmethod
+            def __repr__():
+                return "mock cupyx.scipy.sparse.csc_matrix"
+
+        class CupyArray:
+            @staticmethod
+            def __repr__():
+                return "mock cupy.ndarray"
 
 
 #############################

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -14,11 +14,14 @@ from ..multi_files._anncollection import AnnCollection, _ConcatViewMixin
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-try:
     import torch
     from torch.utils.data import BatchSampler, DataLoader, Sampler
-except ImportError:
-    Sampler, BatchSampler, DataLoader = object, object, object
+else:
+    try:
+        import torch
+        from torch.utils.data import BatchSampler, DataLoader, Sampler
+    except ImportError:
+        Sampler, BatchSampler, DataLoader = object, object, object
 
 
 # Custom sampler to get proper batches instead of joined separate indices

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 from functools import partial
+from importlib.util import find_spec
 from math import ceil
 from typing import TYPE_CHECKING
 
@@ -14,14 +15,11 @@ from ..multi_files._anncollection import AnnCollection, _ConcatViewMixin
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+if find_spec("torch") or TYPE_CHECKING:
     import torch
     from torch.utils.data import BatchSampler, DataLoader, Sampler
 else:
-    try:
-        import torch
-        from torch.utils.data import BatchSampler, DataLoader, Sampler
-    except ImportError:
-        Sampler, BatchSampler, DataLoader = object, object, object
+    Sampler, BatchSampler, DataLoader = object, object, object
 
 
 # Custom sampler to get proper batches instead of joined separate indices

--- a/src/anndata/io.py
+++ b/src/anndata/io.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 from ._core.sparse_dataset import sparse_dataset
@@ -17,11 +17,10 @@ from ._io.read import (
 from ._io.specs import read_elem, write_elem
 from ._io.write import write_csvs, write_loom
 
-if "zarr" in sys.modules or TYPE_CHECKING:
+if find_spec("zarr") or TYPE_CHECKING:
     from ._io.zarr import read_zarr, write_zarr
 else:
-    # In case zarr is not imported (and maybe not installed),
-    # wrap these functions into shims.
+
     def read_zarr(*args, **kw):  # pragma: no cover
         from ._io.zarr import read_zarr
 

--- a/src/anndata/io.py
+++ b/src/anndata/io.py
@@ -19,17 +19,13 @@ from ._io.write import write_csvs, write_loom
 
 if find_spec("zarr") or TYPE_CHECKING:
     from ._io.zarr import read_zarr, write_zarr
-else:
+else:  # pragma: no cover
 
-    def read_zarr(*args, **kw):  # pragma: no cover
-        from ._io.zarr import read_zarr
+    def read_zarr(*args, **kw):
+        raise ImportError("zarr is not installed")
 
-        return read_zarr(*args, **kw)
-
-    def write_zarr(*args, **kw):  # pragma: no cover
-        from ._io.zarr import write_zarr
-
-        return write_zarr(*args, **kw)
+    def write_zarr(*args, **kw):
+        raise ImportError("zarr is not installed")
 
 
 __all__ = [

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -4,6 +4,7 @@ import itertools
 import random
 import re
 import warnings
+from collections import Counter
 from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial, singledispatch, wraps
@@ -35,7 +36,7 @@ from anndata.compat import (
 from anndata.utils import asarray
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Iterable
     from typing import Callable, Literal, TypeGuard, TypeVar
 
     DT = TypeVar("DT")
@@ -1037,46 +1038,52 @@ DASK_CUPY_MATRIX_PARAMS = [
     ),
 ]
 
-try:
-    import zarr
+if TYPE_CHECKING:
+    from zarr import DirectoryStore
+else:
+    try:
+        from zarr import DirectoryStore
+    except ImportError:
 
-    class AccessTrackingStore(zarr.DirectoryStore):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._access_count = {}
-            self._accessed_keys = {}
-
-        def __getitem__(self, key):
-            for tracked in self._access_count:
-                if tracked in key:
-                    self._access_count[tracked] += 1
-                    self._accessed_keys[tracked] += [key]
-            return super().__getitem__(key)
-
-        def get_access_count(self, key):
-            return self._access_count[key]
-
-        def get_accessed_keys(self, key):
-            return self._accessed_keys[key]
-
-        def initialize_key_trackers(self, keys_to_track):
-            for k in keys_to_track:
-                self._access_count[k] = 0
-                self._accessed_keys[k] = []
-
-        def reset_key_trackers(self):
-            self.initialize_key_trackers(self._access_count.keys())
-
-except ImportError:
-
-    class AccessTrackingStore:
-        def __init__(self, *_args, **_kwargs) -> None:
-            raise ImportError(
-                "zarr must be imported to create an `AccessTrackingStore` instance."
-            )
+        class DirectoryStore:
+            def __init__(self, *_args, **_kwargs) -> None:
+                cls_name = type(self).__name__
+                msg = f"zarr must be imported to create a {cls_name} instance."
+                raise ImportError(msg)
 
 
-def get_multiindex_columns_df(shape):
+class AccessTrackingStore(DirectoryStore):
+    _access_count: Counter[str]
+    _accessed_keys: dict[str, list[str]]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._access_count = Counter()
+        self._accessed_keys = {}
+
+    def __getitem__(self, key: str) -> object:
+        for tracked in self._access_count:
+            if tracked in key:
+                self._access_count[tracked] += 1
+                self._accessed_keys[tracked] += [key]
+        return super().__getitem__(key)
+
+    def get_access_count(self, key: str) -> int:
+        return self._access_count[key]
+
+    def get_accessed_keys(self, key: str) -> list[str]:
+        return self._accessed_keys[key]
+
+    def initialize_key_trackers(self, keys_to_track: Iterable[str]) -> None:
+        for k in keys_to_track:
+            self._access_count[k] = 0
+            self._accessed_keys[k] = []
+
+    def reset_key_trackers(self) -> None:
+        self.initialize_key_trackers(self._access_count.keys())
+
+
+def get_multiindex_columns_df(shape: tuple[int, int]) -> pd.DataFrame:
     return pd.DataFrame(
         np.random.rand(shape[0], shape[1]),
         columns=pd.MultiIndex.from_tuples(

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -8,6 +8,7 @@ from collections import Counter
 from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial, singledispatch, wraps
+from importlib.util import find_spec
 from string import ascii_letters
 from typing import TYPE_CHECKING
 
@@ -1038,18 +1039,15 @@ DASK_CUPY_MATRIX_PARAMS = [
     ),
 ]
 
-if TYPE_CHECKING:
+if find_spec("zarr") or TYPE_CHECKING:
     from zarr import DirectoryStore
 else:
-    try:
-        from zarr import DirectoryStore
-    except ImportError:
 
-        class DirectoryStore:
-            def __init__(self, *_args, **_kwargs) -> None:
-                cls_name = type(self).__name__
-                msg = f"zarr must be imported to create a {cls_name} instance."
-                raise ImportError(msg)
+    class DirectoryStore:
+        def __init__(self, *_args, **_kwargs) -> None:
+            cls_name = type(self).__name__
+            msg = f"zarr must be imported to create a {cls_name} instance."
+            raise ImportError(msg)
 
 
 class AccessTrackingStore(DirectoryStore):


### PR DESCRIPTION
Inspired by #1682

The coverage hasn’t changed from before this PR I think. We could definitely add `# pragma: no cover` to the `else` branches for zarr, as we test only with it, but idk what the best approach for the others is.