### PR TITLE
(fix): raise error on non-integer floating types in iterables

### DIFF
--- a/docs/release-notes/1746.bugfix.md
+++ b/docs/release-notes/1746.bugfix.md
@@ -1,0 +1,1 @@
+Error out on floating point indices that are not actually integers {user}`ilan-gold`

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -82,6 +82,10 @@ def _normalize_index(
             indexer = np.array(indexer)
             if len(indexer) == 0:
                 indexer = indexer.astype(int)
+        if isinstance(indexer, np.ndarray) and indexer.dtype == float:
+            indexer_int = indexer.astype(int)
+            if np.all((indexer - indexer_int) != 0):
+                raise IndexError(f"Indexer {indexer!r} has floating point values.")
         if issubclass(indexer.dtype.type, np.integer | np.floating):
             return indexer  # Might not work for range indexes
         elif issubclass(indexer.dtype.type, np.bool_):

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -82,7 +82,9 @@ def _normalize_index(
             indexer = np.array(indexer)
             if len(indexer) == 0:
                 indexer = indexer.astype(int)
-        if isinstance(indexer, np.ndarray) and indexer.dtype == float:
+        if isinstance(indexer, np.ndarray) and np.issubdtype(
+            indexer.dtype, np.floating
+        ):
             indexer_int = indexer.astype(int)
             if np.all((indexer - indexer_int) != 0):
                 raise IndexError(f"Indexer {indexer!r} has floating point values.")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -818,8 +818,11 @@ def test_index_3d_errors(index: tuple[int | EllipsisType, ...], expected_error: 
     "index",
     [
         pytest.param(sparse.csr_matrix(np.random.random((1, 10))), id="sparse"),
-        pytest.param(np.array([1.2, 2.3]), id="ndarray"),
         pytest.param([1.2, 3.4], id="list"),
+        *(
+            pytest.param(np.array([1.2, 2.3], dtype=dtype), id=f"ndarray-{dtype}")
+            for dtype in [np.float32, np.float64]
+        ),
     ],
 )
 def test_index_float_sequence_raises_error(index):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -814,6 +814,19 @@ def test_index_3d_errors(index: tuple[int | EllipsisType, ...], expected_error: 
         gen_adata((10, 10))[index]
 
 
+@pytest.mark.parametrize(
+    "index",
+    [
+        pytest.param(sparse.csr_matrix(np.random.random((1, 10))), id="sparse"),
+        pytest.param(np.array([1.2, 2.3]), id="ndarray"),
+        pytest.param([1.2, 3.4], id="list"),
+    ],
+)
+def test_index_float_sequence_raises_error(index):
+    with pytest.raises(IndexError, match=r"has floating point values"):
+        gen_adata((10, 10))[index]
+
+
 # @pytest.mark.parametrize("dim", ["obs", "var"])
 # @pytest.mark.parametrize(
 #     ("idx", "pat"),


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1735
- [x] Tests added
- [x] Release note added (or unnecessary)
