### PR TITLE
(fix): resolve cupy import error on `cupy-cuda12x<0.13`

### DIFF
--- a/docs/release-notes/1754.bugfix.md
+++ b/docs/release-notes/1754.bugfix.md
@@ -1,0 +1,1 @@
+Fix `cupy<0.13` imports in non-gpu environments {user}`ilan-gold`

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -140,7 +140,16 @@ else:
             return "mock dask.array.core.Array"
 
 
-if find_spec("cupy") or TYPE_CHECKING:
+# https://github.com/scverse/anndata/issues/1749
+def is_cupy_importable() -> bool:
+    try:
+        import cupy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+if is_cupy_importable() or TYPE_CHECKING:
     from cupy import ndarray as CupyArray
     from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
     from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1749
- [ ] Tests added
- [ ] Release note added (or unnecessary)
