### PR TITLE
(fix): python debugger dask h5 meta array

### DIFF
--- a/ci/scripts/towncrier_automation.py
+++ b/ci/scripts/towncrier_automation.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
+from functools import cache
 from typing import TYPE_CHECKING
 
 from packaging.version import Version
@@ -11,8 +13,33 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+class BumpVersion(Version):
+    def __init__(self, version: str) -> None:
+        super().__init__(version)
+
+        if len(self.release) != 3:
+            msg = f"{version} must contain major, minor, and patch version."
+            raise argparse.ArgumentTypeError(msg)
+
+        base_branch = get_base_branch()
+        patch_branch_pattern = re.compile(r"\d+\.\d+\.x")
+        if self.micro != 0 and not patch_branch_pattern.fullmatch(base_branch):
+            msg = (
+                f"{version} is a patch release, but "
+                f"you are trying to release from a non-patch release branch: {base_branch}."
+            )
+            raise argparse.ArgumentTypeError(msg)
+
+        if self.micro == 0 and base_branch != "main":
+            msg = (
+                f"{version} is a minor or major release, "
+                f"but you are trying to release not from main: {base_branch}."
+            )
+            raise argparse.ArgumentTypeError(msg)
+
+
 class Args(argparse.Namespace):
-    version: str
+    version: BumpVersion
     dry_run: bool
 
 
@@ -28,7 +55,7 @@ def parse_args(argv: Sequence[str] | None = None) -> Args:
     )
     parser.add_argument(
         "version",
-        type=str,
+        type=BumpVersion,
         help=(
             "The new version for the release must have at least three parts, like `major.minor.patch` and no `major.minor`. "
             "It can have a suffix like `major.minor.patch.dev0` or `major.minor.0rc1`."
@@ -40,10 +67,6 @@ def parse_args(argv: Sequence[str] | None = None) -> Args:
         action="store_true",
     )
     args = parser.parse_args(argv, Args())
-    # validate the version
-    if len(Version(args.version).release) != 3:
-        msg = f"Version argument {args.version} must contain major, minor, and patch version."
-        raise ValueError(msg)
     return args
 
 
@@ -56,12 +79,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     # Check if we are on the main branch to know if we need to backport
-    base_branch = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+    base_branch = get_base_branch()
     pr_description = "" if base_branch == "main" else "@meeseeksdev backport to main"
     branch_name = f"release_notes_{args.version}"
 
@@ -102,6 +120,16 @@ def main(argv: Sequence[str] | None = None) -> None:
         )
     else:
         print("Dry run, not merging")
+
+
+@cache
+def get_base_branch():
+    return subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
 
 
 if __name__ == "__main__":

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -150,7 +150,7 @@ def read_h5_array(
             c if c not in {None, -1} else s for c, s in zip(chunks, shape, strict=True)
         )
         if chunks is not None
-        else (_DEFAULT_STRIDE,) * len(shape)
+        else tuple(min(_DEFAULT_STRIDE, s) for s in shape)
     )
 
     chunk_layout = tuple(
@@ -159,7 +159,9 @@ def read_h5_array(
     )
 
     make_chunk = partial(make_dask_chunk, path, elem_name)
-    return da.map_blocks(make_chunk, dtype=dtype, chunks=chunk_layout)
+    return da.map_blocks(
+        make_chunk, dtype=dtype, chunks=chunk_layout, meta=np.array([])
+    )
 
 
 @_LAZY_REGISTRY.register_read(ZarrArray, IOSpec("array", "0.2.0"))

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -74,7 +74,9 @@ def sparse_format(request):
     return request.param
 
 
-def create_dense_store(store: str, *, shape=DEFAULT_SHAPE) -> H5Group | ZarrGroup:
+def create_dense_store(
+    store: str, *, shape: tuple[int, ...] = DEFAULT_SHAPE
+) -> H5Group | ZarrGroup:
     X = np.random.randn(*shape)
 
     write_elem(store, "X", X)

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -319,7 +319,7 @@ def test_read_lazy_h5_cluster(sparse_format, tmp_path):
         assert_equal(X_from_disk, X_dask_from_disk)
 
 
-def test_undersized_shape_to_default(store):
+def test_undersized_shape_to_default(store: H5Group | ZarrGroup):
     shape = (3000, 50)
     arr_store = create_dense_store(store, shape=shape)
     X_dask_from_disk = read_elem_as_dask(arr_store["X"])


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
Noticed while using the python debugger - dask sets `block_info` to `None` when run this way, which causes the function to error but setting `meta` (probably a good idea anyway) prevents this.

This also drive-by fixes an "internal" bug which did not have an effect downstream, but still noticed.  And I added a test (which passes anyway without this change, but still a sensible test).

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary): does not change runtime behavior
