### PR TITLE
IO: treat arrays with an empty shape like scalars when writing

### DIFF
--- a/docs/release-notes/1783.bugfix.md
+++ b/docs/release-notes/1783.bugfix.md
@@ -1,0 +1,1 @@
+`write_elem` now filters out incompatible `dataset_kwargs` when saving zero-dimensional arrays {user}`ilia-kats`

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -495,7 +495,9 @@ def write_vlen_string_array(
         _writer.write_elem(f, k, elem[()], dataset_kwargs=dataset_kwargs)
     else:
         str_dtype = h5py.special_dtype(vlen=str)
-        f.create_dataset(k, data=elem.astype(str_dtype), dtype=str_dtype, **dataset_kwargs)
+        f.create_dataset(
+            k, data=elem.astype(str_dtype), dtype=str_dtype, **dataset_kwargs
+        )
 
 
 @_REGISTRY.register_write(
@@ -1146,7 +1148,14 @@ def write_hdf5_scalar(
 ):
     # Can’t compress scalars, error is thrown
     dataset_kwargs = dict(dataset_kwargs)
-    for arg in ("compression", "compression_opts", "chunks", "shuffle", "fletcher32", "scaleoffset"):
+    for arg in (
+        "compression",
+        "compression_opts",
+        "chunks",
+        "shuffle",
+        "fletcher32",
+        "scaleoffset",
+    ):
         dataset_kwargs.pop(arg, None)
     f.create_dataset(key, data=np.array(value), **dataset_kwargs)
 

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -1137,7 +1137,14 @@ def write_hdf5_scalar(
 ):
     # Can’t compress scalars, error is thrown
     dataset_kwargs = dict(dataset_kwargs)
-    for arg in ("compression", "compression_opts", "chunks", "shuffle", "fletcher32", "scaleoffset"):
+    for arg in (
+        "compression",
+        "compression_opts",
+        "chunks",
+        "shuffle",
+        "fletcher32",
+        "scaleoffset",
+    ):
         dataset_kwargs.pop(arg, None)
     f.create_dataset(key, data=np.array(value), **dataset_kwargs)
 

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -21,7 +21,7 @@ from anndata._core import views
 from anndata._core.index import _normalize_indices
 from anndata._core.merge import intersect_keys
 from anndata._core.sparse_dataset import _CSCDataset, _CSRDataset, sparse_dataset
-from anndata._io.utils import H5PY_V3, check_key, zero_dim_array
+from anndata._io.utils import H5PY_V3, check_key, zero_dim_array_as_scalar
 from anndata._warnings import OldFormatWarning
 from anndata.compat import (
     AwkArray,
@@ -382,7 +382,7 @@ def write_list(
 @_REGISTRY.register_write(ZarrGroup, h5py.Dataset, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, np.ma.MaskedArray, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, ZarrArray, IOSpec("array", "0.2.0"))
-@zero_dim_array
+@zero_dim_array_as_scalar
 def write_basic(
     f: GroupStorageType,
     k: str,
@@ -478,7 +478,7 @@ def read_string_array_partial(d, items=None, indices=slice(None)):
 )
 @_REGISTRY.register_write(H5Group, (np.ndarray, "U"), IOSpec("string-array", "0.2.0"))
 @_REGISTRY.register_write(H5Group, (np.ndarray, "O"), IOSpec("string-array", "0.2.0"))
-@zero_dim_array
+@zero_dim_array_as_scalar
 def write_vlen_string_array(
     f: H5Group,
     k: str,
@@ -500,7 +500,7 @@ def write_vlen_string_array(
 )
 @_REGISTRY.register_write(ZarrGroup, (np.ndarray, "U"), IOSpec("string-array", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, (np.ndarray, "O"), IOSpec("string-array", "0.2.0"))
-@zero_dim_array
+@zero_dim_array_as_scalar
 def write_vlen_string_array_zarr(
     f: ZarrGroup,
     k: str,
@@ -1137,14 +1137,7 @@ def write_hdf5_scalar(
 ):
     # Can’t compress scalars, error is thrown
     dataset_kwargs = dict(dataset_kwargs)
-    for arg in (
-        "compression",
-        "compression_opts",
-        "chunks",
-        "shuffle",
-        "fletcher32",
-        "scaleoffset",
-    ):
+    for arg in ("compression", "compression_opts", "chunks", "shuffle", "fletcher32", "scaleoffset"):
         dataset_kwargs.pop(arg, None)
     f.create_dataset(key, data=np.array(value), **dataset_kwargs)
 

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import wraps
+from functools import wraps, WRAPPER_ASSIGNMENTS
 from itertools import pairwise
 from typing import TYPE_CHECKING, cast
 from warnings import warn
@@ -285,3 +285,16 @@ def _read_legacy_raw(
     if "varm" in attrs and "raw.varm" in f:
         raw["varm"] = read_attr(f["raw.varm"])
     return raw
+
+def zero_dim_array(func):
+    """\
+    A decorator for write_elem implementations of arrays where zero-dimensional arrays need special handling.
+    """
+    @wraps(func, assigned=WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
+    def func_wrapper(f, k, elem, *, _writer, dataset_kwargs):
+        if elem.shape == ():
+            _writer.write_elem(f, k, elem[()], dataset_kwargs=dataset_kwargs)
+        else:
+            func(f, k, elem, _writer=_writer, dataset_kwargs=dataset_kwargs)
+
+    return func_wrapper

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -12,10 +12,11 @@ from .._core.sparse_dataset import BaseCompressedSparseDataset
 from ..compat import add_note
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Literal
+    from collections.abc import Callable, Mapping
+    from typing import Literal, Any
 
-    from .._types import StorageType
+    from .specs.registry import Writer
+    from .._types import StorageType, _WriteInternal, ContravariantRWAble
     from ..compat import H5Group, ZarrGroup
 
     Storage = StorageType | BaseCompressedSparseDataset
@@ -287,13 +288,13 @@ def _read_legacy_raw(
     return raw
 
 
-def zero_dim_array(func):
+def zero_dim_array_as_scalar(func: _WriteInternal):
     """\
     A decorator for write_elem implementations of arrays where zero-dimensional arrays need special handling.
     """
 
     @wraps(func, assigned=WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
-    def func_wrapper(f, k, elem, *, _writer, dataset_kwargs):
+    def func_wrapper(f: StorageType, k: str, elem: ContravariantRWAble, *, _writer: Writer, dataset_kwargs: Mapping[str, Any]):
         if elem.shape == ():
             _writer.write_elem(f, k, elem[()], dataset_kwargs=dataset_kwargs)
         else:

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import wraps, WRAPPER_ASSIGNMENTS
+from functools import WRAPPER_ASSIGNMENTS, wraps
 from itertools import pairwise
 from typing import TYPE_CHECKING, cast
 from warnings import warn
@@ -286,10 +286,12 @@ def _read_legacy_raw(
         raw["varm"] = read_attr(f["raw.varm"])
     return raw
 
+
 def zero_dim_array(func):
     """\
     A decorator for write_elem implementations of arrays where zero-dimensional arrays need special handling.
     """
+
     @wraps(func, assigned=WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
     def func_wrapper(f, k, elem, *, _writer, dataset_kwargs):
         if elem.shape == ():

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -13,11 +13,11 @@ from ..compat import add_note
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
-    from typing import Literal, Any
+    from typing import Any, Literal
 
-    from .specs.registry import Writer
-    from .._types import StorageType, _WriteInternal, ContravariantRWAble
+    from .._types import ContravariantRWAble, StorageType, _WriteInternal
     from ..compat import H5Group, ZarrGroup
+    from .specs.registry import Writer
 
     Storage = StorageType | BaseCompressedSparseDataset
 
@@ -294,7 +294,14 @@ def zero_dim_array_as_scalar(func: _WriteInternal):
     """
 
     @wraps(func, assigned=WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
-    def func_wrapper(f: StorageType, k: str, elem: ContravariantRWAble, *, _writer: Writer, dataset_kwargs: Mapping[str, Any]):
+    def func_wrapper(
+        f: StorageType,
+        k: str,
+        elem: ContravariantRWAble,
+        *,
+        _writer: Writer,
+        dataset_kwargs: Mapping[str, Any],
+    ):
         if elem.shape == ():
             _writer.write_elem(f, k, elem[()], dataset_kwargs=dataset_kwargs)
         else:

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -208,6 +208,7 @@ def test_io_spec(store, value, encoding_type):
     assert_equal(value, from_disk)
     assert get_spec(store[key]) == _REGISTRY.get_spec(value)
 
+
 @pytest.mark.parametrize(
     ("value", "encoding_type"),
     [
@@ -219,12 +220,15 @@ def test_io_spec(store, value, encoding_type):
 )
 def test_io_spec_compressed_scalars(store: G, value: np.ndarray, encoding_type: str):
     key = f"key_for_{encoding_type}"
-    write_elem(store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5})
+    write_elem(
+        store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5}
+    )
 
     assert encoding_type == _read_attr(store[key].attrs, "encoding-type")
 
     from_disk = read_elem(store[key])
     assert_equal(value, from_disk)
+
 
 # Can't instantiate cupy types at the top level, so converting them within the test
 @pytest.mark.gpu

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -208,6 +208,7 @@ def test_io_spec(store, value, encoding_type):
     assert_equal(value, from_disk)
     assert get_spec(store[key]) == _REGISTRY.get_spec(value)
 
+
 @pytest.mark.parametrize(
     ("value", "encoding_type"),
     [
@@ -219,12 +220,15 @@ def test_io_spec(store, value, encoding_type):
 )
 def test_io_spec_compressed_scalars(store, value, encoding_type):
     key = f"key_for_{encoding_type}"
-    write_elem(store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5})
+    write_elem(
+        store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5}
+    )
 
     assert encoding_type == _read_attr(store[key].attrs, "encoding-type")
 
     from_disk = read_elem(store[key])
     assert_equal(value, from_disk)
+
 
 # Can't instantiate cupy types at the top level, so converting them within the test
 @pytest.mark.gpu

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -208,7 +208,6 @@ def test_io_spec(store, value, encoding_type):
     assert_equal(value, from_disk)
     assert get_spec(store[key]) == _REGISTRY.get_spec(value)
 
-
 @pytest.mark.parametrize(
     ("value", "encoding_type"),
     [
@@ -218,17 +217,14 @@ def test_io_spec(store, value, encoding_type):
         pytest.param(np.asarray("test"), "string", id="scalar_string"),
     ],
 )
-def test_io_spec_compressed_scalars(store, value, encoding_type):
+def test_io_spec_compressed_scalars(store: G, value: np.ndarray, encoding_type: str):
     key = f"key_for_{encoding_type}"
-    write_elem(
-        store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5}
-    )
+    write_elem(store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5})
 
     assert encoding_type == _read_attr(store[key].attrs, "encoding-type")
 
     from_disk = read_elem(store[key])
     assert_equal(value, from_disk)
-
 
 # Can't instantiate cupy types at the top level, so converting them within the test
 @pytest.mark.gpu

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -208,6 +208,23 @@ def test_io_spec(store, value, encoding_type):
     assert_equal(value, from_disk)
     assert get_spec(store[key]) == _REGISTRY.get_spec(value)
 
+@pytest.mark.parametrize(
+    ("value", "encoding_type"),
+    [
+        pytest.param(np.asarray(1), "numeric-scalar", id="scalar_int"),
+        pytest.param(np.asarray(1.0), "numeric-scalar", id="scalar_float"),
+        pytest.param(np.asarray(True), "numeric-scalar", id="scalar_bool"),
+        pytest.param(np.asarray("test"), "string", id="scalar_string"),
+    ],
+)
+def test_io_spec_compressed_scalars(store, value, encoding_type):
+    key = f"key_for_{encoding_type}"
+    write_elem(store, key, value, dataset_kwargs={"compression": "gzip", "compression_opts": 5})
+
+    assert encoding_type == _read_attr(store[key].attrs, "encoding-type")
+
+    from_disk = read_elem(store[key])
+    assert_equal(value, from_disk)
 
 # Can't instantiate cupy types at the top level, so converting them within the test
 @pytest.mark.gpu


### PR DESCRIPTION
h5py treats arrays with empty shapes as scalars and raises an exception if dataset_kwargs has options incompatible with scalars. So let's treat these arrays like scalars ourselves and filter out incompatible options.

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [x] Tests added
- [x] Release note added