### PR TITLE
(performance): speedup for `zarr`-based sparse indexing

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -72,7 +72,9 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install AnnData
-        run: uv pip install --system -e ".[dev,test,cu12]" llvmlite>=0.43
+        run:
+          printf "llvmlite>=0.43\nscanpy>=1.10.0rc1" | tee /tmp/constraints.txt
+          uv pip install --system -e ".[dev,test,cu12]" -c /tmp/constraints.txt
 
       - name: Env list
         run: pip list

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -72,7 +72,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install AnnData
-        run:
+        run: |
           printf "llvmlite>=0.43\nscanpy>=1.10.0rc1" | tee /tmp/constraints.txt
           uv pip install --system -e ".[dev,test,cu12]" -c /tmp/constraints.txt
 

--- a/docs/release-notes/1790.performance.md
+++ b/docs/release-notes/1790.performance.md
@@ -1,1 +1,1 @@
-Batch slice-based indexing in {class}`anndata.abc.CSRDataset` and {class}`anndata.abc.CSCDataset` for performance boost in {mod}`zarr` {user}`ilan-gold`
+Batch slice-based indexing in {class}`anndata.abc.CSRDataset` and {class}`anndata.abc.CSCDataset` for performance boost in `zarr` {user}`ilan-gold`

--- a/docs/release-notes/1790.performance.md
+++ b/docs/release-notes/1790.performance.md
@@ -1,0 +1,1 @@
+Batch slice-based indexing in {class}`anndata.abc.CSRDataset` and {class}`anndata.abc.CSCDataset` for performance boost in {mod}`zarr` {user}`ilan-gold`

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -67,25 +67,14 @@ class BackedSparseMatrix(_cs_matrix):
             return sparse_dataset(self.data.parent).to_memory()
         if isinstance(self.data, ZarrArray):
             import zarr
-            from packaging.version import Version
 
-            is_zarr_v2 = Version(zarr.__version__) < Version("3.0.0b0")
-            if is_zarr_v2:
-                sparse_group = zarr.open(
+            return sparse_dataset(
+                zarr.open(
                     store=self.data.store,
                     mode="r",
                     chunk_store=self.data.chunk_store,  # chunk_store is needed, not clear why
                 )[Path(self.data.path).parent]
-            else:
-                anndata_group = zarr.open_group(store=self.data.store, mode="r")
-                sparse_group = anndata_group[
-                    str(
-                        Path(str(self.data.store_path))
-                        .relative_to(str(anndata_group.store_path))
-                        .parent
-                    )
-                ]
-            return sparse_dataset(sparse_group).to_memory()
+            ).to_memory()
         return super().copy()
 
     def _set_many(self, i: Iterable[int], j: Iterable[int], x):

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -250,30 +250,44 @@ def slice_as_int(s: slice, l: int) -> int:
 def get_compressed_vectors(
     x: BackedSparseMatrix, row_idxs: Iterable[int]
 ) -> tuple[Sequence, Sequence, Sequence]:
-    slices = [slice(*(x.indptr[i : i + 2])) for i in row_idxs]
-    data = np.concatenate([x.data[s] for s in slices])
-    indices = np.concatenate([x.indices[s] for s in slices])
-    indptr = list(accumulate(chain((0,), (s.stop - s.start for s in slices))))
+    indptr_slices = [slice(*(x.indptr[i : i + 2])) for i in row_idxs]
+    # HDF5 cannot handle out-of-order integer indexing
+    if isinstance(x.data, ZarrArray):
+        as_np_indptr = np.concatenate(
+            [np.arange(s.start, s.stop) for s in indptr_slices]
+        )
+        data = x.data[as_np_indptr]
+        indices = x.indices[as_np_indptr]
+    else:
+        data = np.concatenate([x.data[s] for s in indptr_slices])
+        indices = np.concatenate([x.indices[s] for s in indptr_slices])
+    indptr = list(accumulate(chain((0,), (s.stop - s.start for s in indptr_slices))))
     return data, indices, indptr
 
 
 def get_compressed_vectors_for_slices(
     x: BackedSparseMatrix, slices: Iterable[slice]
 ) -> tuple[Sequence, Sequence, Sequence]:
-    indptr_sels = [x.indptr[slice(s.start, s.stop + 1)] for s in slices]
-    data = np.concatenate([x.data[s[0] : s[-1]] for s in indptr_sels])
-    indices = np.concatenate([x.indices[s[0] : s[-1]] for s in indptr_sels])
+    indptr_list = [x.indptr[slice(s.start, s.stop + 1)] for s in slices]
+    # HDF5 cannot handle out-of-order integer indexing
+    if isinstance(x.data, ZarrArray):
+        indptr_int = np.concatenate([np.arange(s[0], s[-1]) for s in indptr_list])
+        data = x.data[indptr_int]
+        indices = x.indices[indptr_int]
+    else:
+        data = np.concatenate([x.data[s[0] : s[-1]] for s in indptr_list])
+        indices = np.concatenate([x.indices[s[0] : s[-1]] for s in indptr_list])
     # Need to track the size of the gaps in the slices to each indptr subselection
-    total = indptr_sels[0][0]
+    total = indptr_list[0][0]
     offsets = [total]
-    for i, sel in enumerate(indptr_sels[1:]):
-        total = (sel[0] - indptr_sels[i][-1]) + total
+    for i, sel in enumerate(indptr_list[1:]):
+        total = (sel[0] - indptr_list[i][-1]) + total
         offsets.append(total)
-    start_indptr = indptr_sels[0] - offsets[0]
+    start_indptr = indptr_list[0] - offsets[0]
     if len(slices) < 2:  # there is only one slice so no need to concatenate
         return data, indices, start_indptr
     end_indptr = np.concatenate(
-        [s[1:] - offsets[i + 1] for i, s in enumerate(indptr_sels[1:])]
+        [s[1:] - offsets[i + 1] for i, s in enumerate(indptr_list[1:])]
     )
     indptr = np.concatenate([start_indptr, end_indptr])
     return data, indices, indptr

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -273,14 +273,14 @@ def get_compressed_vectors_for_slices(
     # HDF5 cannot handle out-of-order integer indexing
     if isinstance(x.data, ZarrArray):
         indptr_int = np.concatenate(
-            [np.arange(start, stop) for (start, stop) in indptr_limits]
+            [np.arange(start, stop) for start, stop in indptr_limits]
         )
         data = x.data[indptr_int]
         indices = x.indices[indptr_int]
     else:
-        data = np.concatenate([x.data[start:stop] for (start, stop) in indptr_limits])
+        data = np.concatenate([x.data[start:stop] for start, stop in indptr_limits])
         indices = np.concatenate(
-            [x.indices[start:stop] for (start, stop) in indptr_limits]
+            [x.indices[start:stop] for start, stop in indptr_limits]
         )
     # Need to track the size of the gaps in the slices to each indptr subselection
     offsets = [indptr_indices[0][0]]

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -16,7 +16,7 @@ import warnings
 from abc import ABC
 from collections.abc import Iterable
 from functools import cached_property
-from itertools import accumulate, chain
+from itertools import accumulate, chain, pairwise
 from math import floor
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
@@ -280,20 +280,23 @@ def get_compressed_vectors_for_slices(
     x: BackedSparseMatrix, slices: Iterable[slice]
 ) -> tuple[Sequence, Sequence, Sequence]:
     indptr_indices = [x.indptr[slice(s.start, s.stop + 1)] for s in slices]
+    indptr_limits = [(i[0], i[-1]) for i in indptr_indices]
     # HDF5 cannot handle out-of-order integer indexing
     if isinstance(x.data, ZarrArray):
-        indptr_int = np.concatenate([np.arange(s[0], s[-1]) for s in indptr_indices])
+        indptr_int = np.concatenate(
+            [np.arange(start, stop) for (start, stop) in indptr_limits]
+        )
         data = x.data[indptr_int]
         indices = x.indices[indptr_int]
     else:
-        data = np.concatenate([x.data[s[0] : s[-1]] for s in indptr_indices])
-        indices = np.concatenate([x.indices[s[0] : s[-1]] for s in indptr_indices])
+        data = np.concatenate([x.data[start:stop] for (start, stop) in indptr_limits])
+        indices = np.concatenate(
+            [x.indices[start:stop] for (start, stop) in indptr_limits]
+        )
     # Need to track the size of the gaps in the slices to each indptr subselection
-    total = indptr_indices[0][0]
-    offsets = [total]
-    for i, sel in enumerate(indptr_indices[1:]):
-        total = (sel[0] - indptr_indices[i][-1]) + total
-        offsets.append(total)
+    offsets = [indptr_indices[0][0]]
+    for (_, stop0), (start1, _) in pairwise(indptr_limits):
+        offsets.append((start1 - stop0) + offsets[-1])
     start_indptr = indptr_indices[0] - offsets[0]
     if len(slices) < 2:  # there is only one slice so no need to concatenate
         return data, indices, start_indptr

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -523,9 +523,9 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
                 f"Matrices must have same format. Currently are "
                 f"{self.format!r} and {sparse_matrix.format!r}"
             )
-        [indptr_offset] = self.group["indices"].shape
+        indptr_offset = len(self.group["indices"])
         if self.group["indptr"].dtype == np.int32:
-            new_nnz = indptr_offset + sparse_matrix.indices.shape[0]
+            new_nnz = indptr_offset + len(sparse_matrix.indices)
             if new_nnz >= np.iinfo(np.int32).max:
                 raise OverflowError(
                     "This array was written with a 32 bit intptr, but is now large "


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

```python
import scipy.sparse as sp
import numpy as np
import anndata as ad
import zarr
from pathlib import Path

data_path = Path('data/foo.zarr')
if not data_path.exists():
    z = zarr.open_group('data/foo.zarr', mode='w')
    arr = sp.random(1_000_000, 10_000, format="csr", random_state=np.random.default_rng())
    ad.io.write_elem(z, "X", arr)
z = zarr.open_group('data/foo.zarr', mode='r')

adata = ad.AnnData(X=ad.io.sparse_dataset(z["X"]))
idx = np.random.randint(0, adata.shape[0], 1024)
idx.sort()
%time adata[idx].X
```
On my computer, this is a 3-5X speedup.

- [ ] Closes #
- [ ] Tests added
- [x] Release note added (or unnecessary)
