### PR TITLE
(chore): pin `zarr`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     # array-api-compat 1.5 has https://github.com/scverse/anndata/issues/1410
     "array_api_compat>1.4,!=1.5",
     "legacy-api-wrap",
+    "zarr<3.0.0"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
This represents a rather large change for us, which I had not realized.  We are pinning `zarr` as a test dependency but not as a normal one (not the first time I have misread that).  This could lead to users downloading the wrong version (in fact, it will, if they are not aware of out implicit constraint).

At this point it probably makes sense to add it in...

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
