### PR TITLE
(chore): disallow `AnnData(...)` with non-csr{r,c} matrices/arrays

### DIFF
--- a/docs/release-notes/1829.breaking.md
+++ b/docs/release-notes/1829.breaking.md
@@ -1,0 +1,1 @@
+Disallow declaration of {class}`~anndata.AnnData` with non-`cs{r,c}` sparse data-structures {user}`ilan-gold`

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -41,14 +41,15 @@ def coerce_array(
             warnings.warn(msg, ImplicitModificationWarning)
             value = value.A
         return value
-    is_non_csr_c_matrix = isinstance(value, sparse.spmatrix) and not isinstance(
-        value, sparse.csr_matrix | sparse.csc_matrix
+    is_non_csc_r_array_or_matrix = (
+        (isinstance(value, base) and not isinstance(value, csr_c_format))
+        for base, csr_c_format in [
+            (sparse.spmatrix, sparse.csr_matrix | sparse.csc_matrix),
+            (SpArray, sparse.csr_array | sparse.csc_array),
+        ]
     )
-    is_non_csr_c_array = isinstance(value, SpArray) and not isinstance(
-        value, sparse.csr_array | sparse.csc_array
-    )
-    if is_non_csr_c_array or is_non_csr_c_matrix:
-        msg = f"Only CSR and CSC {'matrices' if is_non_csr_c_matrix else 'arrays'} are supported."
+    if any(is_non_csc_r_array_or_matrix):
+        msg = f"Only CSR and CSC {'matrices' if isinstance(value, sparse.spmatrix) else 'arrays'} are supported."
         raise ValueError(msg)
     if isinstance(value, pd.DataFrame):
         if allow_df:

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
+from anndata.compat import SpArray
+
 from .._warnings import ImplicitModificationWarning
 from ..utils import (
     ensure_df_homogeneous,
@@ -39,14 +41,15 @@ def coerce_array(
             warnings.warn(msg, ImplicitModificationWarning)
             value = value.A
         return value
-    elif isinstance(value, sparse.spmatrix):
-        msg = (
-            f"AnnData previously had undefined behavior around matrices of type {type(value)}."
-            "In 0.12, passing in this type will throw an error. Please convert to a supported type."
-            "Continue using for this minor version at your own risk."
-        )
-        warnings.warn(msg, FutureWarning)
-        return value
+    is_non_csr_c_matrix = isinstance(value, sparse.spmatrix) and not isinstance(
+        value, sparse.csr_matrix | sparse.csc_matrix
+    )
+    is_non_csr_c_array = isinstance(value, SpArray) and not isinstance(
+        value, sparse.csr_array | sparse.csc_array
+    )
+    if is_non_csr_c_array or is_non_csr_c_matrix:
+        msg = f"Only CSR and CSC {'matrices' if is_non_csr_c_matrix else 'arrays'} are supported."
+        raise ValueError(msg)
     if isinstance(value, pd.DataFrame):
         if allow_df:
             raise_value_error_if_multiindex_columns(value, name)

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -184,10 +184,10 @@ def test_set_dense_x_view_from_sparse():
     assert_equal(orig.X[30:], x[30:])  # change propagates through
 
 
-def test_warn_on_non_csr_csc_matrix():
-    X = sparse.eye(100)
-    with pytest.warns(
-        FutureWarning,
-        match=rf"AnnData previously had undefined behavior around matrices of type {type(X)}.*",
+def test_fail_on_non_csr_csc_matrix():
+    X = sparse.eye(100, format="coo")
+    with pytest.raises(
+        ValueError,
+        match=r"Only CSR and CSC.*",
     ):
         ad.AnnData(X=X)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Towards https://github.com/scverse/anndata/issues/1649, removing the ability to instantiate the class externally is a great start (thanks to @flying-sheep for the reminder: https://github.com/scverse/scanpy/pull/3431#discussion_r1918116620)
- [x] Tests added
- [ ] Release note added (or unnecessary)
