### PR TITLE
(chore): Update version number inference in dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__/
 # Distribution / packaging
 /dist/
 /ci/min-deps.txt
-/src/anndata/_version.py
 /requirements*.lock
 /.python-version
 

--- a/docs/release-notes/1831.dev.md
+++ b/docs/release-notes/1831.dev.md
@@ -1,0 +1,1 @@
+Fix version number inference in development environments (CI and local) {user}`flying-sheep`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ dask = ["dask[array]>=2022.09.2,!=2024.8.*,!=2024.9.*"]
 
 [tool.hatch.version]
 source = "vcs"
-[tool.hatch.build.hooks.vcs]
 raw-options.version_scheme = "release-branch-semver"
 [tool.hatch.build.targets.wheel]
 packages = ["src/anndata", "src/testing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "h5py>=3.7",
     "exceptiongroup; python_version<'3.11'",
     "natsort",
-    "packaging>=20.0",
+    "packaging>=24.2",
     # array-api-compat 1.5 has https://github.com/scverse/anndata/issues/1410
     "array_api_compat>1.4,!=1.5",
     "legacy-api-wrap",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ Home-page = "https://github.com/scverse/anndata"
 
 [project.optional-dependencies]
 dev = [
-    # dev version generation
-    "setuptools-scm",
+    # runtime dev version generation
+    "hatch-vcs",
     "anndata[dev-doc,dev-test]",
 ]
 doc = [
@@ -113,7 +113,6 @@ dask = ["dask[array]>=2022.09.2,!=2024.8.*,!=2024.9.*"]
 [tool.hatch.version]
 source = "vcs"
 [tool.hatch.build.hooks.vcs]
-version-file = "src/anndata/_version.py"
 raw-options.version_scheme = "release-branch-semver"
 [tool.hatch.build.targets.wheel]
 packages = ["src/anndata", "src/testing"]

--- a/src/anndata/__init__.py
+++ b/src/anndata/__init__.py
@@ -2,25 +2,16 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
 
-try:  # See https://github.com/maresb/hatch-vcs-footgun-example
-    from setuptools_scm import get_version
 
-    __version__ = get_version(root="../..", relative_to=__file__)
-except (ImportError, LookupError):
-    try:
-        from ._version import __version__
-    except ModuleNotFoundError:
-        msg = "anndata is not correctly installed. Please install it, e.g. with pip."
-        raise RuntimeError(msg)
+from ._version import __version__
 
 # Allowing notes to be added to exceptions. See: https://github.com/scverse/anndata/issues/868
-import sys
-
 if sys.version_info < (3, 11):
     # Backport package for exception groups
     import exceptiongroup  # noqa: F401

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 __all__ = ["__version__"]
 
 
-def _get_version_from_vcs() -> str:
+def _get_version_from_vcs() -> str:  # pragma: no cover
     from hatchling.metadata.core import ProjectMetadata
     from hatchling.plugin.exceptions import UnknownPluginError
     from hatchling.plugin.manager import PluginManager
@@ -21,8 +21,8 @@ def _get_version_from_vcs() -> str:
         raise LookupError(msg)
     root = Path(pyproject_toml).parent
     metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
-    # Version can be either statically set in pyproject.toml or computed dynamically:
     try:
+        # Version can be either statically set in pyproject.toml or computed dynamically:
         return metadata.core.version or metadata.hatch.version.cached
     except UnknownPluginError:
         msg = "Unable to import hatch plugin."

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -12,6 +12,7 @@ __all__ = ["__version__"]
 
 def _get_version_from_vcs() -> str:
     from hatchling.metadata.core import ProjectMetadata
+    from hatchling.plugin.exceptions import UnknownPluginError
     from hatchling.plugin.manager import PluginManager
     from hatchling.utils.fs import locate_file
 
@@ -21,7 +22,11 @@ def _get_version_from_vcs() -> str:
     root = Path(pyproject_toml).parent
     metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
     # Version can be either statically set in pyproject.toml or computed dynamically:
-    return metadata.core.version or metadata.hatch.version.cached
+    try:
+        return metadata.core.version or metadata.hatch.version.cached
+    except UnknownPluginError:
+        msg = "Unable to import hatch plugin."
+        raise ImportError(msg)
 
 
 try:

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -1,0 +1,34 @@
+"""Get version from VCS in a dev environment or from package metadata in production.
+
+See <https://github.com/maresb/hatch-vcs-footgun-example>.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.metadata.core import ProjectMetadata
+from hatchling.plugin.manager import PluginManager
+from hatchling.utils.fs import locate_file
+
+__all__ = ["__version__"]
+
+
+def _get_version_from_vcs() -> str:
+    if (pyproject_toml := locate_file(__file__, "pyproject.toml")) is None:
+        msg = "pyproject.toml not found although hatchling is installed"
+        raise LookupError(msg)
+    root = Path(pyproject_toml).parent
+    metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
+    # Version can be either statically set in pyproject.toml or computed dynamically:
+    return metadata.core.version or metadata.hatch.version.cached
+
+
+try:
+    from ._version import _get_version_from_vcs
+
+    __version__ = _get_version_from_vcs()
+except (ImportError, LookupError):
+    import importlib.metadata
+
+    __version__ = importlib.metadata.version("anndata")

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -25,8 +25,6 @@ def _get_version_from_vcs() -> str:
 
 
 try:
-    from ._version import _get_version_from_vcs
-
     __version__ = _get_version_from_vcs()
 except (ImportError, LookupError):
     import importlib.metadata

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from hatchling.metadata.core import ProjectMetadata
-from hatchling.plugin.manager import PluginManager
-from hatchling.utils.fs import locate_file
-
 __all__ = ["__version__"]
 
 
 def _get_version_from_vcs() -> str:
+    from hatchling.metadata.core import ProjectMetadata
+    from hatchling.plugin.manager import PluginManager
+    from hatchling.utils.fs import locate_file
+
     if (pyproject_toml := locate_file(__file__, "pyproject.toml")) is None:
         msg = "pyproject.toml not found although hatchling is installed"
         raise LookupError(msg)


### PR DESCRIPTION
this PR has two closely related bugfixes:

## actually configure version inference correctly

Turns out I messed up in #1680 and put the config into the wrong section, disabling it. So this PR fixes that:

```diff
 [tool.hatch.version]
 ...
+raw-options.version_scheme = "release-branch-semver"
 [tool.hatch.build.hooks.vcs]
 ...
-raw-options.version_scheme = "release-branch-semver"
```

`main` branch before this PR:

```console
❯ hatch version
0.11.1.dev38+gfaec0f8
```

(this is wrong as it’s <0.11.3 which is already released)

`main` branch after this PR:

```console
❯ hatch version
0.12.0.dev40+gffbacdea
❯ hatch build
──── sdist ────
dist/anndata-0.12.0.dev40+gffbacdea.tar.gz
──── wheel ────
dist/anndata-0.12.0.dev40+gffbacdea-py3-none-any.whl
```

moving that config value to the `tool.hatch.version` table makes build time versions work as expected (e.g. `pip install -e .../anndata` in CI), but this PR also fixes a second problem:

## make the runtime version use our config

We follow “hatch-vcs-footgun-example”, which updated: https://github.com/maresb/hatch-vcs-footgun-example/pull/4

By using `hatchling` APIs instead of `setuptools_vcs` directly, we can make sure the config used by the runtime code is the same used at build time, i.e. in a dev environment, `anndata.__version__` gets calculated in the same way as the version embedded in the metadata.