### PR TITLE
Revert "(fix): bound sphinx due to autodoc incompat"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "anndata[dev-doc,dev-test]",
 ]
 doc = [
-    "sphinx>=7.4.6",
+    "sphinx>=8.2.1",
     "sphinx-book-theme>=1.1.0",
     "sphinx-autodoc-typehints>=2.2.0",
     "sphinx-issues",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,7 @@ dev = [
     "anndata[dev-doc,dev-test]",
 ]
 doc = [
-    # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523
-    # means autodoc-typehints is incompatible with sphinx 8.2.0
-    "sphinx>=7.4.6,<8.2.0",
+    "sphinx>=7.4.6",
     "sphinx-book-theme>=1.1.0",
     "sphinx-autodoc-typehints>=2.2.0",
     "sphinx-issues",


### PR DESCRIPTION
Reverts scverse/anndata#1865, fixes #1866

https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.1.0