### PR TITLE
initial support for Dask DataFrames in obsm/varm

### DIFF
--- a/docs/release-notes/1880.feature.md
+++ b/docs/release-notes/1880.feature.md
@@ -1,0 +1,1 @@
+Add support for Dask DataFrames in `.obsm` and `.varm` ({user}`ilia-kats`)

--- a/src/anndata/_core/aligned_mapping.py
+++ b/src/anndata/_core/aligned_mapping.py
@@ -264,7 +264,16 @@ class AxisArraysBase(AlignedMappingBase):
     def _validate_value(self, val: Value, key: str) -> Value:
         if isinstance(val, pd.DataFrame):
             raise_value_error_if_multiindex_columns(val, f"{self.attrname}[{key!r}]")
-            if not val.index.equals(self.dim_names):
+            if (
+                not val.index.equals(self.dim_names)
+                and (
+                    val.index.dtype != "string"
+                    and self.dim_names.dtype != "O"
+                    or val.index.dtype != "O"
+                    and self.dim_names.dtype != "string"
+                )
+                and (val.index != self.dim_names).any()
+            ):
                 # Could probably also re-order index if it’s contained
                 try:
                     pd.testing.assert_index_equal(val.index, self.dim_names)

--- a/src/anndata/_core/file_backing.py
+++ b/src/anndata/_core/file_backing.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import h5py
 
-from ..compat import AwkArray, DaskArray, ZarrArray, ZarrGroup
+from ..compat import AwkArray, DaskArray, DaskDataFrame, ZarrArray, ZarrGroup
 from .sparse_dataset import BaseCompressedSparseDataset
 
 if TYPE_CHECKING:
@@ -143,7 +143,8 @@ def _(x: BaseCompressedSparseDataset, *, copy: bool = False):
 
 
 @to_memory.register(DaskArray)
-def _(x: DaskArray, *, copy: bool = False):
+@to_memory.register(DaskDataFrame)
+def _(x: DaskArray | DaskDataFrame, *, copy: bool = False):
     return x.compute()
 
 

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
-from anndata.compat import CSArray
+from anndata.compat import CSArray, DaskDataFrame
 
 from .._warnings import ImplicitModificationWarning
 from ..utils import (
@@ -51,7 +51,7 @@ def coerce_array(
     if any(is_non_csc_r_array_or_matrix):
         msg = f"Only CSR and CSC {'matrices' if isinstance(value, sparse.spmatrix) else 'arrays'} are supported."
         raise ValueError(msg)
-    if isinstance(value, pd.DataFrame):
+    if isinstance(value, pd.DataFrame | DaskDataFrame):
         if allow_df:
             raise_value_error_if_multiindex_columns(value, name)
         return value if allow_df else ensure_df_homogeneous(value, name)

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -100,12 +100,18 @@ if TYPE_CHECKING:
     from dask.array.core import Array as DaskArray
 elif find_spec("dask"):
     from dask.array import Array as DaskArray
+    from dask.dataframe import DataFrame as DaskDataFrame
 else:
 
     class DaskArray:
         @staticmethod
         def __repr__():
             return "mock dask.array.core.Array"
+
+    class DaskDataFrame:
+        @staticmethod
+        def __repr__():
+            return "mock dask.dataframe.dask_expr._collection.DataFrame"
 
 
 # https://github.com/scverse/anndata/issues/1749

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -32,6 +32,7 @@ from anndata.compat import (
     CupyCSRMatrix,
     CupySparseMatrix,
     DaskArray,
+    DaskDataFrame,
     ZarrArray,
 )
 from anndata.utils import asarray
@@ -644,8 +645,13 @@ def assert_equal_h5py_dataset(
 
 
 @assert_equal.register(DaskArray)
+@assert_equal.register(DaskDataFrame)
 def assert_equal_dask_array(
-    a: DaskArray, b: object, *, exact: bool = False, elem_name: str | None = None
+    a: DaskArray | DaskDataFrame,
+    b: object,
+    *,
+    exact: bool = False,
+    elem_name: str | None = None,
 ):
     assert_equal(b, a.compute(), exact=exact, elem_name=elem_name)
 

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -13,7 +13,7 @@ from scipy import sparse
 import anndata
 
 from ._core.sparse_dataset import BaseCompressedSparseDataset
-from .compat import CSArray, CupyArray, CupySparseMatrix, DaskArray
+from .compat import CSArray, CupyArray, CupySparseMatrix, DaskArray, DaskDataFrame
 from .logging import get_logger
 
 if TYPE_CHECKING:
@@ -113,6 +113,11 @@ def axis_len(x, axis: Literal[0, 1]) -> int | None:
     Returns None if `x` is an awkward array with variable length in the requested dimension.
     """
     return x.shape[axis]
+
+
+@axis_len.register(DaskDataFrame)
+def axis_len_dask_df(df, axis: Literal[0, 1]) -> int | None:
+    return df.shape[axis].compute()
 
 
 try:


### PR DESCRIPTION
This PR adds support for Dask DataFrames in `.obsm`/`.varm`.

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary)
