### PR TITLE
Backport CS* tightening

### DIFF
--- a/src/anndata/_core/aligned_mapping.py
+++ b/src/anndata/_core/aligned_mapping.py
@@ -9,10 +9,9 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
-from scipy.sparse import spmatrix
 
 from .._warnings import ExperimentalFeatureWarning, ImplicitModificationWarning
-from ..compat import AwkArray
+from ..compat import AwkArray, CSArray, CSMatrix
 from ..utils import (
     axis_len,
     convert_to_dict,
@@ -36,7 +35,7 @@ if TYPE_CHECKING:
 OneDIdx = Sequence[int] | Sequence[bool] | slice
 TwoDIdx = tuple[OneDIdx, OneDIdx]
 # TODO: pd.DataFrame only allowed in AxisArrays?
-Value = pd.DataFrame | spmatrix | np.ndarray
+Value = pd.DataFrame | CSArray | CSMatrix | np.ndarray
 
 P = TypeVar("P", bound="AlignedMappingBase")
 """Parent mapping an AlignedView is based on."""

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -26,7 +26,7 @@ from anndata._warnings import ImplicitModificationWarning
 
 from .. import utils
 from .._settings import settings
-from ..compat import CSArray, DaskArray, ZarrArray, _move_adj_mtx
+from ..compat import DaskArray, SpArray, ZarrArray, _move_adj_mtx
 from ..logging import anndata_logger as logger
 from ..utils import (
     axis_len,
@@ -615,7 +615,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     if sparse.issparse(self._adata_ref._X) and isinstance(
                         value, np.ndarray
                     ):
-                        if isinstance(self._adata_ref.X, CSArray):
+                        if isinstance(self._adata_ref.X, SpArray):
                             memory_class = sparse.coo_array
                         else:
                             memory_class = sparse.coo_matrix
@@ -1705,7 +1705,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # Backwards compat (some of this could be more efficient)
         # obs used to always be an outer join
         sparse_class = sparse.csr_matrix
-        if any(isinstance(a.X, CSArray) for a in all_adatas):
+        if any(isinstance(a.X, SpArray) for a in all_adatas):
             sparse_class = sparse.csr_array
         out.obs = concat(
             [AnnData(sparse_class(a.shape), obs=a.obs) for a in all_adatas],

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -26,7 +26,7 @@ from anndata._warnings import ImplicitModificationWarning
 
 from .. import utils
 from .._settings import settings
-from ..compat import DaskArray, SpArray, ZarrArray, _move_adj_mtx
+from ..compat import CSArray, DaskArray, ZarrArray, _move_adj_mtx
 from ..logging import anndata_logger as logger
 from ..utils import (
     axis_len,
@@ -557,7 +557,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         #     return X
 
     @X.setter
-    def X(self, value: np.ndarray | sparse.spmatrix | SpArray | None):
+    def X(self, value: np.ndarray | sparse.spmatrix | CSArray | None):
         if value is None:
             if self.isbacked:
                 msg = "Cannot currently remove data matrix from backed object."
@@ -615,7 +615,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     if sparse.issparse(self._adata_ref._X) and isinstance(
                         value, np.ndarray
                     ):
-                        if isinstance(self._adata_ref.X, SpArray):
+                        if isinstance(self._adata_ref.X, CSArray):
                             memory_class = sparse.coo_array
                         else:
                             memory_class = sparse.coo_matrix
@@ -1705,7 +1705,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # Backwards compat (some of this could be more efficient)
         # obs used to always be an outer join
         sparse_class = sparse.csr_matrix
-        if any(isinstance(a.X, SpArray) for a in all_adatas):
+        if any(isinstance(a.X, CSArray) for a in all_adatas):
             sparse_class = sparse.csr_array
         out.obs = concat(
             [AnnData(sparse_class(a.shape), obs=a.obs) for a in all_adatas],

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -195,13 +195,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     def __init__(
         self,
-        X: np.ndarray | sparse.spmatrix | pd.DataFrame | None = None,
+        X: ArrayDataStructureType | pd.DataFrame | None = None,
         obs: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         var: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         uns: Mapping[str, Any] | None = None,
         obsm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
-        layers: Mapping[str, np.ndarray | sparse.spmatrix] | None = None,
+        layers: Mapping[str, ArrayDataStructureType] | None = None,
         raw: Mapping[str, Any] | None = None,
         dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
@@ -557,7 +557,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         #     return X
 
     @X.setter
-    def X(self, value: np.ndarray | sparse.spmatrix | CSArray | None):
+    def X(self, value: ArrayDataStructureType | None):
         if value is None:
             if self.isbacked:
                 msg = "Cannot currently remove data matrix from backed object."
@@ -1159,7 +1159,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._init_as_actual(adata_subset)
 
     # TODO: Update, possibly remove
-    def __setitem__(self, index: Index, val: float | np.ndarray | sparse.spmatrix):
+    def __setitem__(self, index: Index, val: float | ArrayDataStructureType):
         if self.is_view:
             msg = "Object is view and cannot be accessed with `[]`."
             raise ValueError(msg)

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse, spmatrix
 
-from ..compat import AwkArray, CSArray, DaskArray, SpArray
+from ..compat import AwkArray, CSArray, CSMatrix, DaskArray, SpArray
 
 if TYPE_CHECKING:
     from ..compat import Index, Index1D
@@ -69,13 +69,13 @@ def _normalize_index(
     elif isinstance(indexer, str):
         return index.get_loc(indexer)  # int
     elif isinstance(
-        indexer, Sequence | np.ndarray | pd.Index | spmatrix | np.matrix | CSArray
+        indexer, Sequence | np.ndarray | pd.Index | CSMatrix | np.matrix | CSArray
     ):
         if hasattr(indexer, "shape") and (
             (indexer.shape == (index.shape[0], 1))
             or (indexer.shape == (1, index.shape[0]))
         ):
-            if isinstance(indexer, spmatrix | CSArray):
+            if isinstance(indexer, CSMatrix | CSArray):
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)
         if not isinstance(indexer, np.ndarray | pd.Index):
@@ -182,7 +182,7 @@ def _subset_dask(a: DaskArray, subset_idx: Index):
 
 @_subset.register(spmatrix)
 @_subset.register(SpArray)
-def _subset_sparse(a: spmatrix | CSArray, subset_idx: Index):
+def _subset_sparse(a: CSMatrix | CSArray, subset_idx: Index):
     # Correcting for indexing behaviour of sparse.spmatrix
     if len(subset_idx) > 1 and all(isinstance(x, Iterable) for x in subset_idx):
         first_idx = subset_idx[0]

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -10,10 +10,10 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse, spmatrix
 
-from ..compat import AwkArray, CSArray, CSMatrix, DaskArray, SpArray
+from ..compat import AwkArray, DaskArray, SpArray
 
 if TYPE_CHECKING:
-    from ..compat import Index, Index1D
+    from ..compat import CSArray, CSMatrix, Index, Index1D
 
 
 def _normalize_indices(
@@ -69,13 +69,13 @@ def _normalize_index(
     elif isinstance(indexer, str):
         return index.get_loc(indexer)  # int
     elif isinstance(
-        indexer, Sequence | np.ndarray | pd.Index | CSMatrix | np.matrix | CSArray
+        indexer, Sequence | np.ndarray | pd.Index | spmatrix | np.matrix | SpArray
     ):
         if hasattr(indexer, "shape") and (
             (indexer.shape == (index.shape[0], 1))
             or (indexer.shape == (1, index.shape[0]))
         ):
-            if isinstance(indexer, CSMatrix | CSArray):
+            if isinstance(indexer, spmatrix | SpArray):
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)
         if not isinstance(indexer, np.ndarray | pd.Index):

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse, spmatrix
 
-from ..compat import AwkArray, CSArray, DaskArray
+from ..compat import AwkArray, CSArray, DaskArray, SpArray
 
 if TYPE_CHECKING:
     from ..compat import Index, Index1D
@@ -181,7 +181,7 @@ def _subset_dask(a: DaskArray, subset_idx: Index):
 
 
 @_subset.register(spmatrix)
-@_subset.register(CSArray)
+@_subset.register(SpArray)
 def _subset_sparse(a: spmatrix | CSArray, subset_idx: Index):
     # Correcting for indexing behaviour of sparse.spmatrix
     if len(subset_idx) > 1 and all(isinstance(x, Iterable) for x in subset_idx):

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse, spmatrix
 
-from ..compat import AwkArray, DaskArray, SpArray
+from ..compat import AwkArray, CSArray, DaskArray
 
 if TYPE_CHECKING:
     from ..compat import Index, Index1D
@@ -69,13 +69,13 @@ def _normalize_index(
     elif isinstance(indexer, str):
         return index.get_loc(indexer)  # int
     elif isinstance(
-        indexer, Sequence | np.ndarray | pd.Index | spmatrix | np.matrix | SpArray
+        indexer, Sequence | np.ndarray | pd.Index | spmatrix | np.matrix | CSArray
     ):
         if hasattr(indexer, "shape") and (
             (indexer.shape == (index.shape[0], 1))
             or (indexer.shape == (1, index.shape[0]))
         ):
-            if isinstance(indexer, spmatrix | SpArray):
+            if isinstance(indexer, spmatrix | CSArray):
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)
         if not isinstance(indexer, np.ndarray | pd.Index):
@@ -181,8 +181,8 @@ def _subset_dask(a: DaskArray, subset_idx: Index):
 
 
 @_subset.register(spmatrix)
-@_subset.register(SpArray)
-def _subset_sparse(a: spmatrix | SpArray, subset_idx: Index):
+@_subset.register(CSArray)
+def _subset_sparse(a: spmatrix | CSArray, subset_idx: Index):
     # Correcting for indexing behaviour of sparse.spmatrix
     if len(subset_idx) > 1 and all(isinstance(x, Iterable) for x in subset_idx):
         first_idx = subset_idx[0]

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -29,6 +29,7 @@ from ..compat import (
     CupyCSRMatrix,
     CupySparseMatrix,
     DaskArray,
+    SpArray,
     _map_cat_to_str,
 )
 from ..utils import asarray, axis_len, warn_once
@@ -166,7 +167,7 @@ def equal_series(a, b) -> bool:
 
 
 @equal.register(sparse.spmatrix)
-@equal.register(CSArray)
+@equal.register(SpArray)
 @equal.register(CupySparseMatrix)
 def equal_sparse(a, b) -> bool:
     # It's a weird api, don't blame me

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -207,7 +207,7 @@ def equal_awkward(a, b) -> bool:
     return ak.almost_equal(a, b)
 
 
-def as_sparse(x, use_sparse_array: bool = False) -> CSMatrix | CSArray:
+def as_sparse(x, *, use_sparse_array: bool = False) -> CSMatrix | CSArray:
     if not isinstance(x, spmatrix | SpArray):
         if CAN_USE_SPARSE_ARRAY and use_sparse_array:
             return sparse.csr_array(x)

--- a/src/anndata/_core/raw.py
+++ b/src/anndata/_core/raw.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from typing import ClassVar
 
-    from scipy import sparse
-
+    from ..compat import CSMatrix
     from .aligned_mapping import AxisArraysView
     from .anndata import AnnData
     from .sparse_dataset import BaseCompressedSparseDataset
@@ -31,7 +30,7 @@ class Raw:
     def __init__(
         self,
         adata: AnnData,
-        X: np.ndarray | sparse.spmatrix | None = None,
+        X: np.ndarray | CSMatrix | None = None,
         var: pd.DataFrame | Mapping[str, Sequence] | None = None,
         varm: AxisArrays | Mapping[str, np.ndarray] | None = None,
     ):
@@ -67,7 +66,7 @@ class Raw:
         return self.X
 
     @property
-    def X(self) -> BaseCompressedSparseDataset | np.ndarray | sparse.spmatrix:
+    def X(self) -> BaseCompressedSparseDataset | np.ndarray | CSMatrix:
         # TODO: Handle unsorted array of integer indices for h5py.Datasets
         if not self._adata.isbacked:
             return self._X

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -30,7 +30,7 @@ from scipy.sparse import _sparsetools
 
 from .. import abc
 from .._settings import settings
-from ..compat import H5Group, SpArray, ZarrArray, ZarrGroup, _read_attr
+from ..compat import CSArray, H5Group, ZarrArray, ZarrGroup, _read_attr
 from .index import _fix_slice_bounds, _subset, unpack_index
 
 if TYPE_CHECKING:
@@ -327,7 +327,7 @@ def get_memory_class(
 ) -> type[_cs_matrix]:
     for fmt, _, memory_class in FORMATS:
         if format == fmt:
-            if use_sparray_in_io and issubclass(memory_class, SpArray):
+            if use_sparray_in_io and issubclass(memory_class, CSArray):
                 return memory_class
             elif not use_sparray_in_io and issubclass(memory_class, ss.spmatrix):
                 return memory_class
@@ -340,7 +340,7 @@ def get_backed_class(
 ) -> type[BackedSparseMatrix]:
     for fmt, backed_class, _ in FORMATS:
         if format == fmt:
-            if use_sparray_in_io and issubclass(backed_class, SpArray):
+            if use_sparray_in_io and issubclass(backed_class, CSArray):
                 return backed_class
             elif not use_sparray_in_io and issubclass(backed_class, ss.spmatrix):
                 return backed_class
@@ -435,7 +435,7 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
 
     def __getitem__(
         self, index: Index | tuple[()]
-    ) -> float | ss.csr_matrix | ss.csc_matrix | SpArray:
+    ) -> float | ss.csr_matrix | ss.csc_matrix | CSArray:
         indices = self._normalize_index(index)
         row, col = indices
         mtx = self._to_backed()
@@ -466,8 +466,8 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
         mtx_fmt = get_memory_class(
             self.format, use_sparray_in_io=settings.use_sparse_array_on_read
         )
-        must_convert_to_array = issubclass(mtx_fmt, SpArray) and not isinstance(
-            sub, SpArray
+        must_convert_to_array = issubclass(mtx_fmt, CSArray) and not isinstance(
+            sub, CSArray
         )
         if isinstance(sub, BackedSparseMatrix) or must_convert_to_array:
             return mtx_fmt(sub)
@@ -494,7 +494,7 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
         mock_matrix[row, col] = value
 
     # TODO: split to other classes?
-    def append(self, sparse_matrix: ss.csr_matrix | ss.csc_matrix | SpArray) -> None:
+    def append(self, sparse_matrix: ss.csr_matrix | ss.csc_matrix | CSArray) -> None:
         """Append an in-memory or on-disk sparse matrix to the current object's store.
 
         Parameters
@@ -620,7 +620,7 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
         mtx.indptr = self._indptr
         return mtx
 
-    def to_memory(self) -> ss.csr_matrix | ss.csc_matrix | SpArray:
+    def to_memory(self) -> ss.csr_matrix | ss.csc_matrix | CSArray:
         format_class = get_memory_class(
             self.format, use_sparray_in_io=settings.use_sparse_array_on_read
         )

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -30,7 +30,7 @@ from scipy.sparse import _sparsetools
 
 from .. import abc
 from .._settings import settings
-from ..compat import CSArray, CSMatrix, H5Group, ZarrArray, ZarrGroup, _read_attr
+from ..compat import H5Group, SpArray, ZarrArray, ZarrGroup, _read_attr
 from .index import _fix_slice_bounds, _subset, unpack_index
 
 if TYPE_CHECKING:
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from scipy.sparse._compressed import _cs_matrix
 
     from .._types import GroupStorageType
-    from ..compat import H5Array
+    from ..compat import CSArray, CSMatrix, H5Array
     from .index import Index, Index1D
 else:
     from scipy.sparse import spmatrix as _cs_matrix
@@ -327,9 +327,9 @@ def get_memory_class(
 ) -> type[_cs_matrix]:
     for fmt, _, memory_class in FORMATS:
         if format == fmt:
-            if use_sparray_in_io and issubclass(memory_class, CSArray):
+            if use_sparray_in_io and issubclass(memory_class, SpArray):
                 return memory_class
-            elif not use_sparray_in_io and issubclass(memory_class, CSMatrix):
+            elif not use_sparray_in_io and issubclass(memory_class, ss.spmatrix):
                 return memory_class
     msg = f"Format string {format} is not supported."
     raise ValueError(msg)
@@ -340,9 +340,9 @@ def get_backed_class(
 ) -> type[BackedSparseMatrix]:
     for fmt, backed_class, _ in FORMATS:
         if format == fmt:
-            if use_sparray_in_io and issubclass(backed_class, CSArray):
+            if use_sparray_in_io and issubclass(backed_class, SpArray):
                 return backed_class
-            elif not use_sparray_in_io and issubclass(backed_class, CSMatrix):
+            elif not use_sparray_in_io and issubclass(backed_class, ss.spmatrix):
                 return backed_class
     msg = f"Format string {format} is not supported."
     raise ValueError(msg)
@@ -464,8 +464,8 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
         mtx_fmt = get_memory_class(
             self.format, use_sparray_in_io=settings.use_sparse_array_on_read
         )
-        must_convert_to_array = issubclass(mtx_fmt, CSArray) and not isinstance(
-            sub, CSArray
+        must_convert_to_array = issubclass(mtx_fmt, SpArray) and not isinstance(
+            sub, SpArray
         )
         if isinstance(sub, BackedSparseMatrix) or must_convert_to_array:
             return mtx_fmt(sub)

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -18,6 +18,7 @@ from .._core.anndata import AnnData
 from .._core.file_backing import filename
 from .._core.sparse_dataset import BaseCompressedSparseDataset
 from ..compat import (
+    CSMatrix,
     _clean_uns,
     _decode_structured_array,
     _from_fixed_length_strings,
@@ -82,14 +83,14 @@ def write_h5ad(
         f.attrs.setdefault("encoding-version", "0.1.0")
 
         if "X" in as_dense and isinstance(
-            adata.X, sparse.spmatrix | BaseCompressedSparseDataset
+            adata.X, CSMatrix | BaseCompressedSparseDataset
         ):
             write_sparse_as_dense(f, "X", adata.X, dataset_kwargs=dataset_kwargs)
         elif not (adata.isbacked and Path(adata.filename) == Path(filepath)):
             # If adata.isbacked, X should already be up to date
             write_elem(f, "X", adata.X, dataset_kwargs=dataset_kwargs)
         if "raw/X" in as_dense and isinstance(
-            adata.raw.X, sparse.spmatrix | BaseCompressedSparseDataset
+            adata.raw.X, CSMatrix | BaseCompressedSparseDataset
         ):
             write_sparse_as_dense(
                 f, "raw/X", adata.raw.X, dataset_kwargs=dataset_kwargs
@@ -115,7 +116,7 @@ def write_h5ad(
 def write_sparse_as_dense(
     f: h5py.Group,
     key: str,
-    value: sparse.spmatrix | BaseCompressedSparseDataset,
+    value: CSMatrix | BaseCompressedSparseDataset,
     *,
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ):
@@ -172,7 +173,7 @@ def read_h5ad(
     backed: Literal["r", "r+"] | bool | None = None,
     *,
     as_sparse: Sequence[str] = (),
-    as_sparse_fmt: type[sparse.spmatrix] = sparse.csr_matrix,
+    as_sparse_fmt: type[CSMatrix] = sparse.csr_matrix,
     chunk_size: int = 6000,  # TODO, probably make this 2d chunks
 ) -> AnnData:
     """\
@@ -273,7 +274,7 @@ def read_h5ad(
 def _read_raw(
     f: h5py.File | AnnDataFileManager,
     as_sparse: Collection[str] = (),
-    rdasp: Callable[[h5py.Dataset], sparse.spmatrix] | None = None,
+    rdasp: Callable[[h5py.Dataset], CSMatrix] | None = None,
     *,
     attrs: Collection[str] = ("X", "var", "varm"),
 ) -> dict:
@@ -346,7 +347,7 @@ def read_dataset(dataset: h5py.Dataset):
 
 @report_read_key_on_error
 def read_dense_as_sparse(
-    dataset: h5py.Dataset, sparse_format: sparse.spmatrix, axis_chunk: int
+    dataset: h5py.Dataset, sparse_format: CSMatrix, axis_chunk: int
 ):
     if sparse_format == sparse.csr_matrix:
         return read_dense_as_csr(dataset, axis_chunk)

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -18,7 +18,6 @@ from .._core.anndata import AnnData
 from .._core.file_backing import filename
 from .._core.sparse_dataset import BaseCompressedSparseDataset
 from ..compat import (
-    CSMatrix,
     _clean_uns,
     _decode_structured_array,
     _from_fixed_length_strings,
@@ -39,6 +38,7 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from .._core.file_backing import AnnDataFileManager
+    from ..compat import CSMatrix
 
 T = TypeVar("T")
 
@@ -83,14 +83,14 @@ def write_h5ad(
         f.attrs.setdefault("encoding-version", "0.1.0")
 
         if "X" in as_dense and isinstance(
-            adata.X, CSMatrix | BaseCompressedSparseDataset
+            adata.X, sparse.spmatrix | BaseCompressedSparseDataset
         ):
             write_sparse_as_dense(f, "X", adata.X, dataset_kwargs=dataset_kwargs)
         elif not (adata.isbacked and Path(adata.filename) == Path(filepath)):
             # If adata.isbacked, X should already be up to date
             write_elem(f, "X", adata.X, dataset_kwargs=dataset_kwargs)
         if "raw/X" in as_dense and isinstance(
-            adata.raw.X, CSMatrix | BaseCompressedSparseDataset
+            adata.raw.X, sparse.spmatrix | BaseCompressedSparseDataset
         ):
             write_sparse_as_dense(
                 f, "raw/X", adata.raw.X, dataset_kwargs=dataset_kwargs

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
     from typing import Literal, ParamSpec, TypeVar
 
-    from ...compat import CSArray, DaskArray, H5File
+    from ...compat import CSArray, CSMatrix, DaskArray, H5File
     from .registry import DaskReader
 
     BlockInfo = Mapping[
@@ -72,7 +72,7 @@ def make_dask_chunk(
     path_or_sparse_dataset: Path | D,
     elem_name: str,
     block_info: BlockInfo | None = None,
-) -> sparse.csr_matrix | sparse.csc_matrix | CSArray:
+) -> CSMatrix | CSArray:
     if block_info is None:
         msg = "Block info is required"
         raise ValueError(msg)

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
     from typing import Literal, ParamSpec, TypeVar
 
-    from ...compat import DaskArray, H5File, SpArray
+    from ...compat import CSArray, DaskArray, H5File
     from .registry import DaskReader
 
     BlockInfo = Mapping[
@@ -72,7 +72,7 @@ def make_dask_chunk(
     path_or_sparse_dataset: Path | D,
     elem_name: str,
     block_info: BlockInfo | None = None,
-) -> sparse.csr_matrix | sparse.csc_matrix | SpArray:
+) -> sparse.csr_matrix | sparse.csc_matrix | CSArray:
     if block_info is None:
         msg = "Block info is required"
         raise ValueError(msg)

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -51,13 +51,9 @@ if TYPE_CHECKING:
     from numpy import typing as npt
     from numpy.typing import NDArray
 
-    from anndata._types import ArrayStorageType, GroupStorageType
-    from anndata.compat import (
-        CSArray,
-        CSMatrix,
-    )
-    from anndata.typing import AxisStorable, InMemoryArrayOrScalarType
-
+    from ..._types import ArrayStorageType, GroupStorageType
+    from ...compat import CSArray, CSMatrix
+    from ...typing import AxisStorable, InMemoryArrayOrScalarType
     from .registry import Reader, Writer
 
 ####################

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from anndata._types import ArrayStorageType, GroupStorageType
-    from anndata.compat import SpArray
+    from anndata.compat import CSArray
     from anndata.typing import AxisStorable, InMemoryArrayOrScalarType
 
     from .registry import Reader, Writer
@@ -127,7 +127,7 @@ def _to_cpu_mem_wrapper(write_func):
 @_REGISTRY.register_read(H5Array, IOSpec("", ""))
 def read_basic(
     elem: H5File | H5Group | H5Array, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | SpArray:
+) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | CSArray:
     from anndata._io import h5ad
 
     warn(
@@ -149,7 +149,7 @@ def read_basic(
 @_REGISTRY.register_read(ZarrArray, IOSpec("", ""))
 def read_basic_zarr(
     elem: ZarrGroup | ZarrArray, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | SpArray:
+) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | CSArray:
     from anndata._io import zarr
 
     warn(
@@ -590,7 +590,7 @@ def write_recarray_zarr(
 def write_sparse_compressed(
     f: GroupStorageType,
     key: str,
-    value: sparse.spmatrix | SpArray,
+    value: sparse.spmatrix | CSArray,
     *,
     _writer: Writer,
     fmt: Literal["csr", "csc"],
@@ -758,7 +758,7 @@ def write_dask_sparse(
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csr_matrix", "0.1.0"))
 def read_sparse(
     elem: GroupStorageType, *, _reader: Reader
-) -> sparse.spmatrix | SpArray:
+) -> sparse.spmatrix | CSArray:
     return sparse_dataset(elem).to_memory()
 
 

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -52,7 +52,10 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from anndata._types import ArrayStorageType, GroupStorageType
-    from anndata.compat import CSArray
+    from anndata.compat import (
+        CSArray,
+        CSMatrix,
+    )
     from anndata.typing import AxisStorable, InMemoryArrayOrScalarType
 
     from .registry import Reader, Writer
@@ -127,7 +130,7 @@ def _to_cpu_mem_wrapper(write_func):
 @_REGISTRY.register_read(H5Array, IOSpec("", ""))
 def read_basic(
     elem: H5File | H5Group | H5Array, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | CSArray:
+) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
     from anndata._io import h5ad
 
     warn(
@@ -149,7 +152,7 @@ def read_basic(
 @_REGISTRY.register_read(ZarrArray, IOSpec("", ""))
 def read_basic_zarr(
     elem: ZarrGroup | ZarrArray, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | sparse.spmatrix | CSArray:
+) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
     from anndata._io import zarr
 
     warn(
@@ -590,7 +593,7 @@ def write_recarray_zarr(
 def write_sparse_compressed(
     f: GroupStorageType,
     key: str,
-    value: sparse.spmatrix | CSArray,
+    value: CSMatrix | CSArray,
     *,
     _writer: Writer,
     fmt: Literal["csr", "csc"],
@@ -756,9 +759,7 @@ def write_dask_sparse(
 @_REGISTRY.register_read(H5Group, IOSpec("csr_matrix", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csc_matrix", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csr_matrix", "0.1.0"))
-def read_sparse(
-    elem: GroupStorageType, *, _reader: Reader
-) -> sparse.spmatrix | CSArray:
+def read_sparse(elem: GroupStorageType, *, _reader: Reader) -> CSMatrix | CSArray:
     return sparse_dataset(elem).to_memory()
 
 

--- a/src/anndata/abc.py
+++ b/src/anndata/abc.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import numpy as np
     from scipy.sparse import csc_matrix, csr_matrix
 
-    from .compat import Index, SpArray
+    from .compat import CSArray, Index
 
 
 __all__ = ["CSRDataset", "CSCDataset"]
@@ -31,7 +31,7 @@ class _AbstractCSDataset(ABC):
     """Which file type is used on-disk."""
 
     @abstractmethod
-    def __getitem__(self, index: Index) -> float | csr_matrix | csc_matrix | SpArray:
+    def __getitem__(self, index: Index) -> float | csr_matrix | csc_matrix | CSArray:
         """Load a slice or an element from the sparse dataset into memory.
 
         Parameters
@@ -45,7 +45,7 @@ class _AbstractCSDataset(ABC):
         """
 
     @abstractmethod
-    def to_memory(self) -> csr_matrix | csc_matrix | SpArray:
+    def to_memory(self) -> csr_matrix | csc_matrix | CSArray:
         """Load the sparse dataset into memory.
 
         Returns

--- a/src/anndata/abc.py
+++ b/src/anndata/abc.py
@@ -7,9 +7,8 @@ if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
     import numpy as np
-    from scipy.sparse import csc_matrix, csr_matrix
 
-    from .compat import CSArray, Index
+    from .compat import CSArray, CSMatrix, Index
 
 
 __all__ = ["CSRDataset", "CSCDataset"]
@@ -31,7 +30,7 @@ class _AbstractCSDataset(ABC):
     """Which file type is used on-disk."""
 
     @abstractmethod
-    def __getitem__(self, index: Index) -> float | csr_matrix | csc_matrix | CSArray:
+    def __getitem__(self, index: Index) -> float | CSMatrix | CSArray:
         """Load a slice or an element from the sparse dataset into memory.
 
         Parameters
@@ -45,7 +44,7 @@ class _AbstractCSDataset(ABC):
         """
 
     @abstractmethod
-    def to_memory(self) -> csr_matrix | csc_matrix | CSArray:
+    def to_memory(self) -> CSMatrix | CSArray:
         """Load the sparse dataset into memory.
 
         Returns

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -33,14 +33,14 @@ if TYPE_CHECKING:
 
 CAN_USE_SPARSE_ARRAY = Version(scipy.__version__) >= Version("1.11")
 
-if not CAN_USE_SPARSE_ARRAY:
+if TYPE_CHECKING or CAN_USE_SPARSE_ARRAY:
+    CSArray = scipy.sparse.csr_array | scipy.sparse.csc_array
+else:
 
-    class SpArray:
+    class CSArray:
         @staticmethod
         def __repr__():
-            return "mock scipy.sparse.sparray"
-else:
-    SpArray = scipy.sparse.sparray
+            return "mock scipy.sparse._cs_array"
 
 
 class Empty:
@@ -57,7 +57,7 @@ Index = (
     | tuple[EllipsisType, Index1D, Index1D]
     | tuple[Index1D, EllipsisType, Index1D]
     | scipy.sparse.spmatrix
-    | SpArray
+    | CSArray
 )
 H5Group = h5py.Group
 H5Array = h5py.Dataset

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 # scipy sparse array comapt #
 #############################
 
+CSMatrix = scipy.sparse.csr_matrix | scipy.sparse.csc_matrix
 
 CAN_USE_SPARSE_ARRAY = Version(scipy.__version__) >= Version("1.11")
 
@@ -62,7 +63,7 @@ Index = (
     | tuple[Index1D, Index1D, EllipsisType]
     | tuple[EllipsisType, Index1D, Index1D]
     | tuple[Index1D, EllipsisType, Index1D]
-    | scipy.sparse.spmatrix
+    | CSMatrix
     | CSArray
 )
 H5Group = h5py.Group

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -34,8 +34,14 @@ if TYPE_CHECKING:
 CAN_USE_SPARSE_ARRAY = Version(scipy.__version__) >= Version("1.11")
 
 if TYPE_CHECKING or CAN_USE_SPARSE_ARRAY:
+    SpArray = scipy.sparse.sparray
     CSArray = scipy.sparse.csr_array | scipy.sparse.csc_array
 else:
+
+    class SpArray:
+        @staticmethod
+        def __repr__():
+            return "mock scipy.sparse.sparray"
 
     class CSArray:
         @staticmethod

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -26,12 +26,12 @@ from anndata._core.views import ArrayView
 from anndata.compat import (
     CAN_USE_SPARSE_ARRAY,
     AwkArray,
+    CSArray,
     CupyArray,
     CupyCSCMatrix,
     CupyCSRMatrix,
     CupySparseMatrix,
     DaskArray,
-    SpArray,
     ZarrArray,
 )
 from anndata.utils import asarray
@@ -603,7 +603,7 @@ def assert_equal_sparse(a, b, exact=False, elem_name=None):
     assert_equal(b, a, exact, elem_name=elem_name)
 
 
-@assert_equal.register(SpArray)
+@assert_equal.register(CSArray)
 def assert_equal_sparse_array(a, b, exact=False, elem_name=None):
     return assert_equal_sparse(a, b, exact, elem_name)
 
@@ -808,7 +808,7 @@ def _(a):
     return da.from_array(a, _half_chunk_size(a.shape))
 
 
-@as_sparse_dask_array.register(SpArray)
+@as_sparse_dask_array.register(CSArray)
 def _(a):
     import dask.array as da
 

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -26,12 +26,12 @@ from anndata._core.views import ArrayView
 from anndata.compat import (
     CAN_USE_SPARSE_ARRAY,
     AwkArray,
-    CSArray,
     CupyArray,
     CupyCSCMatrix,
     CupyCSRMatrix,
     CupySparseMatrix,
     DaskArray,
+    SpArray,
     ZarrArray,
 )
 from anndata.utils import asarray
@@ -603,7 +603,7 @@ def assert_equal_sparse(a, b, exact=False, elem_name=None):
     assert_equal(b, a, exact, elem_name=elem_name)
 
 
-@assert_equal.register(CSArray)
+@assert_equal.register(SpArray)
 def assert_equal_sparse_array(a, b, exact=False, elem_name=None):
     return assert_equal_sparse(a, b, exact, elem_name)
 
@@ -808,7 +808,7 @@ def _(a):
     return da.from_array(a, _half_chunk_size(a.shape))
 
 
-@as_sparse_dask_array.register(CSArray)
+@as_sparse_dask_array.register(SpArray)
 def _(a):
     import dask.array as da
 

--- a/src/anndata/typing.py
+++ b/src/anndata/typing.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from numpy import ma
-from scipy import sparse
 
 from . import abc
 from ._core.anndata import AnnData
 from .compat import (
     AwkArray,
     CSArray,
+    CSMatrix,
     CupyArray,
     CupySparseMatrix,
     DaskArray,
@@ -35,8 +35,7 @@ Index = _Index
 ArrayDataStructureType: TypeAlias = (
     np.ndarray
     | ma.MaskedArray
-    | sparse.csr_matrix
-    | sparse.csc_matrix
+    | CSMatrix
     | CSArray
     | AwkArray
     | H5Array

--- a/src/anndata/typing.py
+++ b/src/anndata/typing.py
@@ -11,11 +11,11 @@ from . import abc
 from ._core.anndata import AnnData
 from .compat import (
     AwkArray,
+    CSArray,
     CupyArray,
     CupySparseMatrix,
     DaskArray,
     H5Array,
-    SpArray,
     ZappyArray,
     ZarrArray,
 )
@@ -37,7 +37,7 @@ ArrayDataStructureType: TypeAlias = (
     | ma.MaskedArray
     | sparse.csr_matrix
     | sparse.csc_matrix
-    | SpArray
+    | CSArray
     | AwkArray
     | H5Array
     | ZarrArray

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -13,7 +13,7 @@ from scipy import sparse
 import anndata
 
 from ._core.sparse_dataset import BaseCompressedSparseDataset
-from .compat import CupyArray, CupySparseMatrix, DaskArray, SpArray
+from .compat import CSArray, CupyArray, CupySparseMatrix, DaskArray
 from .logging import get_logger
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ def asarray(x):
     return np.asarray(x)
 
 
-@asarray.register(SpArray)
+@asarray.register(CSArray)
 @asarray.register(sparse.spmatrix)
 def asarray_sparse(x):
     return x.toarray()

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -13,7 +13,7 @@ from scipy import sparse
 import anndata
 
 from ._core.sparse_dataset import BaseCompressedSparseDataset
-from .compat import CSArray, CupyArray, CupySparseMatrix, DaskArray
+from .compat import CupyArray, CupySparseMatrix, DaskArray, SpArray
 from .logging import get_logger
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ def asarray(x):
     return np.asarray(x)
 
 
-@asarray.register(CSArray)
+@asarray.register(SpArray)
 @asarray.register(sparse.spmatrix)
 def asarray_sparse(x):
     return x.toarray()

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -10,7 +10,7 @@ import pytest
 from scipy import sparse
 
 import anndata as ad
-from anndata.compat import CSArray
+from anndata.compat import CSArray, CSMatrix
 from anndata.tests.helpers import (
     GEN_ADATA_DASK_ARGS,
     as_dense_dask_array,
@@ -200,8 +200,8 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
     var_idx = subset_func2(mem_adata.var_names)
     if (
         array_type is asarray
-        and isinstance(obs_idx, list | np.ndarray | sparse.spmatrix | CSArray)
-        and isinstance(var_idx, list | np.ndarray | sparse.spmatrix | CSArray)
+        and isinstance(obs_idx, list | np.ndarray | CSMatrix | CSArray)
+        and isinstance(var_idx, list | np.ndarray | CSMatrix | CSArray)
     ):
         pytest.xfail(
             "Fancy indexing does not work with multiple arrays on a h5py.Dataset"

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -10,7 +10,7 @@ import pytest
 from scipy import sparse
 
 import anndata as ad
-from anndata.compat import SpArray
+from anndata.compat import CSArray
 from anndata.tests.helpers import (
     GEN_ADATA_DASK_ARGS,
     as_dense_dask_array,
@@ -200,8 +200,8 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
     var_idx = subset_func2(mem_adata.var_names)
     if (
         array_type is asarray
-        and isinstance(obs_idx, list | np.ndarray | sparse.spmatrix | SpArray)
-        and isinstance(var_idx, list | np.ndarray | sparse.spmatrix | SpArray)
+        and isinstance(obs_idx, list | np.ndarray | sparse.spmatrix | CSArray)
+        and isinstance(var_idx, list | np.ndarray | sparse.spmatrix | CSArray)
     ):
         pytest.xfail(
             "Fancy indexing does not work with multiple arrays on a h5py.Dataset"

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -14,7 +14,7 @@ import anndata as ad
 from anndata._core.anndata import AnnData
 from anndata._core.sparse_dataset import sparse_dataset
 from anndata._io.specs.registry import read_elem_as_dask
-from anndata.compat import CAN_USE_SPARSE_ARRAY, CSArray, DaskArray
+from anndata.compat import CAN_USE_SPARSE_ARRAY, CSArray, CSMatrix, DaskArray
 from anndata.experimental import read_dispatched
 from anndata.tests.helpers import AccessTrackingStore, assert_equal, subset_func
 
@@ -263,8 +263,8 @@ def test_consecutive_bool(
 )
 def test_dataset_append_memory(
     tmp_path: Path,
-    sparse_format: Callable[[ArrayLike], sparse.spmatrix],
-    append_method: Callable[[list[sparse.spmatrix]], sparse.spmatrix],
+    sparse_format: Callable[[ArrayLike], CSMatrix],
+    append_method: Callable[[list[CSMatrix]], CSMatrix],
     diskfmt: Literal["h5ad", "zarr"],
 ):
     path = tmp_path / f"test.{diskfmt.replace('ad', '')}"
@@ -319,7 +319,7 @@ def test_append_array_cache_bust(tmp_path: Path, diskfmt: Literal["h5ad", "zarr"
 )
 def test_read_array(
     tmp_path: Path,
-    sparse_format: Callable[[ArrayLike], sparse.spmatrix],
+    sparse_format: Callable[[ArrayLike], CSMatrix],
     diskfmt: Literal["h5ad", "zarr"],
     subset_func,
     subset_func2,
@@ -339,7 +339,7 @@ def test_read_array(
     ad.settings.use_sparse_array_on_read = True
     assert issubclass(type(diskmtx[obs_idx, var_idx]), CSArray)
     ad.settings.use_sparse_array_on_read = False
-    assert issubclass(type(diskmtx[obs_idx, var_idx]), sparse.spmatrix)
+    assert issubclass(type(diskmtx[obs_idx, var_idx]), CSMatrix)
 
 
 @pytest.mark.parametrize(
@@ -351,8 +351,8 @@ def test_read_array(
 )
 def test_dataset_append_disk(
     tmp_path: Path,
-    sparse_format: Callable[[ArrayLike], sparse.spmatrix],
-    append_method: Callable[[list[sparse.spmatrix]], sparse.spmatrix],
+    sparse_format: Callable[[ArrayLike], CSMatrix],
+    append_method: Callable[[list[CSMatrix]], CSMatrix],
     diskfmt: Literal["h5ad", "zarr"],
 ):
     path = tmp_path / f"test.{diskfmt.replace('ad', '')}"
@@ -379,7 +379,7 @@ def test_dataset_append_disk(
 @pytest.mark.parametrize("sparse_format", [sparse.csr_matrix, sparse.csc_matrix])
 def test_lazy_array_cache(
     tmp_path: Path,
-    sparse_format: Callable[[ArrayLike], sparse.spmatrix],
+    sparse_format: Callable[[ArrayLike], CSMatrix],
 ):
     elems = {"indptr", "indices", "data"}
     path = tmp_path / "test.zarr"
@@ -481,7 +481,7 @@ def width_idx_kinds(
 )
 def test_data_access(
     tmp_path: Path,
-    sparse_format: Callable[[ArrayLike], sparse.spmatrix],
+    sparse_format: Callable[[ArrayLike], CSMatrix],
     idx_maj: Idx,
     idx_min: Idx,
     exp: Sequence[str],

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -14,7 +14,7 @@ import anndata as ad
 from anndata._core.anndata import AnnData
 from anndata._core.sparse_dataset import sparse_dataset
 from anndata._io.specs.registry import read_elem_as_dask
-from anndata.compat import CAN_USE_SPARSE_ARRAY, DaskArray, SpArray
+from anndata.compat import CAN_USE_SPARSE_ARRAY, CSArray, DaskArray
 from anndata.experimental import read_dispatched
 from anndata.tests.helpers import AccessTrackingStore, assert_equal, subset_func
 
@@ -337,7 +337,7 @@ def test_read_array(
     if not CAN_USE_SPARSE_ARRAY:
         pytest.skip("scipy.sparse.cs{r,c}array not available")
     ad.settings.use_sparse_array_on_read = True
-    assert issubclass(type(diskmtx[obs_idx, var_idx]), SpArray)
+    assert issubclass(type(diskmtx[obs_idx, var_idx]), CSArray)
     ad.settings.use_sparse_array_on_read = False
     assert issubclass(type(diskmtx[obs_idx, var_idx]), sparse.spmatrix)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -38,7 +38,7 @@ def test_creation():
     AnnData(ma.array([[1, 2], [3, 4]]), uns=dict(mask=[0, 1, 1, 0]))
     AnnData(sp.eye(2, format="csr"))
     if CAN_USE_SPARSE_ARRAY:
-        AnnData(sp.eye_array(2))
+        AnnData(sp.eye_array(2, format="csr"))
     X = np.array([[1, 2, 3], [4, 5, 6]])
     adata = AnnData(
         X=X,

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -20,7 +20,14 @@ from scipy import sparse
 from anndata import AnnData, Raw, concat
 from anndata._core import merge
 from anndata._core.index import _subset
-from anndata.compat import AwkArray, CSArray, CupySparseMatrix, DaskArray, SpArray
+from anndata.compat import (
+    AwkArray,
+    CSArray,
+    CSMatrix,
+    CupySparseMatrix,
+    DaskArray,
+    SpArray,
+)
 from anndata.tests import helpers
 from anndata.tests.helpers import (
     BASE_MATRIX_PARAMS,
@@ -200,7 +207,7 @@ def test_concatenate_roundtrip(join_type, array_type, concat_func, backwards_com
         if isinstance(orig.X, CSArray):
             base_type = CSArray
         else:
-            base_type = sparse.spmatrix
+            base_type = CSMatrix
     if isinstance(orig.X, CupySparseMatrix):
         base_type = CupySparseMatrix
     assert isinstance(result.X, base_type)
@@ -404,7 +411,7 @@ def test_concatenate_obsm_outer(obsm_adatas, fill_val):
         ),
     )
 
-    assert isinstance(outer.obsm["sparse"], sparse.spmatrix)
+    assert isinstance(outer.obsm["sparse"], CSMatrix)
     np.testing.assert_equal(
         outer.obsm["sparse"].toarray(),
         np.array(
@@ -1496,7 +1503,7 @@ def test_concat_X_dtype(cpu_array_type, sparse_indexer_type):
     if sparse.issparse(result.X):
         # See https://github.com/scipy/scipy/issues/20389 for why this doesn't work with csc
         if sparse_indexer_type == np.int64 and (
-            issubclass(cpu_array_type, sparse.spmatrix) or adata.X.format == "csc"
+            issubclass(cpu_array_type, CSMatrix) or adata.X.format == "csc"
         ):
             pytest.xfail(
                 "Data type int64 is not maintained for sparse matrices or csc array"

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -204,10 +204,7 @@ def test_concatenate_roundtrip(join_type, array_type, concat_func, backwards_com
     assert_equal(result[orig.obs_names].copy(), orig)
     base_type = type(orig.X)
     if sparse.issparse(orig.X):
-        if isinstance(orig.X, CSArray):
-            base_type = CSArray
-        else:
-            base_type = CSMatrix
+        base_type = CSArray if isinstance(orig.X, CSArray) else CSMatrix
     if isinstance(orig.X, CupySparseMatrix):
         base_type = CupySparseMatrix
     assert isinstance(result.X, base_type)

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -20,7 +20,7 @@ from scipy import sparse
 from anndata import AnnData, Raw, concat
 from anndata._core import merge
 from anndata._core.index import _subset
-from anndata.compat import AwkArray, CSArray, CupySparseMatrix, DaskArray
+from anndata.compat import AwkArray, CSArray, CupySparseMatrix, DaskArray, SpArray
 from anndata.tests import helpers
 from anndata.tests.helpers import (
     BASE_MATRIX_PARAMS,
@@ -69,7 +69,7 @@ def _filled_sparse(a, fill_value=None):
         return sparse.csr_matrix(np.broadcast_to(fill_value, a.shape))
 
 
-@filled_like.register(CSArray)
+@filled_like.register(SpArray)
 def _filled_sparse_array(a, fill_value=None):
     return sparse.csr_array(filled_like(sparse.csr_matrix(a)))
 

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -20,7 +20,7 @@ from scipy import sparse
 from anndata import AnnData, Raw, concat
 from anndata._core import merge
 from anndata._core.index import _subset
-from anndata.compat import AwkArray, CupySparseMatrix, DaskArray, SpArray
+from anndata.compat import AwkArray, CSArray, CupySparseMatrix, DaskArray
 from anndata.tests import helpers
 from anndata.tests.helpers import (
     BASE_MATRIX_PARAMS,
@@ -69,7 +69,7 @@ def _filled_sparse(a, fill_value=None):
         return sparse.csr_matrix(np.broadcast_to(fill_value, a.shape))
 
 
-@filled_like.register(SpArray)
+@filled_like.register(CSArray)
 def _filled_sparse_array(a, fill_value=None):
     return sparse.csr_array(filled_like(sparse.csr_matrix(a)))
 
@@ -197,8 +197,8 @@ def test_concatenate_roundtrip(join_type, array_type, concat_func, backwards_com
     assert_equal(result[orig.obs_names].copy(), orig)
     base_type = type(orig.X)
     if sparse.issparse(orig.X):
-        if isinstance(orig.X, SpArray):
-            base_type = SpArray
+        if isinstance(orig.X, CSArray):
+            base_type = CSArray
         else:
             base_type = sparse.spmatrix
     if isinstance(orig.X, CupySparseMatrix):

--- a/tests/test_concatenate_disk.py
+++ b/tests/test_concatenate_disk.py
@@ -30,7 +30,7 @@ GEN_ADATA_OOC_CONCAT_ARGS = dict(
         pd.DataFrame,
     ),
     varm_types=(sparse.csr_matrix, np.ndarray, pd.DataFrame),
-    layers_types=(sparse.spmatrix, np.ndarray, pd.DataFrame),
+    layers_types=(sparse.csr_matrix, np.ndarray, pd.DataFrame),
 )
 
 

--- a/tests/test_io_conversion.py
+++ b/tests/test_io_conversion.py
@@ -10,6 +10,7 @@ import pytest
 from scipy import sparse
 
 import anndata as ad
+from anndata.compat import CSMatrix
 from anndata.tests.helpers import assert_equal, gen_adata
 
 
@@ -99,8 +100,8 @@ def test_dense_to_sparse_memory(tmp_path, spmtx_format, to_convert):
     orig = gen_adata((50, 50), np.array)
     orig.raw = orig.copy()
     orig.write_h5ad(dense_path)
-    assert not isinstance(orig.X, sparse.spmatrix)
-    assert not isinstance(orig.raw.X, sparse.spmatrix)
+    assert not isinstance(orig.X, CSMatrix)
+    assert not isinstance(orig.raw.X, CSMatrix)
 
     curr = ad.read_h5ad(dense_path, as_sparse=to_convert, as_sparse_fmt=spmtx_format)
 

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -7,7 +7,7 @@ import zarr
 from scipy import sparse
 
 import anndata as ad
-from anndata.compat import SpArray
+from anndata.compat import CSArray
 from anndata.experimental import read_dispatched, write_dispatched
 from anndata.tests.helpers import assert_equal, gen_adata
 
@@ -96,7 +96,7 @@ def test_write_dispatched_chunks():
         # TODO: Should the passed path be absolute?
         path = "/" + store.path + "/" + k
         if hasattr(elem, "shape") and not isinstance(
-            elem, sparse.spmatrix | SpArray | ad.AnnData
+            elem, sparse.spmatrix | CSArray | ad.AnnData
         ):
             if re.match(r"^/((X)|(layers)).*", path):
                 chunks = (M, N)

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -4,10 +4,9 @@ import re
 
 import h5py
 import zarr
-from scipy import sparse
 
 import anndata as ad
-from anndata.compat import CSArray
+from anndata.compat import CSArray, CSMatrix
 from anndata.experimental import read_dispatched, write_dispatched
 from anndata.tests.helpers import assert_equal, gen_adata
 
@@ -96,7 +95,7 @@ def test_write_dispatched_chunks():
         # TODO: Should the passed path be absolute?
         path = "/" + store.path + "/" + k
         if hasattr(elem, "shape") and not isinstance(
-            elem, sparse.spmatrix | CSArray | ad.AnnData
+            elem, CSMatrix | CSArray | ad.AnnData
         ):
             if re.match(r"^/((X)|(layers)).*", path):
                 chunks = (M, N)

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -22,7 +22,7 @@ from anndata._io.specs import (
     get_spec,
 )
 from anndata._io.specs.registry import IORegistryError
-from anndata.compat import CAN_USE_SPARSE_ARRAY, SpArray, ZarrGroup, _read_attr
+from anndata.compat import CAN_USE_SPARSE_ARRAY, CSArray, ZarrGroup, _read_attr
 from anndata.experimental import read_elem_as_dask
 from anndata.io import read_elem, write_elem
 from anndata.tests.helpers import (
@@ -630,4 +630,4 @@ def test_read_sparse_array(
         pytest.skip("scipy.sparse.cs{r,c}array not available")
     ad.settings.use_sparse_array_on_read = True
     mtx = ad.io.read_elem(f["mtx"])
-    assert issubclass(type(mtx), SpArray)
+    assert issubclass(type(mtx), CSArray)

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -22,7 +22,13 @@ from anndata._io.specs import (
     get_spec,
 )
 from anndata._io.specs.registry import IORegistryError
-from anndata.compat import CAN_USE_SPARSE_ARRAY, CSArray, ZarrGroup, _read_attr
+from anndata.compat import (
+    CAN_USE_SPARSE_ARRAY,
+    CSArray,
+    CSMatrix,
+    ZarrGroup,
+    _read_attr,
+)
 from anndata.experimental import read_elem_as_dask
 from anndata.io import read_elem, write_elem
 from anndata.tests.helpers import (
@@ -244,7 +250,7 @@ def test_io_spec_compressed_scalars(store: G, value: np.ndarray, encoding_type: 
 @pytest.mark.parametrize("as_dask", [False, True])
 def test_io_spec_cupy(store, value, encoding_type, as_dask):
     if as_dask:
-        if isinstance(value, sparse.spmatrix):
+        if isinstance(value, CSMatrix):
             value = as_cupy_sparse_dask_array(value, format=encoding_type[:3])
         else:
             value = as_dense_cupy_dask_array(value)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -15,12 +15,11 @@ import pandas as pd
 import pytest
 import zarr
 from numba.core.errors import NumbaDeprecationWarning
-from scipy import sparse
 from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 
 import anndata as ad
 from anndata._io.specs.registry import IORegistryError
-from anndata.compat import CSArray, DaskArray, _read_attr
+from anndata.compat import CSArray, CSMatrix, DaskArray, _read_attr
 from anndata.tests.helpers import as_dense_dask_array, assert_equal, gen_adata
 
 if TYPE_CHECKING:
@@ -160,7 +159,7 @@ def test_readwrite_kitchensink(tmp_path, storage, typ, backing_h5ad, dataset_kwa
     # since we tested if assigned types and loaded types are DaskArray
     # this would also work if they work
     if isinstance(adata_src.raw.X, CSArray):
-        assert isinstance(adata.raw.X, sparse.spmatrix)
+        assert isinstance(adata.raw.X, CSMatrix)
     else:
         assert isinstance(adata_src.raw.X, type(adata.raw.X) | DaskArray)
     assert isinstance(

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -20,7 +20,7 @@ from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 
 import anndata as ad
 from anndata._io.specs.registry import IORegistryError
-from anndata.compat import DaskArray, SpArray, _read_attr
+from anndata.compat import CSArray, DaskArray, _read_attr
 from anndata.tests.helpers import as_dense_dask_array, assert_equal, gen_adata
 
 if TYPE_CHECKING:
@@ -159,7 +159,7 @@ def test_readwrite_kitchensink(tmp_path, storage, typ, backing_h5ad, dataset_kwa
     # either load as same type or load the convert DaskArray to array
     # since we tested if assigned types and loaded types are DaskArray
     # this would also work if they work
-    if isinstance(adata_src.raw.X, SpArray):
+    if isinstance(adata_src.raw.X, CSArray):
         assert isinstance(adata.raw.X, sparse.spmatrix)
     else:
         assert isinstance(adata_src.raw.X, type(adata.raw.X) | DaskArray)


### PR DESCRIPTION
So the accurate types are used in a soon-to-be-released anndata version.

I also did a few things I missed in the original review. Getting these into `main` in a separate PR: https://github.com/scverse/anndata/pull/1890

TODO:

- [x] should one fix be backported? https://github.com/scverse/anndata/pull/1768#pullrequestreview-2663880468

  *(no, breaking change)*

- [x] only changes to types and tests