### PR TITLE
(fix): undo writing of arrays as elem in sparse

### DIFF
--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -724,12 +724,16 @@ def write_sparse_compressed(
     for attr_name in ["data", "indices", "indptr"]:
         attr = getattr(value, attr_name)
         dtype = indptr_dtype if attr_name == "indptr" else attr.dtype
-        _writer.write_elem(
-            g,
-            attr_name,
-            attr,
-            dataset_kwargs={"dtype": dtype, **dataset_kwargs},
-        )
+        if isinstance(f, H5Group) or is_zarr_v2():
+            g.create_dataset(
+                attr_name, data=attr, shape=attr.shape, dtype=dtype, **dataset_kwargs
+            )
+        else:
+            arr = g.create_array(
+                attr_name, shape=attr.shape, dtype=dtype, **dataset_kwargs
+            )
+            # see https://github.com/zarr-developers/zarr-python/discussions/2712
+            arr[...] = attr[...]
 
 
 write_csr = partial(write_sparse_compressed, fmt="csr")

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -206,3 +206,6 @@ def test_io_dispatched_keys(tmp_path: Path):
 
     assert sorted(h5ad_read_keys) == sorted(zarr_read_keys)
     assert sorted(h5ad_write_keys) == sorted(zarr_write_keys)
+    for sub_sparse_key in ["data", "indices", "indptr"]:
+        assert f"/X/{sub_sparse_key}" not in h5ad_read_keys
+        assert f"/X/{sub_sparse_key}" not in h5ad_write_keys


### PR DESCRIPTION
I accidentally introduced a "bug" (or maybe more of a file specification discrepancy) in https://github.com/scverse/anndata/pull/1624/commits/5938d86f0130265fa126ff3fddaac7e99143e41e which I would like to reverse.  The subarrays of a sparse matrix should not be written as "elems" in the sense of getting metadata, I think.  Certainly that was not the previous behavior so I think the behavior (modulo an update for zarr v3) should be restored

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or **unnecessary**)
