### PR TITLE
fix outer concatenation along var when varm is not empty

### DIFF
--- a/docs/release-notes/1911.bugfix.md
+++ b/docs/release-notes/1911.bugfix.md
@@ -1,0 +1,1 @@
+Fix concatenation of {class}`anndata.AnnData` objects along `var` using `join="outer"` when `varm` is not empty. {user}`ilia-kats`

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -858,7 +858,9 @@ def concat_arrays(arrays, reindexers, axis=0, index=None, fill_value=None):
         )
 
 
-def inner_concat_aligned_mapping(mappings, *, reindexers=None, index=None, axis=0, concat_axis=None):
+def inner_concat_aligned_mapping(
+    mappings, *, reindexers=None, index=None, axis=0, concat_axis=None
+):
     if concat_axis is None:
         concat_axis = axis
     result = {}
@@ -866,7 +868,9 @@ def inner_concat_aligned_mapping(mappings, *, reindexers=None, index=None, axis=
     for k in intersect_keys(mappings):
         els = [m[k] for m in mappings]
         if reindexers is None:
-            cur_reindexers = gen_inner_reindexers(els, new_index=index, axis=concat_axis)
+            cur_reindexers = gen_inner_reindexers(
+                els, new_index=index, axis=concat_axis
+            )
         else:
             cur_reindexers = reindexers
 
@@ -976,7 +980,9 @@ def outer_concat_aligned_mapping(
     for k in union_keys(mappings):
         els = [m.get(k, MissingVal) for m in mappings]
         if reindexers is None:
-            cur_reindexers = gen_outer_reindexers(els, ns, new_index=index, axis=concat_axis)
+            cur_reindexers = gen_outer_reindexers(
+                els, ns, new_index=index, axis=concat_axis
+            )
         else:
             cur_reindexers = reindexers
 
@@ -1377,7 +1383,10 @@ def concat(
         [a.layers for a in adatas], axis=axis, reindexers=reindexers
     )
     concat_mapping = concat_aligned_mapping(
-        [getattr(a, f"{axis_name}m") for a in adatas], axis=axis, concat_axis=0, index=concat_indices
+        [getattr(a, f"{axis_name}m") for a in adatas],
+        axis=axis,
+        concat_axis=0,
+        index=concat_indices,
     )
     if pairwise:
         concat_pairwise = concat_pairwise_mapping(

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -1447,7 +1447,10 @@ def test_concat_outer_aligned_mapping(elem, axis):
     concated = concat({"a": a, "b": b}, join="outer", label="group", axis=axis)
 
     mask = getattr(concated, axis)["group"] == "b"
-    result = getattr(concated[(mask, slice(None)) if axis == "obs" else (slice(None), mask)], f"{axis}m")[elem]
+    result = getattr(
+        concated[(mask, slice(None)) if axis == "obs" else (slice(None), mask)],
+        f"{axis}m",
+    )[elem]
 
     check_filled_like(result, elem_name=f"{axis}m/{elem}")
 

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -1438,15 +1438,18 @@ def test_concat_size_0_axis(axis_name, join_type, merge_strategy, shape):
 
 
 @pytest.mark.parametrize("elem", ["sparse", "array", "df", "da"])
-def test_concat_outer_aligned_mapping(elem):
+@pytest.mark.parametrize("axis", ["obs", "var"])
+def test_concat_outer_aligned_mapping(elem, axis):
     a = gen_adata((5, 5), **GEN_ADATA_DASK_ARGS)
     b = gen_adata((3, 5), **GEN_ADATA_DASK_ARGS)
-    del b.obsm[elem]
+    del getattr(b, f"{axis}m")[elem]
 
-    concated = concat({"a": a, "b": b}, join="outer", label="group")
-    result = concated[concated.obs["group"] == "b"].obsm[elem]
+    concated = concat({"a": a, "b": b}, join="outer", label="group", axis=axis)
 
-    check_filled_like(result, elem_name=f"obsm/{elem}")
+    mask = getattr(concated, axis)["group"] == "b"
+    result = getattr(concated[(mask, slice(None)) if axis == "obs" else (slice(None), mask)], f"{axis}m")[elem]
+
+    check_filled_like(result, elem_name=f"{axis}m/{elem}")
 
 
 @mark_legacy_concatenate


### PR DESCRIPTION
The problem was that the code assumed that there is only one concatenation axis throughout. However, when concatenating varm, there is a difference between the AnnData concatenation axis (1) and the varm concatenation axis (0).

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary)
