### PR TITLE
(fix): add `convert_strings_to_categoricals` to methods 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,13 +69,28 @@ You might have more success by assembling the {class}`AnnData` object yourself f
 ## Writing
 
 Writing a complete {class}`AnnData` object to disk in anndata’s native formats `.h5ad` and `zarr`.
+(These functions are also exported as {func}`io.write_h5ad` and {func}`io.write_zarr`.)
 
 ```{eval-rst}
 .. autosummary::
    :toctree: generated/
 
-   AnnData.write
+   AnnData.write_h5ad
    AnnData.write_zarr
+
+
+..
+    .. autosummary::
+       :toctree: generated/
+
+       io.write_h5ad
+       io.write_zarr
+
+.. toctree::
+   :hidden:
+
+   generated/anndata.io.write_h5ad
+   generated/anndata.io.write_zarr
 ```
 
 Writing individual portions ({attr}`~AnnData.obs`, {attr}`~AnnData.varm` etc.) of the {class}`AnnData` object.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,9 @@ qualname_overrides = {
     "anndata._types.Write": "anndata.experimental.Write",
     "zarr.core.array.Array": "zarr.Array",
     "zarr.core.group.Group": "zarr.Group",
+    # Buffer is not yet exported, so the buffer class registry is the closest thing
+    "zarr.core.buffer.core.Buffer": "zarr.registry.Registry",
+    "zarr.storage._common.StorePath": "zarr.storage.StorePath",
     "anndata.compat.DaskArray": "dask.array.Array",
     "anndata.compat.CupyArray": "cupy.ndarray",
     "anndata.compat.CupySparseMatrix": "cupyx.scipy.sparse.spmatrix",

--- a/docs/release-notes/1914.bugfix.md
+++ b/docs/release-notes/1914.bugfix.md
@@ -1,0 +1,1 @@
+Add `convert_strings_to_categoricals` parameter also to {meth}`~anndata.AnnData.write_h5ad` and {meth}`~anndata.AnnData.write_zarr` as intended {user}`flying-sheep`

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
     from os import PathLike
     from typing import Any, Literal
 
+    from zarr.storage import StoreLike
+
     from ..compat import Index1D
     from ..typing import XDataType
     from .aligned_mapping import AxisArraysView, LayersView, PairwiseArraysView
@@ -216,7 +218,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         raw: Mapping[str, Any] | None = None,
         dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
-        filename: PathLike | None = None,
+        filename: PathLike[str] | str | None = None,
         filemode: Literal["r", "r+"] | None = None,
         asview: bool = False,
         obsp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
@@ -960,7 +962,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         return self.file.filename
 
     @filename.setter
-    def filename(self, filename: PathLike | None):
+    def filename(self, filename: PathLike[str] | str | None):
         # convert early for later comparison
         filename = None if filename is None else Path(filename)
         # change from backing-mode back to full loading into memory
@@ -1439,7 +1441,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         return AnnData(**new)
 
-    def copy(self, filename: PathLike | None = None) -> AnnData:
+    def copy(self, filename: PathLike[str] | str | None = None) -> AnnData:
         """Full copy, optionally on disk."""
         if not self.isbacked:
             if self.is_view and self._has_X():
@@ -1800,9 +1802,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 )
                 raise ValueError(msg)
 
+    @old_positionals("compression", "compression_opts", "as_dense")
     def write_h5ad(
         self,
-        filename: PathLike | None = None,
+        filename: PathLike[str] | str | None = None,
+        *,
+        convert_strings_to_categoricals: bool = True,
         compression: Literal["gzip", "lzf"] | None = None,
         compression_opts: int | Any = None,
         as_dense: Sequence[str] = (),
@@ -1826,6 +1831,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         ----------
         filename
             Filename of data file. Defaults to backing file.
+        convert_strings_to_categoricals
+            Convert string columns to categorical.
         compression
             For [`lzf`, `gzip`], see the h5py :ref:`dataset_compression`.
 
@@ -1880,6 +1887,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         write_h5ad(
             Path(filename),
             self,
+            convert_strings_to_categoricals=convert_strings_to_categoricals,
             compression=compression,
             compression_opts=compression_opts,
             as_dense=as_dense,
@@ -1891,7 +1899,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     write = write_h5ad  # a shortcut and backwards compat
 
     @old_positionals("skip_data", "sep")
-    def write_csvs(self, dirname: PathLike, *, skip_data: bool = True, sep: str = ","):
+    def write_csvs(
+        self, dirname: PathLike[str] | str, *, skip_data: bool = True, sep: str = ","
+    ):
         """\
         Write annotation to `.csv` files.
 
@@ -1912,7 +1922,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         write_csvs(dirname, self, skip_data=skip_data, sep=sep)
 
     @old_positionals("write_obsm_varm")
-    def write_loom(self, filename: PathLike, *, write_obsm_varm: bool = False):
+    def write_loom(
+        self, filename: PathLike[str] | str, *, write_obsm_varm: bool = False
+    ):
         """\
         Write `.loom`-formatted hdf5 file.
 
@@ -1925,10 +1937,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         write_loom(filename, self, write_obsm_varm=write_obsm_varm)
 
+    @old_positionals("chunks")
     def write_zarr(
         self,
-        store: MutableMapping | PathLike,
+        store: StoreLike,
+        *,
         chunks: tuple[int, ...] | None = None,
+        convert_strings_to_categoricals: bool = True,
     ):
         """\
         Write a hierarchical Zarr array store.
@@ -1939,6 +1954,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             The filename, a :class:`~typing.MutableMapping`, or a Zarr storage class.
         chunks
             Chunk shape.
+        convert_strings_to_categoricals
+            Convert string columns to categorical.
         """
         from ..io import write_zarr
 
@@ -1949,7 +1966,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 "Please pass `write_zarr(adata)` instead."
             )
             raise ValueError(msg)
-        write_zarr(store, self, chunks=chunks)
+        write_zarr(
+            store,
+            self,
+            chunks=chunks,
+            convert_strings_to_categoricals=convert_strings_to_categoricals,
+        )
 
     def chunked_X(self, chunk_size: int | None = None):
         """\
@@ -2090,10 +2112,10 @@ def _infer_shape_for_axis(
             return elem.shape[0]
     for elem, id in zip([layers, xxxm, xxxp], ["layers", "xxxm", "xxxp"]):
         if elem is not None:
-            elem = cast(Mapping, elem)
+            elem = cast("Mapping", elem)
             for sub_elem in elem.values():
                 if hasattr(sub_elem, "shape"):
-                    size = cast(int, sub_elem.shape[axis if id == "layers" else 0])
+                    size = cast("int", sub_elem.shape[axis if id == "layers" else 0])
                     return size
     return None
 

--- a/src/anndata/_core/file_backing.py
+++ b/src/anndata/_core/file_backing.py
@@ -26,7 +26,7 @@ class AnnDataFileManager:
     def __init__(
         self,
         adata: anndata.AnnData,
-        filename: PathLike | None = None,
+        filename: PathLike[str] | str | None = None,
         filemode: Literal["r", "r+"] | None = None,
     ):
         self._adata_ref = weakref.ref(adata)
@@ -81,12 +81,12 @@ class AnnDataFileManager:
         return self._filename
 
     @filename.setter
-    def filename(self, filename: PathLike | None):
+    def filename(self, filename: PathLike[str] | str | None):
         self._filename = None if filename is None else Path(filename)
 
     def open(
         self,
-        filename: PathLike | None = None,
+        filename: PathLike[str] | str | None = None,
         filemode: Literal["r", "r+"] | None = None,
     ):
         if filename is not None:

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -36,6 +36,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping, Sequence
+    from os import PathLike
     from typing import Any, Literal
 
     from .._core.file_backing import AnnDataFileManager
@@ -44,7 +45,7 @@ T = TypeVar("T")
 
 
 def write_h5ad(
-    filepath: Path | str,
+    filepath: PathLike[str] | str,
     adata: AnnData,
     *,
     as_dense: Sequence[str] = (),
@@ -140,7 +141,9 @@ def write_sparse_as_dense(
         del f[key]
 
 
-def read_h5ad_backed(filename: str | Path, mode: Literal["r", "r+"]) -> AnnData:
+def read_h5ad_backed(
+    filename: str | PathLike[str], mode: Literal["r", "r+"]
+) -> AnnData:
     d = dict(filename=filename, filemode=mode)
 
     f = h5py.File(filename, mode)
@@ -169,7 +172,7 @@ def read_h5ad_backed(filename: str | Path, mode: Literal["r", "r+"]) -> AnnData:
 
 
 def read_h5ad(
-    filename: str | Path,
+    filename: PathLike[str] | str,
     backed: Literal["r", "r+"] | bool | None = None,
     *,
     as_sparse: Sequence[str] = (),

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -53,6 +53,7 @@ def write_h5ad(
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
     **kwargs,
 ) -> None:
+    """See :meth:`~anndata.AnnData.write_h5ad`."""
     if isinstance(as_dense, str):
         as_dense = [as_dense]
     if "raw.X" in as_dense:

--- a/src/anndata/_io/read.py
+++ b/src/anndata/_io/read.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def read_csv(
-    filename: PathLike | Iterator[str],
+    filename: PathLike[str] | str | Iterator[str],
     delimiter: str | None = ",",
     first_column_names: bool | None = None,
     dtype: str = "float32",
@@ -49,7 +49,9 @@ def read_csv(
     return read_text(filename, delimiter, first_column_names, dtype)
 
 
-def read_excel(filename: PathLike, sheet: str | int, dtype: str = "float32") -> AnnData:
+def read_excel(
+    filename: PathLike[str] | str, sheet: str | int, dtype: str = "float32"
+) -> AnnData:
     """\
     Read `.xlsx` (Excel) file.
 
@@ -73,7 +75,7 @@ def read_excel(filename: PathLike, sheet: str | int, dtype: str = "float32") -> 
     return AnnData(X, row, col)
 
 
-def read_umi_tools(filename: PathLike, dtype=None) -> AnnData:
+def read_umi_tools(filename: PathLike[str] | str, dtype=None) -> AnnData:
     """\
     Read a gzipped condensed count matrix from umi_tools.
 
@@ -96,7 +98,7 @@ def read_umi_tools(filename: PathLike, dtype=None) -> AnnData:
     return AnnData(X=X, obs=obs, var=var)
 
 
-def read_hdf(filename: PathLike, key: str) -> AnnData:
+def read_hdf(filename: PathLike[str] | str, key: str) -> AnnData:
     """\
     Read `.h5` (hdf5) file.
 
@@ -152,7 +154,7 @@ def _fmt_loom_axis_attrs(
 
 @_deprecate_positional_args(version="0.9")
 def read_loom(
-    filename: PathLike,
+    filename: PathLike[str] | str,
     *,
     sparse: bool = True,
     cleanup: bool = False,
@@ -295,7 +297,7 @@ def read_loom(
     return adata
 
 
-def read_mtx(filename: PathLike, dtype: str = "float32") -> AnnData:
+def read_mtx(filename: PathLike[str] | str, dtype: str = "float32") -> AnnData:
     """\
     Read `.mtx` file.
 
@@ -317,7 +319,7 @@ def read_mtx(filename: PathLike, dtype: str = "float32") -> AnnData:
 
 
 def read_text(
-    filename: PathLike | Iterator[str],
+    filename: PathLike[str] | str | Iterator[str],
     delimiter: str | None = None,
     first_column_names: bool | None = None,
     dtype: str = "float32",

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -193,7 +193,7 @@ def read_indices(group):
 
 
 def read_partial(
-    pth: PathLike,
+    pth: PathLike[str] | str,
     *,
     obs_idx=slice(None),
     var_idx=slice(None),

--- a/src/anndata/_io/write.py
+++ b/src/anndata/_io/write.py
@@ -84,7 +84,8 @@ def write_csvs(
 @old_positionals("write_obsm_varm")
 def write_loom(
     filename: PathLike[str] | str, adata: AnnData, *, write_obsm_varm: bool = False
-):
+) -> None:
+    """See :meth:`~anndata.AnnData.write_loom`."""
     filename = Path(filename)
     row_attrs = {k: np.array(v) for k, v in adata.var.to_dict("list").items()}
     row_names = adata.var_names

--- a/src/anndata/_io/write.py
+++ b/src/anndata/_io/write.py
@@ -24,7 +24,11 @@ logger = get_logger(__name__)
 
 @old_positionals("skip_data", "sep")
 def write_csvs(
-    dirname: PathLike, adata: AnnData, *, skip_data: bool = True, sep: str = ","
+    dirname: PathLike[str] | str,
+    adata: AnnData,
+    *,
+    skip_data: bool = True,
+    sep: str = ",",
 ):
     """See :meth:`~anndata.AnnData.write_csvs`."""
     dirname = Path(dirname)
@@ -78,7 +82,9 @@ def write_csvs(
 
 
 @old_positionals("write_obsm_varm")
-def write_loom(filename: PathLike, adata: AnnData, *, write_obsm_varm: bool = False):
+def write_loom(
+    filename: PathLike[str] | str, adata: AnnData, *, write_obsm_varm: bool = False
+):
     filename = Path(filename)
     row_attrs = {k: np.array(v) for k, v in adata.var.to_dict("list").items()}
     row_names = adata.var_names

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -19,6 +19,7 @@ from .utils import _read_legacy_raw, report_read_key_on_error
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
+    from os import PathLike
 
     from zarr.core.common import AccessModeLiteral
     from zarr.storage import StoreLike
@@ -61,7 +62,7 @@ def write_zarr(
         zarr.consolidate_metadata(f.store)
 
 
-def read_zarr(store: str | Path | MutableMapping | zarr.Group) -> AnnData:
+def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnData:
     """\
     Read from a hierarchical Zarr array store.
 

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -35,6 +35,7 @@ def write_zarr(
     convert_strings_to_categoricals: bool = True,
     **ds_kwargs,
 ) -> None:
+    """See :meth:`~anndata.AnnData.write_zarr`."""
     if isinstance(store, Path):
         store = str(store)
     if convert_strings_to_categoricals:

--- a/src/anndata/experimental/backed/_io.py
+++ b/src/anndata/experimental/backed/_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 import warnings
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 @doctest_needs("xarray")
 def read_lazy(
-    store: str | Path | MutableMapping | ZarrGroup | h5py.Dataset,
+    store: PathLike[str] | str | MutableMapping | ZarrGroup | h5py.Dataset,
     *,
     load_annotation_index: bool = True,
 ) -> AnnData:
@@ -89,7 +90,7 @@ def read_lazy(
         raise ImportError(msg)
     is_h5_store = isinstance(store, h5py.Dataset | h5py.File | h5py.Group)
     is_h5 = (
-        isinstance(store, Path | str) and Path(store).suffix == ".h5ad"
+        isinstance(store, PathLike | str) and Path(store).suffix == ".h5ad"
     ) or is_h5_store
 
     has_keys = True  # true if consolidated or h5ad

--- a/src/anndata/experimental/merge.py
+++ b/src/anndata/experimental/merge.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
 import shutil
 from collections.abc import Mapping
 from functools import singledispatch
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -105,9 +105,9 @@ def as_group(store, *, mode: str) -> ZarrGroup | H5Group:
     raise NotImplementedError(msg)
 
 
-@as_group.register(os.PathLike)
+@as_group.register(PathLike)
 @as_group.register(str)
-def _(store: os.PathLike | str, *, mode: str) -> ZarrGroup | H5Group:
+def _(store: PathLike[str] | str, *, mode: str) -> ZarrGroup | H5Group:
     store = Path(store)
     if store.suffix == ".h5ad":
         import h5py
@@ -410,8 +410,8 @@ def _write_axis_annot(
 
 
 def concat_on_disk(
-    in_files: Collection[str | os.PathLike] | Mapping[str, str | os.PathLike],
-    out_file: str | os.PathLike,
+    in_files: Collection[PathLike[str] | str] | Mapping[str, PathLike[str] | str],
+    out_file: PathLike[str] | str,
     *,
     max_loaded_elems: int = 100_000_000,
     axis: Literal["obs", 0, "var", 1] = 0,

--- a/tests/lazy/test_concat.py
+++ b/tests/lazy/test_concat.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.skipif(not find_spec("xarray"), reason="xarray not inst
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
     from typing import Literal
 
     from numpy.typing import NDArray
@@ -314,7 +315,7 @@ def test_concat_df_ds_mixed_types(
     assert_equal(mixed_concatenated, in_memory_concatenated)
 
 
-def test_concat_bad_mixed_types(tmp_path: str):
+def test_concat_bad_mixed_types(tmp_path: Path):
     orig = gen_adata((100, 200), np.array)
     orig.write_zarr(tmp_path)
     remote = read_lazy(tmp_path)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -607,20 +607,24 @@ def test_read_umi_tools():
     assert set(adata.obs_names) == {"ACAAGG", "TTCACG"}
 
 
-def test_write_categorical(tmp_path, diskfmt):
+@pytest.mark.parametrize("s2c", [True, False], ids=["str2cat", "preserve"])
+def test_write_categorical(
+    *, tmp_path: Path, diskfmt: Literal["h5ad", "zarr"], s2c: bool
+) -> None:
+    ad.settings.allow_write_nullable_strings = True
     adata_pth = tmp_path / f"adata.{diskfmt}"
-    orig = ad.AnnData(
-        obs=pd.DataFrame(
-            dict(
-                cat1=["a", "a", "b", np.nan, np.nan],
-                cat2=pd.Categorical(["a", "a", "b", np.nan, np.nan]),
-            )
-        ),
+    obs = dict(
+        str=pd.array(["a", "a", "b", pd.NA, pd.NA], dtype="string"),
+        cat=pd.Categorical(["a", "a", "b", np.nan, np.nan]),
+        **(dict(obj=["a", "a", "b", np.nan, np.nan]) if s2c else {}),
     )
-    getattr(orig, f"write_{diskfmt}")(adata_pth)
-    curr = getattr(ad, f"read_{diskfmt}")(adata_pth)
+    orig = ad.AnnData(obs=pd.DataFrame(obs))
+    getattr(orig, f"write_{diskfmt}")(adata_pth, convert_strings_to_categoricals=s2c)
+    curr: ad.AnnData = getattr(ad, f"read_{diskfmt}")(adata_pth)
     assert np.all(orig.obs.notna() == curr.obs.notna())
     assert np.all(orig.obs.stack().dropna() == curr.obs.stack().dropna())
+    assert curr.obs["str"].dtype == ("category" if s2c else "string")
+    assert curr.obs["cat"].dtype == "category"
 
 
 def test_write_categorical_index(tmp_path, diskfmt):

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -32,7 +32,6 @@ from anndata.compat import (
 from anndata.tests.helpers import as_dense_dask_array, assert_equal, gen_adata
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Literal
 
 HERE = Path(__file__).parent
@@ -541,7 +540,7 @@ def test_write_csv_view(typ, tmp_path):
     # https://github.com/scverse/anndata/issues/401
     import hashlib
 
-    def md5_path(pth: PathLike) -> bytes:
+    def md5_path(pth: Path) -> bytes:
         checksum = hashlib.md5()
         with pth.open("rb") as f:
             while True:


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #1915
- [x] Tests added
- [x] Release note added (or unnecessary)

Also
- fixes the Path types all over.
- Exports `anndata.io.write_{h5ad,zarr}` in an understated manner

I added this to the `0.11.4` milestone as it mostly corrects an oversight in #1474, but if you want I can split this up instead.