### PR TITLE
(fix): correct workflow branch selection

### DIFF
--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "*.*.x"
+      - "[0-9]+.[0-9]+.x"
   pull_request:
 
 env:


### PR DESCRIPTION
otherwise each CI job will run twice for each commit n backport PRs: once for pushing to `auto-backport-of-pr-1234-on-1.11.x` and once for PR into `1.11.x`

see here for the weird pattern language this uses: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

(of course it’s a different pattern language than the one used in rulesets, otherwise one could use the same pattern for both and that would be too easy)