### PR TITLE
(chore): upgrade `__setitem__` warning for `BaseCompressedSparseDataset`

### DIFF
--- a/docs/release-notes/1928.bugfix.md
+++ b/docs/release-notes/1928.bugfix.md
@@ -1,0 +1,1 @@
+Upgrade old deprecation warning to a `FutureWarning` on `BaseCompressedSparseDataset.__setitem__`, showing our intent to remove the feature in the next release.  {user}`ilan-gold`

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -501,7 +501,7 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
 
     def __setitem__(self, index: Index | tuple[()], value) -> None:
         warnings.warn(
-            "__setitem__ will be removed in the next anndata release. We do not recommend relying on its stability.",
+            "__setitem__ for backed sparse will be removed in the next anndata release.",
             FutureWarning,
         )
         row, col = self._normalize_index(index)

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -501,8 +501,8 @@ class BaseCompressedSparseDataset(abc._AbstractCSDataset, ABC):
 
     def __setitem__(self, index: Index | tuple[()], value) -> None:
         warnings.warn(
-            "__setitem__ will likely be removed in the near future. We do not recommend relying on its stability.",
-            PendingDeprecationWarning,
+            "__setitem__ will be removed in the next anndata release. We do not recommend relying on its stability.",
+            FutureWarning,
         )
         row, col = self._normalize_index(index)
         mock_matrix = self._to_backed()

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -315,7 +315,9 @@ def test_backed_modification_sparse(adata, backing_h5ad, sparse_format):
     assert adata.filename == backing_h5ad
     assert adata.isbacked
 
-    with pytest.warns(FutureWarning, match=r"__setitem__ will be removed"):
+    with pytest.warns(
+        FutureWarning, match=r"__setitem__ for backed sparse will be removed"
+    ):
         adata.X[0, [0, 2]] = 10
         adata.X[1, [0, 2]] = [11, 12]
         with pytest.raises(ValueError, match=r"cannot change the sparsity structure"):

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -315,9 +315,7 @@ def test_backed_modification_sparse(adata, backing_h5ad, sparse_format):
     assert adata.filename == backing_h5ad
     assert adata.isbacked
 
-    with pytest.warns(
-        PendingDeprecationWarning, match=r"__setitem__ will likely be removed"
-    ):
+    with pytest.warns(FutureWarning, match=r"__setitem__ will be removed"):
         adata.X[0, [0, 2]] = 10
         adata.X[1, [0, 2]] = [11, 12]
         with pytest.raises(ValueError, match=r"cannot change the sparsity structure"):


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] towards #1897, we need to stop subclassing from `scipy`, and to do that we need to remove `__setitem__` since we will not reimplement it
- [x] Tests added
- [x] Release note added (or unnecessary)
