### PR TITLE
(fix): force `dask` cluster tests to be run in same process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ addopts = [
     "--doctest-modules",
     "--pyargs",
     "-ptesting.anndata._pytest",
+    "--dist=loadgroup",
 ]
 filterwarnings = [
     "ignore::anndata._warnings.OldFormatWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ Home-page = "https://github.com/scverse/anndata"
 dev = [
     # runtime dev version generation
     "hatch-vcs",
-    "anndata[dev-doc,dev-test]",
+    "anndata[dev-doc,test]",
 ]
 doc = [
     "sphinx>=8.2.1",
@@ -91,6 +91,7 @@ test = [
     "pytest-randomly",
     "pytest-memray",
     "pytest-mock",
+    "pytest-xdist[psutil]",
     "filelock",
     "matplotlib",
     "scikit-learn",
@@ -98,13 +99,12 @@ test = [
     "joblib",
     "boltons",
     "scanpy>=1.10",
-    "httpx",              # For data downloading
+    "httpx",                # For data downloading
     "dask[distributed]",
     "awkward>=2.3",
     "pyarrow",
     "anndata[dask]",
 ]
-dev-test = [ "pytest-xdist[psutil]" ] # local test speedups
 gpu = [ "cupy" ]
 cu12 = [ "cupy-cuda12x" ]
 cu11 = [ "cupy-cuda11x" ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ if Version(dask.__version__) < Version("2024.8.0"):
     from dask.base import normalize_seq
 else:
     from dask.tokenize import normalize_seq
+
 from filelock import FileLock
 from scipy import sparse
 

--- a/tests/lazy/test_concat.py
+++ b/tests/lazy/test_concat.py
@@ -214,6 +214,7 @@ def test_concat_to_memory_var(
         stores_for_concat[store_idx].reset_key_trackers()
 
 
+@pytest.mark.xdist_group("dask")
 def test_concat_data_with_cluster_to_memory(
     adata_remote: AnnData, join: Join_T, local_cluster_addr: str
 ) -> None:

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -110,6 +110,7 @@ def test_dask_write(adata, tmp_path, diskfmt):
     assert isinstance(orig.varm["a"], DaskArray)
 
 
+@pytest.mark.xdist_group("dask")
 def test_dask_distributed_write(
     adata: AnnData,
     tmp_path: Path,

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -336,6 +336,7 @@ def test_read_lazy_subsets_nd_dask(store, n_dims, chunks):
         assert_equal(X_from_disk[index], X_dask_from_disk[index])
 
 
+@pytest.mark.xdist_group("dask")
 def test_read_lazy_h5_cluster(
     sparse_format: Literal["csr", "csc"], tmp_path: Path, local_cluster_addr: str
 ) -> None:


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
I was surprised to discover that simply making the cluster a param works, now let's see about CI
- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
