### PR TITLE
Add linkable labels to API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,8 @@ The central class:
    AnnData
 ```
 
+(combining-api)=
+
 ## Combining
 
 Combining {class}`AnnData` objects.
@@ -24,6 +26,8 @@ See also the section on concatenation.
 
    concat
 ```
+
+(reading-api)=
 
 ## Reading
 
@@ -65,6 +69,8 @@ You might have more success by assembling the {class}`AnnData` object yourself f
    io.read_text
    io.read_umi_tools
 ```
+
+(writing-api)=
 
 ## Writing
 
@@ -177,6 +183,8 @@ Types used by the former:
    experimental.backed._xarray.Dataset2D
 ```
 
+(errors-api)=
+
 ## Errors and warnings
 
 ```{eval-rst}
@@ -185,6 +193,8 @@ Types used by the former:
 
    ImplicitModificationWarning
 ```
+
+(settings-api)=
 
 ## Settings
 
@@ -195,6 +205,8 @@ Types used by the former:
    settings
    settings.override
 ```
+
+(types-api)=
 
 ## Custom Types/Classes for Readable/Writeable Elements
 


### PR DESCRIPTION
I think `types` makes sense for the last one, it can be a link to all of `anndata.{abc,typing,types}` 