### PR TITLE
(chore): Remove old unused compat utilities

### DIFF
--- a/src/anndata/_io/read.py
+++ b/src/anndata/_io/read.py
@@ -15,7 +15,7 @@ import pandas as pd
 from scipy import sparse
 
 from .. import AnnData
-from ..compat import _deprecate_positional_args
+from ..compat import old_positionals
 from .utils import is_float
 
 if TYPE_CHECKING:
@@ -152,7 +152,18 @@ def _fmt_loom_axis_attrs(
     return axis_df, axis_mapping
 
 
-@_deprecate_positional_args(version="0.9")
+@old_positionals(
+    "sparse",
+    "cleanup",
+    "X_name",
+    "obs_names",
+    "obsm_names",
+    "var_names",
+    "varm_names",
+    "dtype",
+    "obsm_mapping",
+    "varm_mapping",
+)
 def read_loom(  # noqa: PLR0912, PLR0913
     filename: PathLike[str] | str,
     *,

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from codecs import decode
 from collections.abc import Mapping
-from functools import cache, partial, singledispatch, wraps
+from functools import cache, partial, singledispatch
 from importlib.util import find_spec
-from inspect import Parameter, signature
 from types import EllipsisType
 from typing import TYPE_CHECKING, TypeVar
 from warnings import warn
@@ -14,7 +13,6 @@ import numpy as np
 import pandas as pd
 import scipy
 from packaging.version import Version
-from zarr import Array as ZarrArray  # noqa: F401
 from zarr import Group as ZarrGroup
 
 if TYPE_CHECKING:
@@ -322,11 +320,12 @@ def _move_adj_mtx(d):
             and isinstance(n[k], scipy.sparse.spmatrix | np.ndarray)
             and len(n[k].shape) == 2
         ):
-            warn(
-                f"Moving element from .uns['neighbors']['{k}'] to .obsp['{k}'].\n\n"
-                "This is where adjacency matrices should go now.",
-                FutureWarning,
+            msg = (
+                f"Moving element from .uns['neighbors'][{k!r}] to .obsp[{k!r}].\n\n"
+                "This is where adjacency matrices should go now."
             )
+            # 4: caller -> 3: `AnnData.__init__` -> 2: `_init_as_actual` → 1: here
+            warn(msg, FutureWarning)  # , stacklevel=4)
             obsp[k] = n.pop(k)
 
 
@@ -338,60 +337,6 @@ def _find_sparse_matrices(d: Mapping, n: int, keys: tuple, paths: list):
         elif scipy.sparse.issparse(v) and v.shape == (n, n):
             paths.append((*keys, k))
     return paths
-
-
-# This function was adapted from scikit-learn
-# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/validation.py
-def _deprecate_positional_args(func=None, *, version: str = "1.0 (renaming of 0.25)"):
-    """Decorator for methods that issues warnings for positional arguments.
-    Using the keyword-only argument syntax in pep 3102, arguments after the
-    * will issue a warning when passed as a positional argument.
-
-    Parameters
-    ----------
-    func
-        Function to check arguments on.
-    version
-        The version when positional arguments will result in error.
-    """
-
-    def _inner_deprecate_positional_args(f):
-        sig = signature(f)
-        kwonly_args = []
-        all_args = []
-
-        for name, param in sig.parameters.items():
-            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
-                all_args.append(name)
-            elif param.kind == Parameter.KEYWORD_ONLY:
-                kwonly_args.append(name)
-
-        @wraps(f)
-        def inner_f(*args, **kwargs):
-            extra_args = len(args) - len(all_args)
-            if extra_args <= 0:
-                return f(*args, **kwargs)
-
-            # extra_args > 0
-            args_msg = [
-                f"{name}={arg}"
-                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
-            ]
-            args_msg = ", ".join(args_msg)
-            warn(
-                f"Pass {args_msg} as keyword args. From version {version} passing "
-                "these as positional arguments will result in an error",
-                FutureWarning,
-            )
-            kwargs.update(zip(sig.parameters, args))
-            return f(**kwargs)
-
-        return inner_f
-
-    if func is not None:
-        return _inner_deprecate_positional_args(func)
-
-    return _inner_deprecate_positional_args
 
 
 def _transpose_by_block(dask_array: DaskArray) -> DaskArray:

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import scipy
 from packaging.version import Version
+from zarr import Array as ZarrArray  # noqa: F401
 from zarr import Group as ZarrGroup
 
 if TYPE_CHECKING:

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import random
-import re
 import warnings
 from collections import Counter, defaultdict
 from collections.abc import Mapping
@@ -941,20 +940,6 @@ def _(a, format="csr"):
         return a.copy()
     return a.rechunk((a.chunks[0], -1)).map_blocks(
         partial(as_cupy, typ=memory_class), dtype=a.dtype
-    )
-
-
-def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str | re.Pattern):
-    """
-    Checks whether the printed error message or the notes contains the given pattern.
-
-    DOES NOT WORK IN IPYTHON - because of the way IPython handles exceptions
-    """
-    import traceback
-
-    message = "".join(traceback.format_exception_only(e.type, e.value))
-    assert re.search(pattern, message), (
-        f"Could not find pattern: '{pattern}' in error:\n\n{message}\n"
     )
 
 

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -6,7 +6,6 @@ import re
 import warnings
 from collections import Counter, defaultdict
 from collections.abc import Mapping
-from contextlib import contextmanager
 from functools import partial, singledispatch, wraps
 from string import ascii_letters
 from typing import TYPE_CHECKING
@@ -943,21 +942,6 @@ def _(a, format="csr"):
     return a.rechunk((a.chunks[0], -1)).map_blocks(
         partial(as_cupy, typ=memory_class), dtype=a.dtype
     )
-
-
-@contextmanager
-def pytest_8_raises(exc_cls, *, match: str | re.Pattern | None = None):
-    """Error handling using pytest 8's support for __notes__.
-
-    See: https://github.com/pytest-dev/pytest/pull/11227
-
-    Remove once pytest 8 is out!
-    """
-
-    with pytest.raises(exc_cls) as exc_info:
-        yield exc_info
-
-    check_error_or_notes_match(exc_info, match)
 
 
 def check_error_or_notes_match(e: pytest.ExceptionInfo, pattern: str | re.Pattern):


### PR DESCRIPTION
I ran into some puzzling behavior in #1967 that I’d like to fix.

This is a cleanup PR that makes things less muddled before debugging that.