### PR TITLE
Catch all exceptions getting version from VCS, fallback to `importlib`

### DIFF
--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -44,7 +44,7 @@ def _get_version_from_vcs(project_name: str) -> str:  # pragma: no cover
         msg = (
             f"Unknown error getting version from hatchling config for '{project_name}'."
         )
-        warnings.warn(f"{msg}: {e}")
+        warnings.warn(f"{msg}: {e}", stacklevel=1)
         raise GetVersionError(msg) from e
 
     # We found a hatchling environment, but is it ours?

--- a/src/anndata/_version.py
+++ b/src/anndata/_version.py
@@ -5,12 +5,19 @@ See <https://github.com/maresb/hatch-vcs-footgun-example>.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 __all__ = ["__version__"]
 
+_PROJECT_NAME = "anndata"
 
-def _get_version_from_vcs() -> str:  # pragma: no cover
+
+class GetVersionError(Exception):
+    pass
+
+
+def _get_version_from_vcs(project_name: str) -> str:  # pragma: no cover
     from hatchling.metadata.core import ProjectMetadata
     from hatchling.plugin.exceptions import UnknownPluginError
     from hatchling.plugin.manager import PluginManager
@@ -23,15 +30,33 @@ def _get_version_from_vcs() -> str:  # pragma: no cover
     metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
     try:
         # Version can be either statically set in pyproject.toml or computed dynamically:
-        return metadata.core.version or metadata.hatch.version.cached
+        version = metadata.core.version or metadata.hatch.version.cached
     except UnknownPluginError as e:
         msg = "Unable to import hatch plugin."
         raise ImportError(msg) from e
+    except ValueError as e:
+        msg = f"Could not find hatchling project data in TOML file, {pyproject_toml}"
+        raise GetVersionError(msg) from e
+    except TypeError as e:
+        msg = "Could not parse build configuration."
+        raise GetVersionError(msg) from e
+    except Exception as e:
+        msg = (
+            f"Unknown error getting version from hatchling config for '{project_name}'."
+        )
+        warnings.warn(f"{msg}: {e}")
+        raise GetVersionError(msg) from e
+
+    # We found a hatchling environment, but is it ours?
+    if metadata.core.name != project_name:
+        msg = f"Data in pyproject.toml is not related to {project_name}."
+        raise GetVersionError(msg)
+    return version
 
 
 try:
-    __version__ = _get_version_from_vcs()
-except (ImportError, LookupError):
+    __version__ = _get_version_from_vcs(_PROJECT_NAME)
+except (ImportError, LookupError, GetVersionError):
     import importlib.metadata
 
-    __version__ = importlib.metadata.version("anndata")
+    __version__ = importlib.metadata.version(_PROJECT_NAME)


### PR DESCRIPTION
This closes #1960.

`anndata` developers are using hatch build tool with a hatchling backend and relying on the hatch project configuration to make sure the version is up to date. However, the chosen approach can generate conflicts when the user has a `pyproject.toml` file of their own (see #1960).

This PR makes sure to catch all exceptions generated while trying to read the dev configuration and fall back to `importlib`. Additionally, as a safeguard, even if hatchling can parse and provide the data from the `pyproject.toml`, we will fallback to `importlib` if the project found does not match the expected project name.

The project name is placed as a private constant so that it can be ported to other `scverse` tools that need it.

- [X] Closes #1960
- [ ] Tests added
- [x] Release note added (or unnecessary)
