### PR TITLE
(fix): re-enable search popup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,6 @@ extensions = [
     "sphinx_autodoc_typehints",  # needs to be after napoleon
     "sphinx_issues",
     "sphinx_design",
-    "sphinx_search.extension",
     "sphinxext.opengraph",
     "scanpydoc",  # needs to be before linkcode
     "sphinx.ext.linkcode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,11 @@ doc = [
     "sphinx-toolbox>=3.8.0",
     "sphinxext.opengraph",
     "myst-nb",
-    "scanpydoc[theme,typehints] >=0.15.1",
+    "scanpydoc[theme,typehints] >=0.15.3",
     "awkward>=2.3",
     "IPython",                             # For syntax highlighting in notebooks
     "myst_parser",
     "sphinx_design>=0.5.0",
-    "readthedocs-sphinx-search",
     # for unreleased changes
     "anndata[dev-doc,dask]",
     "awkward>=2.3",


### PR DESCRIPTION
See https://github.com/readthedocs/readthedocs-sphinx-search/issues/144

The real fix was https://github.com/theislab/scanpydoc/pull/208