### PR TITLE
IO: filter out compression kwargs when writing empty datasets

### DIFF
--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -340,11 +340,13 @@ def read_null(_elem, _reader) -> None:
 
 @_REGISTRY.register_write(H5Group, type(None), IOSpec("null", "0.1.0"))
 def write_null_h5py(f, k, _v, _writer, dataset_kwargs=MappingProxyType({})):
+    dataset_kwargs = _remove_scalar_compression_args(dataset_kwargs)
     f.create_dataset(k, data=h5py.Empty("f"), **dataset_kwargs)
 
 
 @_REGISTRY.register_write(ZarrGroup, type(None), IOSpec("null", "0.1.0"))
 def write_null_zarr(f, k, _v, _writer, dataset_kwargs=MappingProxyType({})):
+    dataset_kwargs = _remove_scalar_compression_args(dataset_kwargs)
     # zarr has no first-class null dataset
     if is_zarr_v2():
         import zarr

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -76,6 +76,7 @@ uns_dict = dict(  # unstructured annotation
         f=np.int32(7),
         g=[1, np.float32(2.5)],
     ),
+    uns5=None
 )
 
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -76,7 +76,7 @@ uns_dict = dict(  # unstructured annotation
         f=np.int32(7),
         g=[1, np.float32(2.5)],
     ),
-    uns5=None
+    uns5=None,
 )
 
 


### PR DESCRIPTION
Otherwise h5py raises an exception. Similar to #1783 

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [x] Tests added
- [x] Release note unnecessary (fixes a new feature)