### PR TITLE
Fix up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Scverse Community Forum
     url: https://discourse.scverse.org/
     about: If you have questions about “How to do X”, please ask them here.
-  - name: Blank issue
-    url: https://github.com/scverse/anndata/issues/new
-    about: For things that don't quite fit elsewhere. Please note that other templates should be used in most cases – this is mainly for use by the developers.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,6 +8,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: If you have *usage* question, please visit the [Scverse Community Forum](https://discourse.scverse.org/) instead.
+      label: Question
+      description: If you have *usage* question, please visit the [Scverse Community Forum](https://discourse.scverse.org/) instead.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,13 @@
+name: Technical question
+description: You wonder about a design decision or implementation detail?
+#title: ...
+labels:
+  - question
+#assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: If you have *usage* question, please visit the [Scverse Community Forum](https://discourse.scverse.org/) instead.
+    validations:
+      required: true


### PR DESCRIPTION
They changed how the implicit “open blank issue” link renders, and now it’s too prominent, so let’s replace it.

Preview: https://github.com/scverse/anndata/blob/8d541dea6ffa542f02202676afcceaed762910fb/.github/ISSUE_TEMPLATE/question.yml

![grafik](https://github.com/user-attachments/assets/cc22d3a9-c189-4c1b-b049-5409bda016ba)

→

![grafik](https://github.com/user-attachments/assets/91f9bc93-2583-42c7-967b-bd4c41424387)
