### PR TITLE
(fix): setting on `Dataset2D` "just works"

### DIFF
--- a/src/anndata/_core/xarray.py
+++ b/src/anndata/_core/xarray.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
-from ..compat import XDataset
-
-if TYPE_CHECKING:
-    from ..compat import XDataArray
+from ..compat import XDataArray, XDataset
 
 
 class Dataset2D(XDataset):
@@ -143,3 +138,16 @@ class Dataset2D(XDataset):
         if index_key is not None:
             columns.discard(index_key)
         return pd.Index(columns)
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, tuple) and not isinstance(value, XDataArray):
+            # maintain setting behavior of a 2D dataframe i.e., one dim
+            value = (self.index_dim, value)
+        if isinstance(value, XDataArray):
+            if len(value.dims) != 1:
+                msg = f"XDataArray should have only one dimension, found {len(value.dims)}"
+                raise ValueError(msg)
+            if value.dims[0] != self.index_dim:
+                msg = f"DataArray {value} should have dimension {self.index_dim}, found {value.dims[0]}"
+                raise ValueError(msg)
+        super().__setitem__(key, value)

--- a/tests/lazy/test_dataset_2d.py
+++ b/tests/lazy/test_dataset_2d.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from importlib.util import find_spec
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from anndata._core.xarray import Dataset2D
+
+pytestmark = pytest.mark.skipif(not find_spec("xarray"), reason="xarray not installed")
+
+
+def test_dataset_2d_set_array_different_dims():
+    import xarray as xr
+
+    ds = Dataset2D(
+        {"foo": ("obs_names", pd.array(["a", "b", "c"], dtype="category"))},
+        coords={"obs_names": [1, 2, 3]},
+    )
+    da = xr.DataArray(
+        np.arange(3),
+        coords=[np.arange(3)],
+        dims="not_obs_names",
+    )
+    with pytest.raises(ValueError, match="dimension obs_names, found not_obs_names"):
+        ds["foo"] = da
+
+
+def test_dataset_2d_set_extension_array():
+    ds = Dataset2D(
+        {"foo": ("obs_names", pd.array(["a", "b", "c"], dtype="category"))},
+        coords={"obs_names": [1, 2, 3]},
+    )
+    array = pd.array(["e", "f", "g"], dtype="category")
+    ds["foo"] = array
+    assert ds["foo"].dims == ("obs_names",)
+    assert ds["foo"].data is array

--- a/tests/lazy/test_dataset_2d.py
+++ b/tests/lazy/test_dataset_2d.py
@@ -7,32 +7,85 @@ import pandas as pd
 import pytest
 
 from anndata._core.xarray import Dataset2D
+from anndata.compat import XDataArray
 
 pytestmark = pytest.mark.skipif(not find_spec("xarray"), reason="xarray not installed")
 
 
-def test_dataset_2d_set_array_different_dims():
-    import xarray as xr
-
-    ds = Dataset2D(
+@pytest.fixture
+def dataset_2d():
+    return Dataset2D(
         {"foo": ("obs_names", pd.array(["a", "b", "c"], dtype="category"))},
         coords={"obs_names": [1, 2, 3]},
     )
-    da = xr.DataArray(
+
+
+def test_dataset_2d_set_array_different_dims(dataset_2d):
+    da = XDataArray(
         np.arange(3),
         coords=[np.arange(3)],
         dims="not_obs_names",
     )
     with pytest.raises(ValueError, match="dimension obs_names, found not_obs_names"):
-        ds["foo"] = da
+        dataset_2d["foo"] = da
 
 
-def test_dataset_2d_set_extension_array():
-    ds = Dataset2D(
-        {"foo": ("obs_names", pd.array(["a", "b", "c"], dtype="category"))},
-        coords={"obs_names": [1, 2, 3]},
+def test_dataset_2d_set_array_multiple_dims(dataset_2d):
+    da = XDataArray(
+        np.arange(9).reshape(3, 3),
+        coords={"obs_names": np.arange(3), "not_obs_names": np.arange(3)},
+        dims=("obs_names", "not_obs_names"),
     )
+    with pytest.raises(ValueError, match="should have only one dimension"):
+        dataset_2d["foo"] = da
+
+
+def test_dataset_2d_set_dataarray(dataset_2d):
+    da = XDataArray(
+        np.arange(3), coords={"obs_names": [1, 2, 3]}, dims=("obs_names"), name="bar"
+    )
+    dataset_2d["bar"] = da
+    assert dataset_2d["bar"].dims == ("obs_names",)
+    assert dataset_2d["bar"].equals(da)
+
+
+def test_dataset_2d_set_dataarray_bad_coord_name(dataset_2d):
+    da = XDataArray(
+        np.arange(3),
+        coords={"foo": ("obs_names", np.arange(3))},
+        dims=("obs_names"),
+        name="bar",
+    )
+    with pytest.raises(ValueError, match="DataArray should have coordinate obs_names"):
+        dataset_2d["bar"] = da
+
+
+def test_dataset_2d_set_dataarray_bad_name(dataset_2d):
+    da = XDataArray(
+        np.arange(3),
+        coords={"obs_names": np.arange(3)},
+        dims=("obs_names"),
+        name="not_bar",
+    )
+    with pytest.raises(
+        ValueError, match="DataArray should have name bar, found not_bar"
+    ):
+        dataset_2d["bar"] = da
+
+
+def test_dataset_2d_set_extension_array(dataset_2d):
     array = pd.array(["e", "f", "g"], dtype="category")
-    ds["foo"] = array
-    assert ds["foo"].dims == ("obs_names",)
-    assert ds["foo"].data is array
+    dataset_2d["bar"] = array
+    assert dataset_2d["bar"].dims == ("obs_names",)
+    assert dataset_2d["bar"].data is array
+
+
+@pytest.mark.parametrize(
+    "data", [np.arange(3), XDataArray(np.arange(3), dims="obs_names", name="obs_names")]
+)
+def test_dataset_2d_set_index(data, dataset_2d):
+    with pytest.raises(
+        KeyError,
+        match="Cannot set obs_names as a variable",
+    ):
+        dataset_2d["obs_names"] = data


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Since we're enforcing two dimensions on the object (in theory), we should probably be _super_ clear about that while also retaining dataframe-like operations i.e., when you try to "set a column" (in this case, xarray data variable that isn't a coord), it "just works" (sets the column and doesn't do anything else).  This behavior matches that of `pandas` in so far as having a named index doesn't mean it can be set/accessed via `df["my_named_index"]`

- [x] Closes #1990
- [x] Tests added
- [ ] Release note added (or unnecessary)
