### PR TITLE
Improve concat_on_disk varm handling

### DIFF
--- a/src/anndata/experimental/merge.py
+++ b/src/anndata/experimental/merge.py
@@ -371,13 +371,13 @@ def _write_concat_sequence(
 
 
 def _write_alt_mapping(groups, output_group, alt_axis_name, alt_indices, merge):
-    alt_mapping = merge([read_as_backed(g[alt_axis_name]) for g in groups])
+    alt_mapping = merge([read_as_backed(g[f"{alt_axis_name}m"]) for g in groups])
     # If its empty, we need to write an empty dataframe with the correct index
     if not alt_mapping:
         alt_df = pd.DataFrame(index=alt_indices)
-        write_elem(output_group, alt_axis_name, alt_df)
+        write_elem(output_group, f"{alt_axis_name}m", alt_df)
     else:
-        write_elem(output_group, alt_axis_name, alt_mapping)
+        write_elem(output_group, f"{alt_axis_name}m", alt_mapping)
 
 
 def _write_alt_annot(groups, output_group, alt_axis_name, alt_indices, merge):
@@ -400,6 +400,11 @@ def _write_axis_annot(
     if label is not None:
         concat_annot[label] = label_col
     write_elem(output_group, axis_name, concat_annot)
+
+
+def _write_uns(groups, output_group, merge):
+    uns = merge([read_elem(g["uns"]) for g in groups])
+    write_elem(output_group, "uns", uns)
 
 
 def concat_on_disk(
@@ -633,6 +638,9 @@ def concat_on_disk(
     # Write {alt_axis_name}m
     _write_alt_mapping(groups, output_group, alt_axis_name, alt_index, merge)
 
+    # Write uns
+    _write_uns(groups, output_group, uns_merge)
+    
     # Write X
 
     _write_concat_arrays(

--- a/src/anndata/experimental/merge.py
+++ b/src/anndata/experimental/merge.py
@@ -640,7 +640,7 @@ def concat_on_disk(
 
     # Write uns
     _write_uns(groups, output_group, uns_merge)
-    
+
     # Write X
 
     _write_concat_arrays(

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -1394,6 +1394,17 @@ def test_concat_size_0_axis(axis_name, join_type, merge_strategy, shape):
         if shape[axis] == 0 and Version(pd.__version__) >= Version("2.1")
         else nullcontext()
     )
+
+    # only expect warning if the other axis (not the one we're joining along) is empty
+    # pandas warns about concat w/ all-NA entries on non-join axis (from what I remember)
+    # ctx_concat_empty = (
+    #     pytest.warns(
+    #         FutureWarning,
+    #         match=r"The behavior of DataFrame concatenation with empty or all-NA entries is deprecated",
+    #     )
+    #     if shape[1 - axis] == 0 and Version(pd.__version__) >= Version("2.1")
+    #     else nullcontext()
+    # )
     with ctx_concat_empty:
         result = concat(
             {"a": a, "b": b},


### PR DESCRIPTION
This builds on @milos7250’s PR https://github.com/scverse/anndata/pull/1855 and fixes an issue in concat_on_disk where .varm was present in one input but missing in the other, which caused test_concat_on_disk_varm_mapping to fail. I also added a prototype for a stricter .uns merge option called merge_same_strict, which uses merge_nested and a _raise_on_conflict function that only accepts non-empty values that are identical across all datasets; otherwise, it throws a ValueError. The goal was to catch silent conflicts early, but I’m not sure if this behavior makes sense in practice. (Open to feedback on whether it’s worth keeping as an optional merge strategy like uns_merge="same_strict" or dropping it entirely. - was not worth it as it was causing multiple issues). 

This is second attempt as I decided to write the solution from scratch. 