### PR TITLE
(feat): use numpy nan-able string type for `anndata.experimental.MaskedArray`

### DIFF
--- a/docs/release-notes/2011.feature.md
+++ b/docs/release-notes/2011.feature.md
@@ -1,1 +1,1 @@
-Use {attr}`numpy.dtypes.StringDType` with `na_object` set to {attr}`pandas.NA` for nullable string data with {class}`anndata.experimental.Dataset2D` {user}`ilan-gold`
+Use {attr}`numpy.dtypes.StringDType` with `na_object` set to {attr}`pandas.NA` for nullable string data with {class}`anndata.experimental.backed.Dataset2D` {user}`ilan-gold`

--- a/docs/release-notes/2011.feature.md
+++ b/docs/release-notes/2011.feature.md
@@ -1,1 +1,1 @@
-Use {attr}`numpy.dtypes.StringDType` with `na_object` set to {attr}`pandas.NA` for nullable string data as the backing data to the {class}`pandas.arrays.StringArray` {user}`ilan-gold`
+Use {attr}`numpy.dtypes.StringDType` with `na_object` set to {attr}`pandas.NA` for nullable string data with {class}`anndata.experimental.Dataset2D` {user}`ilan-gold`

--- a/docs/release-notes/2011.feature.md
+++ b/docs/release-notes/2011.feature.md
@@ -1,0 +1,1 @@
+Use {attr}`numpy.dtypes.StringDType` with `na_object` set to {attr}`pandas.NA` for nullable string data as the backing data to the {class}`pandas.arrays.StringArray` {user}`ilan-gold`

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -14,7 +14,15 @@ import anndata as ad
 from anndata._core.file_backing import filename, get_elem_name
 from anndata._core.xarray import Dataset2D, requires_xarray
 from anndata.abc import CSCDataset, CSRDataset
-from anndata.compat import DaskArray, H5Array, H5Group, XDataArray, ZarrArray, ZarrGroup
+from anndata.compat import (
+    NULLABLE_NUMPY_STRING_TYPE,
+    DaskArray,
+    H5Array,
+    H5Group,
+    XDataArray,
+    ZarrArray,
+    ZarrGroup,
+)
 
 from .registry import _LAZY_REGISTRY, IOSpec
 
@@ -251,8 +259,7 @@ def _gen_xarray_dict_iterator_from_elems(
                     "base_path_or_zarr_group": v.base_path_or_zarr_group,
                     "elem_name": v.elem_name,
                     "is_nullable_string": isinstance(v, MaskedArray)
-                    and v.dtype  # CategoricalArray dtype access requires a read nad is not necessary here
-                    == np.dtype("O"),
+                    and v.dtype == NULLABLE_NUMPY_STRING_TYPE,
                 },
             )
         elif k == dim_name:

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -41,7 +41,7 @@ from anndata.compat import (
 )
 
 from ..._settings import settings
-from ...compat import is_zarr_v2
+from ...compat import NULLABLE_NUMPY_STRING_TYPE, is_zarr_v2
 from .registry import _REGISTRY, IOSpec, read_elem, read_elem_partial
 
 if TYPE_CHECKING:
@@ -1210,7 +1210,7 @@ def _string_array(
     values: np.ndarray, mask: np.ndarray
 ) -> pd.api.extensions.ExtensionArray:
     """Construct a string array from values and mask."""
-    arr = pd.array(values, dtype=pd.StringDtype())
+    arr = pd.array(values.astype(NULLABLE_NUMPY_STRING_TYPE), dtype=pd.StringDtype())
     arr[mask] = pd.NA
     return arr
 

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -41,7 +41,7 @@ from anndata.compat import (
 )
 
 from ..._settings import settings
-from ...compat import NULLABLE_NUMPY_STRING_TYPE, is_zarr_v2
+from ...compat import is_zarr_v2
 from .registry import _REGISTRY, IOSpec, read_elem, read_elem_partial
 
 if TYPE_CHECKING:
@@ -1210,7 +1210,7 @@ def _string_array(
     values: np.ndarray, mask: np.ndarray
 ) -> pd.api.extensions.ExtensionArray:
     """Construct a string array from values and mask."""
-    arr = pd.array(values.astype(NULLABLE_NUMPY_STRING_TYPE), dtype=pd.StringDtype())
+    arr = pd.array(values, dtype=pd.StringDtype())
     arr[mask] = pd.NA
     return arr
 

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -404,3 +404,10 @@ def _map_cat_to_str(cat: pd.Categorical) -> pd.Categorical:
         return cat.map(str, na_action="ignore")
     else:
         return cat.map(str)
+
+
+NULLABLE_NUMPY_STRING_TYPE = (
+    np.dtype("O")
+    if Version(np.__version__) < Version("2")
+    else np.dtypes.StringDType(na_object=pd.NA)
+)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Using direct nan-able types is much better than object dtypes.  In theory, this functionality should be usable independent of the new zarr dtype business and give us stronger typing going forward.  

- [x] From #1995
- [ ] Tests added
- [ ] Release note added (or unnecessary)
