### PR TITLE
fix: no cache indptr `zarr` dask

### DIFF
--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -132,7 +132,7 @@ def read_sparse_as_dask(
     path_or_sparse_dataset = (
         Path(filename(elem))
         if isinstance(elem, H5Group)
-        else ad.io.sparse_dataset(elem)
+        else ad.io.sparse_dataset(elem, should_cache_indptr=False)
     )
     elem_name = get_elem_name(elem)
     shape: tuple[int, int] = tuple(elem.attrs["shape"])


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Evidently the same problem that was present previously with only hdf5 is now present with zarr v3 as well.  Given that the performance is identical in zarr v2 with/without caching in dask, I think we should simply turn it off in general when using dask.  

I am wondering if this is related to #2021 or https://github.com/dask/dask/issues/11909.  I need to investigate more, but if zarr v3 is doing something unexpectedly with forking a process (which might force the `CSRDataset` class to bust its cache repeatedly, for example, in this case), that could account for these various issues.

But for now, I think this fix is fairly innocuous.

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
