### PR TITLE
feat: array-api compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ test-min = [
     "pyarrow<21",        # https://github.com/scikit-hep/awkward/issues/3579
     "anndata[dask]",
 ]
-test = [ "anndata[test-min,lazy]" ]
+test = [ "anndata[test-min,lazy]", "jax", "jaxlib" ] # TODO: remove jax? own extra?
 gpu = [ "cupy" ]
 cu12 = [ "cupy-cuda12x" ]
 cu11 = [ "cupy-cuda11x" ]

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse
 
-from ..compat import AwkArray, CSArray, CSMatrix, DaskArray, XDataArray
+from ..compat import AwkArray, CSArray, CSMatrix, DaskArray, XDataArray, has_xp
 from .xarray import Dataset2D
 
 if TYPE_CHECKING:
@@ -115,6 +115,9 @@ def _normalize_index(  # noqa: PLR0911, PLR0912
         if isinstance(indexer.data, DaskArray):
             return indexer.data.compute()
         return indexer.data
+    elif has_xp(indexer):
+        msg = "Need to implement array api-based indexing"
+        raise NotImplementedError(msg)
     msg = f"Unknown indexer {indexer!r} of type {type(indexer)}"
     raise IndexError(msg)
 

--- a/src/anndata/_core/index.py
+++ b/src/anndata/_core/index.py
@@ -116,7 +116,7 @@ def _normalize_index(  # noqa: PLR0911, PLR0912
             return indexer.data.compute()
         return indexer.data
     msg = f"Unknown indexer {indexer!r} of type {type(indexer)}"
-    raise IndexError()
+    raise IndexError(msg)
 
 
 def _fix_slice_bounds(s: slice, length: int) -> slice:

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -10,7 +10,7 @@ from scipy import sparse
 from anndata.compat import CSArray, CSMatrix
 
 from .._warnings import ImplicitModificationWarning
-from ..compat import XDataset
+from ..compat import XDataset, has_xp
 from ..utils import (
     ensure_df_homogeneous,
     join_english,
@@ -67,6 +67,8 @@ def coerce_array(
             return np.array(value)
         except (ValueError, TypeError) as _e:
             e = _e
+    if has_xp(value):
+        return value
     # if value isn’t the right type or convertible, raise an error
     msg = f"{name} needs to be of one of {join_english(map(str, array_data_structure_types))}, not {type(value)}."
     if e is not None:

--- a/src/anndata/_core/views.py
+++ b/src/anndata/_core/views.py
@@ -21,6 +21,7 @@ from ..compat import (
     CupyCSRMatrix,
     DaskArray,
     ZappyArray,
+    has_xp,
 )
 from .access import ElementRef
 from .xarray import Dataset2D
@@ -292,6 +293,9 @@ class DataFrameView(_ViewMixin, pd.DataFrame):
 
 @singledispatch
 def as_view(obj, view_args):
+    if has_xp(obj):
+        # TODO: Determine if we need some sort of specific view object for array-api
+        return obj
     msg = f"No view type has been registered for {type(obj)}"
     raise NotImplementedError(msg)
 

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -12,6 +12,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import scipy
+from array_api_compat import get_namespace as array_api_get_namespace
 from packaging.version import Version
 from zarr import Array as ZarrArray  # noqa: F401
 from zarr import Group as ZarrGroup
@@ -415,3 +416,11 @@ def _map_cat_to_str(cat: pd.Categorical) -> pd.Categorical:
         return cat.map(str, na_action="ignore")
     else:
         return cat.map(str)
+
+
+def has_xp(mod):
+    try:
+        array_api_get_namespace(mod)
+        return True
+    except TypeError:
+        return False

--- a/tests/test_obsmvarm.py
+++ b/tests/test_obsmvarm.py
@@ -144,6 +144,13 @@ def test_setting_daskarray(adata: AnnData):
     assert h == joblib.hash(adata)
 
 
+def test_setting_jax(adata: AnnData):
+    import jax.numpy as jnp
+
+    adata.obsm["jax"] = jnp.ones((adata.shape[0], 10))
+    assert isinstance(adata.obsm["jax"], jnp.ndarray)
+
+
 def test_shape_error(adata: AnnData):
     with pytest.raises(
         ValueError,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -833,7 +833,31 @@ def test_jax_indexer():
     assert_equal(adata[index], adata[index_jax])
 
 
-@pytest.mark.parametrize("index", [np.array([0, 3, 6]), slice(3), Ellipsis])
+@pytest.mark.parametrize(
+    "index",
+    [
+        np.array([0, 3, 6]),
+        slice(3),
+        Ellipsis,
+        (np.array([0, 3, 6]), np.array([1, 4, 7])),
+        (
+            np.array([([True] * 5) + ([False] * 5)]),
+            np.array([([True] * 5) + ([False] * 5)]),
+        ),
+        (
+            np.array([0, 3, 6]),
+            np.array([([True] * 5) + ([False] * 5)]),
+        ),
+    ],
+    ids=[
+        "integer-array",
+        "slice",
+        "ellipsis",
+        "two-axis-integer-arrays",
+        "two-axis-boolean-arrays",
+        "mixed-array-type",
+    ],
+)
 def test_index_into_jax(index):
     import jax.numpy as jnp
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -824,13 +824,22 @@ def test_index_float_sequence_raises_error(index):
         gen_adata((10, 10))[index]
 
 
-def test_jax_view():
+def test_jax_indexer():
     import jax.numpy as jnp
 
     index = np.array([0, 3, 6])
     index_jax = jnp.array(index)
     adata = gen_adata((10, 10))
     assert_equal(adata[index], adata[index_jax])
+
+
+@pytest.mark.parametrize("index", [np.array([0, 3, 6]), slice(3), Ellipsis])
+def test_index_into_jax(index):
+    import jax.numpy as jnp
+
+    adata = ad.AnnData(X=np.ones((10, 10)))
+    adata_as_jax = ad.AnnData(X=jnp.ones((10, 10)))
+    assert_equal(adata[index], adata_as_jax[index])
 
 
 # @pytest.mark.parametrize("dim", ["obs", "var"])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -824,6 +824,15 @@ def test_index_float_sequence_raises_error(index):
         gen_adata((10, 10))[index]
 
 
+def test_jax_view():
+    import jax.numpy as jnp
+
+    index = np.array([0, 3, 6])
+    index_jax = jnp.array(index)
+    adata = gen_adata((10, 10))
+    assert_equal(adata[index], adata[index_jax])
+
+
 # @pytest.mark.parametrize("dim", ["obs", "var"])
 # @pytest.mark.parametrize(
 #     ("idx", "pat"),

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -192,3 +192,9 @@ def test_fail_on_non_csr_csc_matrix():
         match=r"Only CSR and CSC.*",
     ):
         ad.AnnData(X=X)
+
+
+def test_create_anndata_with_jax():
+    import jax.numpy as jnp
+
+    ad.AnnData(X=jnp.ones((10, 10)))


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

@amalia-k510 I will be out for 2.5 weeks starting tomorrow.  Please have a look at this branch and work off of it.

There are three commits:

1. https://github.com/scverse/anndata/commit/21d5882725767b861a77906ecddb5877b4681f85 adds some tests that should (and do) fail because we have no handling.
2. https://github.com/scverse/anndata/commit/7cd6d69e47ba5a401bb5595f92ee17667e467759 adds the `has_xp` function and uses it to both raise a more informative error for indexing with an array-api compatible object and resolve two of the test fail cases from https://github.com/scverse/anndata/commit/21d5882725767b861a77906ecddb5877b4681f85 so that now we can declare `AnnData` objects that have `array-api` compatible arrays (in this case, `jax`)
3. https://github.com/scverse/anndata/commit/eff9dde13028547f140fac66013b528c31c53bc9 builds off the solved problem in https://github.com/scverse/anndata/commit/7cd6d69e47ba5a401bb5595f92ee17667e467759 and now adds a test indexing into such a declared object.  This test now fails because we have no way of creating views of `array-api` compatible objects.  In general views are not part of the array-api so our view mechanism will just be "subset the data"
4. I implemented the `as_view` function for the `array-api`-detected objects in https://github.com/scverse/anndata/commit/b230d11101dbeb8f2050a27e9198685187a92ed4 and added some more tests in https://github.com/scverse/anndata/commit/692a270c12f71600804ff75cee49b00d05cde89a

So the todos are likely now (in no particular order):

- [ ] `anndata.concat` will probably need to be updated to perform concatenation/reindexing correctly, so a new method [added to the `ReIndexer`](https://github.com/scverse/anndata/blob/7ff7e3b8f0b821d7c4cb74417a732752820cbca8/src/anndata/_core/merge.py#L546) for array-api compatible objects (named `_apply_to_array_api` or something as the current ones are named) that aren't already listed (like `numpy.ndarray`)
- [ ] [`src/anndata/_io/specs/registry.py::Writer.write_elem`](https://github.com/scverse/anndata/blob/7ff7e3b8f0b821d7c4cb74417a732752820cbca8/src/anndata/_io/specs/registry.py#L339) will likely need to be updated to use [`__dlpack__`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html#dlpack) to convert the `array-api` arrays into `numpy.ndarray` objects so that they can be safely written using the existing code.  https://numpy.org/doc/stable/reference/generated/numpy.from_dlpack.html will likely be of help
- [ ] Potentially some tests around views where writing into a view (as of `main`) should trigger an update of the parent object, but with the `array-api`, we can probably no longer guarantee that for e.g., `jax.numpy.ndarray`
- [ ] Migrate creation of `jax.numpy.ndarray` objects (and any other array-api compatible obejcts) into the [`gen_adata` ](https://github.com/scverse/anndata/blob/7ff7e3b8f0b821d7c4cb74417a732752820cbca8/src/anndata/tests/helpers.py#L269) function so that they are created by default on `obsm`, `varm`, `layers`, `obsp`, and `varp`.  At this point a lot of tests will start failing but fear not! This is exactly what you want as it will show you what you need to implement - go one by one and implement the new features (keeping the old behavior as-is i.e., `numpy` arrays should continue down their previous codepaths).  The above three todo's likely will appear if you do this first!

- [ ] Add another array-api compatible library beyond `jax` to our test suite (maybe _before_ doing the above given the current set of tests on this branch as that might be cleaner) - I think `cubed` is probably the best candidate: https://cubed-dev.github.io/cubed/array-api.html

- [ ] Support indexing by an array-api compatible object as you started in #2019 (there is a test I have in this branch for that via `test_jax_indexer`

For each of these, the paradigm should be "create (simple) test case, fix the issue the test raises"

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
