### PR TITLE
fix: writing views of backed anndata objects

### DIFF
--- a/docs/release-notes/2092.fix.md
+++ b/docs/release-notes/2092.fix.md
@@ -1,1 +1,1 @@
-Writing of views of {class}`~anndata.AnnData` in backed mode {user}`ilan-gold`
+Enable writing of views of {class}`~anndata.AnnData` in backed mode {user}`ilan-gold`

--- a/docs/release-notes/2092.fix.md
+++ b/docs/release-notes/2092.fix.md
@@ -1,0 +1,1 @@
+Writing of views of {class}`~anndata.AnnData` in backed mode {user}`ilan-gold`

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -42,11 +42,7 @@ from .index import _normalize_indices, _subset, get_vector
 from .raw import Raw
 from .sparse_dataset import BaseCompressedSparseDataset, sparse_dataset
 from .storage import coerce_array
-from .views import (
-    DictView,
-    _resolve_idxs,
-    as_view,
-)
+from .views import DictView, _resolve_idxs, as_view
 from .xarray import Dataset2D
 
 if TYPE_CHECKING:
@@ -1907,8 +1903,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
             compression_opts=compression_opts,
             as_dense=as_dense,
         )
-
-        if self.isbacked:
+        # Only reset the filename if the AnnData object now points to a complete new copy
+        if self.isbacked and not self.is_view:
             self.file.filename = filename
 
     write = write_h5ad  # a shortcut and backwards compat

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -106,6 +106,19 @@ def test_read_write_X(tmp_path, mtx_format, backed_mode, as_dense):
     assert np.all(asarray(orig.X) == asarray(from_backed.X))
 
 
+def test_backed_view(tmp_path, backed_mode):
+    base_pth = Path(tmp_path)
+    orig_pth = base_pth / "orig.h5ad"
+
+    orig = ad.AnnData(sparse.random(100, 10, format="csr"))
+    orig.write(orig_pth)
+
+    adata = ad.read_h5ad(orig_pth, backed=backed_mode)
+
+    for i in range(0, adata.shape[0], 10):
+        adata[i : i + 5].write_h5ad(tmp_path / f"chunk_{i}.h5ad")
+
+
 # this is very similar to the views test
 @pytest.mark.filterwarnings("ignore::anndata.ImplicitModificationWarning")
 def test_backing(adata: ad.AnnData, tmp_path: Path, backing_h5ad: Path) -> None:

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -37,7 +37,7 @@ subset_func2 = subset_func
 
 
 @pytest.fixture
-def adata():
+def adata() -> ad.AnnData:
     X_list = [
         [1, 2, 3],
         [4, 5, 6],
@@ -69,12 +69,16 @@ def adata():
     params=[sparse.csr_matrix, sparse.csc_matrix, np.array, as_dense_dask_array],
     ids=["scipy-csr", "scipy-csc", "np-array", "dask_array"],
 )
-def mtx_format(request):
+def mtx_format(
+    request,
+) -> Callable[
+    [np.ndarray], DaskArray | np.ndarray | sparse.csr_array | sparse.csr_matrix
+]:
     return request.param
 
 
 @pytest.fixture(params=[sparse.csr_matrix, sparse.csc_matrix])
-def sparse_format(request):
+def sparse_format(request) -> type[sparse.csr_matrix | sparse.csc_matrix]:
     return request.param
 
 
@@ -100,7 +104,7 @@ def as_dense(request) -> tuple[str] | tuple:
 def test_read_write_X(
     tmp_path: Path,
     mtx_format: Callable[
-        [np.ndarray], DaskArray | sparse.csr_array | sparse.csr_matrix
+        [np.ndarray], DaskArray | np.ndarray | sparse.csr_array | sparse.csr_matrix
     ],
     backed_mode: Literal["r+", "r", False],
     *,
@@ -345,7 +349,9 @@ def test_backed_modification(adata: ad.AnnData, backing_h5ad: Path):
 
 
 def test_backed_modification_sparse(
-    adata: ad.AnnData, backing_h5ad: Path, sparse_format
+    adata: ad.AnnData,
+    backing_h5ad: Path,
+    sparse_format: type[sparse.csr_matrix | sparse.csc_matrix],
 ):
     adata.X[:, 1] = 0  # Make it a little sparse
     adata.X = sparse_format(adata.X)

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -116,7 +116,10 @@ def test_backed_view(tmp_path, backed_mode):
     adata = ad.read_h5ad(orig_pth, backed=backed_mode)
 
     for i in range(0, adata.shape[0], 10):
+        chunk_path = tmp_path / f"chunk_{i}.h5ad"
         adata[i : i + 5].write_h5ad(tmp_path / f"chunk_{i}.h5ad")
+        chunk = adata[i : i + 5]
+        assert_equal(chunk, ad.read_h5ad(chunk_path))
 
 
 # this is very similar to the views test

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import joblib
 import numpy as np
@@ -20,6 +20,10 @@ from anndata.tests.helpers import (
     subset_func,
 )
 from anndata.utils import asarray
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Literal
 
 subset_func2 = subset_func
 
@@ -72,12 +76,12 @@ def sparse_format(request):
 
 
 @pytest.fixture(params=["r+", "r", False])
-def backed_mode(request):
+def backed_mode(request) -> Literal["r+", "r", False]:
     return request.param
 
 
 @pytest.fixture(params=(("X",), ()))
-def as_dense(request):
+def as_dense(request) -> tuple[str] | tuple:
     return request.param
 
 
@@ -90,10 +94,15 @@ def as_dense(request):
 @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
 # TODO: Check to make sure obs, obsm, layers, ... are written and read correctly as well
 @pytest.mark.filterwarnings("error")
-def test_read_write_X(tmp_path, mtx_format, backed_mode, as_dense):
-    base_pth = Path(tmp_path)
-    orig_pth = base_pth / "orig.h5ad"
-    backed_pth = base_pth / "backed.h5ad"
+def test_read_write_X(
+    tmp_path: Path,
+    mtx_format,
+    backed_mode: Literal["r+", "r", False],
+    *,
+    as_dense: tuple[str] | tuple,
+):
+    orig_pth = tmp_path / "orig.h5ad"
+    backed_pth = tmp_path / "backed.h5ad"
 
     orig = ad.AnnData(mtx_format(asarray(sparse.random(10, 10, format="csr"))))
     orig.write(orig_pth)
@@ -106,9 +115,8 @@ def test_read_write_X(tmp_path, mtx_format, backed_mode, as_dense):
     assert np.all(asarray(orig.X) == asarray(from_backed.X))
 
 
-def test_backed_view(tmp_path, backed_mode):
-    base_pth = Path(tmp_path)
-    orig_pth = base_pth / "orig.h5ad"
+def test_backed_view(tmp_path: Path, backed_mode: Literal["r+", "r", False]):
+    orig_pth = tmp_path / "orig.h5ad"
 
     orig = ad.AnnData(sparse.random(100, 10, format="csr"))
     orig.write(orig_pth)
@@ -173,7 +181,7 @@ def test_backing(adata: ad.AnnData, tmp_path: Path, backing_h5ad: Path) -> None:
     adata_subset.write()
 
 
-def test_backing_copy(adata, tmp_path, backing_h5ad):
+def test_backing_copy(adata, tmp_path: Path, backing_h5ad):
     adata.filename = backing_h5ad
     adata.write()
 
@@ -187,7 +195,7 @@ def test_backing_copy(adata, tmp_path, backing_h5ad):
 
 
 # TODO: Also test updating the backing file inplace
-def test_backed_raw(tmp_path):
+def test_backed_raw(tmp_path: Path):
     backed_pth = tmp_path / "backed.h5ad"
     final_pth = tmp_path / "final.h5ad"
     mem_adata = gen_adata((10, 10), **GEN_ADATA_DASK_ARGS)
@@ -210,7 +218,7 @@ def test_backed_raw(tmp_path):
         pytest.param(sparse.csr_array, id="csr_array"),
     ],
 )
-def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
+def test_backed_raw_subset(tmp_path: Path, array_type, subset_func, subset_func2):
     backed_pth = tmp_path / "backed.h5ad"
     final_pth = tmp_path / "final.h5ad"
     mem_adata = gen_adata((10, 10), X_type=array_type, **GEN_ADATA_NO_XARRAY_ARGS)
@@ -256,7 +264,7 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
         pytest.param(as_dense_dask_array, id="dask_array"),
     ],
 )
-def test_to_memory_full(tmp_path, array_type):
+def test_to_memory_full(tmp_path: Path, array_type):
     backed_pth = tmp_path / "backed.h5ad"
     mem_adata = gen_adata((15, 10), X_type=array_type, **GEN_ADATA_DASK_ARGS)
     mem_adata.raw = gen_adata((15, 12), X_type=array_type, **GEN_ADATA_DASK_ARGS)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

I'm kind of punting on knowing that the intention of changing the backing file is after writing. I'm genuinely not sure what this feature would be for other than what I am testing i.e., why would you rewrite a non-view of a backed file in its entirety? 

- [x] Closes #2077
- [x] Tests added
- [x] Release note added (or unnecessary)
