### PR TITLE
Add missing keys methods

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -704,7 +704,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
 
     Return layers’ names::
 
-        adata.layers.keys()
+        adata.layers_keys()
     """
 
     @property

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -140,7 +140,7 @@ def test_assert_equal():
     #     exact=False,
     # )
     adata2 = adata.copy()
-    to_modify = next(iter(adata2.layers.keys()))
+    to_modify = next(iter(adata2.layers_keys()))
     del adata2.layers[to_modify]
     with pytest.raises(AssertionError) as missing_layer_error:
         assert_equal(adata, adata2)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -24,7 +24,7 @@ def X(request):
 def test_creation(X: np.ndarray | None):
     adata = AnnData(X=X, layers=dict(L=L.copy()))
 
-    assert list(adata.layers.keys()) == ["L"]
+    assert adata.layers_keys() == ["L"]
     assert "L" in adata.layers
     assert "X" not in adata.layers
     assert "some_other_thing" not in adata.layers
@@ -39,12 +39,12 @@ def test_views():
     assert adata_view.layers.is_view
     assert adata_view.layers.parent_mapping == adata.layers
 
-    assert adata_view.layers.keys() == adata.layers.keys()
+    assert adata_view.layers_keys() == adata.layers_keys()
     assert (adata_view.layers["L"] == adata.layers["L"][1:, 1:]).all()
 
     adata.layers["S"] = X_
 
-    assert adata_view.layers.keys() == adata.layers.keys()
+    assert adata_view.layers_keys() == adata.layers_keys()
     assert (adata_view.layers["S"] == adata.layers["S"][1:, 1:]).all()
 
     with pytest.warns(ImplicitModificationWarning):
@@ -79,7 +79,7 @@ def test_readwrite(X: np.ndarray | None, backing_h5ad):
     adata.write(backing_h5ad)
     adata_read = read_h5ad(backing_h5ad)
 
-    assert adata.layers.keys() == adata_read.layers.keys()
+    assert adata.layers_keys() == adata_read.layers_keys()
     assert (adata.layers["L"] == adata_read.layers["L"]).all()
 
 
@@ -100,7 +100,7 @@ def test_readwrite_loom(tmp_path):
         adata.write_loom(loom_path)
     adata_read = read_loom(loom_path, X_name="")
 
-    assert adata.layers.keys() == adata_read.layers.keys()
+    assert adata.layers_keys() == adata_read.layers_keys()
     assert (adata.layers["L"] == adata_read.layers["L"]).all()
 
 

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -19,7 +19,7 @@ def test_transpose_orig():
     adata1.uns["test123"] = 1
     assert "test123" in adata.uns
     assert_equal(adata1.X.shape, (3, 5))
-    assert_equal(adata1.obsp.keys(), adata.varp.keys())
+    assert_equal(adata1.obsp_keys(), adata.varp_keys())
 
 
 def _add_raw(adata, *, var_subset=slice(None)):

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -123,7 +123,7 @@ def test_transpose_with_X_as_none(shape):
     adata = gen_adata(shape, X_type=lambda x: None)
     adataT = adata.transpose()
     assert_equal(adataT.shape, shape[::-1])
-    assert_equal(adataT.obsp.keys(), adata.varp.keys())
+    assert_equal(adataT.obsp_keys(), adata.varp_keys())
     assert_equal(adataT.T, adata)
 
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Add `layers_keys()`, `obsp_keys()` and `varp_keys()` as they were missing for these slots and it's more convenient than `list(adata.layers.keys())`

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
