### PR TITLE
ci: clean up coverage reporting

### DIFF
--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -65,7 +65,10 @@ jobs:
         run: uvx hatch -v env create ${{ matrix.env.name }}
 
       - name: Run tests
-        run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto --cov --cov-report=xml --junitxml=test-data/test-results.xml -m "${{ matrix.io_mark }}" ${{ matrix.env.args }}
+        run: |
+          uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto --junitxml=test-data/test-results.xml -m "${{ matrix.io_mark }}" ${{ matrix.env.args }}
+          uvx hatch run ${{ matrix.env.name }}:coverage combine
+          uvx hatch run ${{ matrix.env.name }}:coverage xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -77,7 +77,10 @@ jobs:
         run: uv pip list
 
       - name: Run test
-        run: uv run coverage run -m pytest -m gpu -n auto --cov --cov-report=xml
+        run: |
+          uv run coverage run -m pytest -m gpu -n auto
+          uv run coverage combine
+          uv run coverage xml
 
       - uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev-doc = [ "towncrier>=24.8.0" ] # release notes tool
 test-min = [
     "loompy>=3.0.5",
     "pytest>=8.2,<8.3.4",
-    "pytest-cov",
+    "pytest-cov",           # only for VS Code
     "pytest-randomly",
     "pytest-memray",
     "pytest-mock",


### PR DESCRIPTION
this way we don’t have the duplicate `coverage run -m pytest --cov` which I’m sure only works incidentally