### PR TITLE
fix: write iospec directly with sparse dataset

### DIFF
--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -780,10 +780,10 @@ for store_type, (cls, spec, func) in product(
     _REGISTRY.register_write(store_type, cls, spec)(func)
 
 
-@_REGISTRY.register_write(H5Group, _CSRDataset, IOSpec("", "0.1.0"))
-@_REGISTRY.register_write(H5Group, _CSCDataset, IOSpec("", "0.1.0"))
-@_REGISTRY.register_write(ZarrGroup, _CSRDataset, IOSpec("", "0.1.0"))
-@_REGISTRY.register_write(ZarrGroup, _CSCDataset, IOSpec("", "0.1.0"))
+@_REGISTRY.register_write(H5Group, _CSRDataset, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(H5Group, _CSCDataset, IOSpec("csc_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, _CSRDataset, IOSpec("csr_matrix", "0.1.0"))
+@_REGISTRY.register_write(ZarrGroup, _CSCDataset, IOSpec("csc_matrix", "0.1.0"))
 def write_sparse_dataset(
     f: GroupStorageType,
     k: str,
@@ -800,9 +800,6 @@ def write_sparse_dataset(
         fmt=elem.format,
         dataset_kwargs=dataset_kwargs,
     )
-    # TODO: Cleaner way to do this
-    f[k].attrs["encoding-type"] = f"{elem.format}_matrix"
-    f[k].attrs["encoding-version"] = "0.1.0"
 
 
 def write_cupy_dask(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -623,6 +623,22 @@ def test_anndata_sparse_compat(tmp_path: Path, diskfmt: Literal["h5ad", "zarr"])
     assert_equal(adata.X, base)
 
 
+def test_write(tmp_path: Path, diskfmt: Literal["h5ad", "zarr"]):
+    base = sparse.random(10, 10, format="csr")
+
+    f = (
+        open_write_group(tmp_path / f"parent_store.{diskfmt}", mode="a")
+        if diskfmt == "zarr"
+        else h5py.File(tmp_path / f"parent_store.{diskfmt}", "a")
+    )
+
+    ad.io.write_elem(f, "a_sparse_matrix", base)
+    adata = ad.AnnData(sparse_dataset(f["a_sparse_matrix"]))
+    ad.io.write_elem(f, "adata", adata)
+    adata_roundtripped = ad.io.read_elem(f["adata"])
+    assert_equal(adata_roundtripped.X, base)
+
+
 def test_backed_sizeof(
     ondisk_equivalent_adata: tuple[AnnData, AnnData, AnnData, AnnData],
 ):


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] See added `test_write_dispatched_csr_dataset` for what would have failed - there was no io-spec in the `CS{R,C}Dataset` writer, and was instead appended at the end.  I am not sure why this was done but it prevents creating dispatched write functions properly on sparse datasets unless you check the type of the `elem` @ivirshup any history to this? It's been in since #554
- [x] Tests added
- [ ] Release note added (or unnecessary)
