### PR TITLE
fix: suppress `matplotlib` warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ filterwarnings = [
     "ignore:.*first_column_names:FutureWarning:scanpy",                           # scanpy 1.10.x
     "ignore:Importing read_.* from `anndata` is deprecated:FutureWarning:scanpy",
     "ignore:`__version__` is deprecated:FutureWarning:scanpy",
+    # https://github.com/matplotlib/matplotlib/pull/30589
+    "ignore:.*'(oneOf|parseString|resetCache|enablePackrat)'.*'(one_of|parse_string|reset_cache|enable_packrat)':DeprecationWarning:matplotlib",
+
 ]
 # When `--strict-warnings` is used, all warnings are treated as errors, except those:
 filterwarnings_when_strict = [


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [x] Release note added (or unnecessary)
