### PR TITLE
Backport PR #2122 (fix: merge strategies for `concat_on_disk`)

### DIFF
--- a/docs/release-notes/2122.fix.md
+++ b/docs/release-notes/2122.fix.md
@@ -1,0 +1,1 @@
+Respect off-axis merge options in {func}`anndata.experimental.concat_on_disk` {user}`ilan-gold`

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -143,11 +143,16 @@ def equal_dask_array(a, b) -> bool:
         return False
     if isinstance(b, DaskArray) and tokenize(a) == tokenize(b):
         return True
-    if isinstance(a._meta, CSMatrix):
+    if isinstance(a._meta, np.ndarray):
+        return da.equal(a, b, where=~(da.isnan(a) & da.isnan(b))).all().compute()
+    if a.chunksize == b.chunksize and isinstance(
+        a._meta, CupySparseMatrix | CSMatrix | CSArray
+    ):
         # TODO: Maybe also do this in the other case?
         return da.map_blocks(equal, a, b, drop_axis=(0, 1)).all()
-    else:
-        return da.equal(a, b, where=~(da.isnan(a) == da.isnan(b))).all()
+    msg = "Misaligned chunks detected when checking for merge equality of dask arrays.  Reading full arrays into memory."
+    warn(msg, UserWarning, stacklevel=3)
+    return equal(a.compute(), b.compute())
 
 
 @equal.register(np.ndarray)

--- a/tests/test_concatenate_disk.py
+++ b/tests/test_concatenate_disk.py
@@ -9,6 +9,7 @@ import pytest
 from scipy import sparse
 
 from anndata import AnnData, concat
+from anndata._core import merge
 from anndata._core.merge import _resolve_axis
 from anndata.experimental.merge import as_group, concat_on_disk
 from anndata.io import read_elem, write_elem
@@ -29,6 +30,11 @@ GEN_ADATA_OOC_CONCAT_ARGS = dict(
     varm_types=(sparse.csr_matrix, np.ndarray, pd.DataFrame),
     layers_types=(sparse.csr_matrix, np.ndarray, pd.DataFrame),
 )
+
+
+@pytest.fixture(params=list(merge.MERGE_STRATEGIES.keys()))
+def merge_strategy(request):
+    return request.param
 
 
 @pytest.fixture(params=[0, 1])
@@ -86,16 +92,17 @@ def assert_eq_concat_on_disk(
     file_format: Literal["zarr", "h5ad"],
     max_loaded_elems: int | None = None,
     *args,
+    merge_strategy: merge.StrategiesLiteral | None = None,
     **kwargs,
 ):
     # create one from the concat function
-    res1 = concat(adatas, *args, **kwargs)
+    res1 = concat(adatas, *args, merge=merge_strategy, **kwargs)
     # create one from the on disk concat function
     paths = _adatas_to_paths(adatas, tmp_path, file_format)
     out_name = tmp_path / f"out.{file_format}"
     if max_loaded_elems is not None:
         kwargs["max_loaded_elems"] = max_loaded_elems
-    concat_on_disk(paths, out_name, *args, **kwargs)
+    concat_on_disk(paths, out_name, *args, merge=merge_strategy, **kwargs)
     res2 = read_elem(as_group(out_name, mode="r"))
     assert_equal(res1, res2, exact=False)
 
@@ -112,6 +119,7 @@ def get_array_type(array_type, axis):
 
 
 @pytest.mark.parametrize("reindex", [True, False], ids=["reindex", "no_reindex"])
+@pytest.mark.filterwarnings("ignore:Misaligned chunks detected")
 def test_anndatas(
     *,
     axis: Literal[0, 1],
@@ -121,6 +129,7 @@ def test_anndatas(
     max_loaded_elems: int,
     file_format: Literal["zarr", "h5ad"],
     reindex: bool,
+    merge_strategy: merge.StrategiesLiteral,
 ):
     _, off_axis_name = _resolve_axis(1 - axis)
     random_axes = {0, 1} if reindex else {axis}
@@ -159,6 +168,7 @@ def test_anndatas(
         max_loaded_elems,
         axis=axis,
         join=join_type,
+        merge_strategy=merge_strategy,
     )
 
 


### PR DESCRIPTION
(cherry picked from commit e88a6c2397ccc199eb8265e075e914fc53e8abb1)

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
