### PR TITLE
fix: remove `remove-label` action to handle node 24 migration

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -91,8 +91,13 @@ jobs:
           files: test-data/coverage.xml
 
       - name: Remove 'run-gpu-ci' Label
+        uses: "actions/github-script@v8"
         if: always()
-        uses: actions-ecosystem/action-remove-labels@v1
         with:
-          labels: "run-gpu-ci"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'run-gpu-ci'
+            });


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.  

https://github.com/actions-ecosystem/action-remove-labels hasn't been updated in years, so probably better to just remove it.

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
