### PR TITLE
chore: Add explicit return

### DIFF
--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -335,6 +335,8 @@ def try_unifying_dtype(  # noqa PLR0911, PLR0912
                     if same_orders:
                         return next(iter(dtypes))
                     return object
+        else:
+            return None
     # Boolean
     elif all(pd.api.types.is_bool_dtype(dtype) or dtype is None for dtype in col):
         if any(dtype is None for dtype in col):


### PR DESCRIPTION
Instead of relying the implicit return of None it is better to explicitly deal with the else case.

Caught by mypy

- [X] Related to #2173
- [X] Tests added - irrelevant
- [X] Release note added (or unnecessary)
