### PR TITLE
feat: create parent dirs when writing into h5ad

### DIFF
--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -72,7 +72,7 @@ def write_h5ad(
             adata.strings_to_categoricals(adata.raw.var)
     dataset_kwargs = {**dataset_kwargs, **kwargs}
     filepath = Path(filepath)
-    filepath.mkdir(parents=True, exist_ok=True)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if adata.isbacked else "w"
     if adata.isbacked:  # close so that we can reopen below
         adata.file.close()

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -72,6 +72,7 @@ def write_h5ad(
             adata.strings_to_categoricals(adata.raw.var)
     dataset_kwargs = {**dataset_kwargs, **kwargs}
     filepath = Path(filepath)
+    filepath.mkdir(parents=True, exist_ok=True)
     mode = "a" if adata.isbacked else "w"
     if adata.isbacked:  # close so that we can reopen below
         adata.file.close()


### PR DESCRIPTION
Solves the following error raised when writing an h5ad file if a parent directory does not exist:

```
FileNotFoundError: [Errno 2] Unable to synchronously create file (unable to open file: name = 'dir1/dir2/adata.h5ad', errno = 2, error message = 'No such file or directory', flags = 13, o_flags = 242)
```

It is specifically raised by the following line https://github.com/scverse/anndata/blob/920f8a91d63213264e24d73cbb621e2414351377/src/anndata/_io/h5ad.py#L79

I am not sure if this is the general desired behavior, if not, I would happily modify the implementation (e.g. adding a new function argument to `write_h5ad`).

I believe it makes more sense to create the directories by default. Let me know otherwise. I will happily add a test if this behavior is desired.