### PR TITLE
fix: also skip legacy-api-wrap in warning traceback

### DIFF
--- a/src/anndata/_warnings.py
+++ b/src/anndata/_warnings.py
@@ -4,11 +4,16 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import legacy_api_wrap
+
 if TYPE_CHECKING:
     from typing import Any
 
 
-_FILE_PREFIXES: tuple[str, ...] = (str(Path(__file__).parent),)
+_FILE_PREFIXES: tuple[str, ...] = (
+    str(Path(__file__).parent),
+    str(Path(legacy_api_wrap.__file__).parent),
+)
 
 __all__ = [
     "ExperimentalFeatureWarning",

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -12,6 +12,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import scipy.sparse
+from legacy_api_wrap import legacy_api  # noqa: TID251
 from numpy.typing import NDArray
 from packaging.version import Version
 from zarr import Array as ZarrArray  # noqa: F401
@@ -197,14 +198,7 @@ else:
             return "mock cupy.ndarray"
 
 
-if find_spec("legacy_api_wrap") or TYPE_CHECKING:
-    from legacy_api_wrap import legacy_api  # noqa: TID251
-
-    old_positionals = partial(legacy_api, category=FutureWarning)
-else:
-
-    def old_positionals(*old_positionals):
-        return lambda func: func
+old_positionals = partial(legacy_api, category=FutureWarning)
 
 
 #############################


### PR DESCRIPTION
I forgot in #2202 that we use legacy-api-wrap here too!

Before #2202:

```console
❯ python -c 'import scanpy as sc; sc.datasets.krumsiek11()'
/…/anndata/_core/anndata.py:1796: UserWarning: Observation names are not unique. To make them unique, call `.obs_names_make_unique`.
  utils.warn_names_duplicates("obs")
```

After #2202 but before this:

```console
❯ python -c 'import scanpy as sc; sc.datasets.krumsiek11()'
/…/legacy_api_wrap/__init__.py:82: UserWarning: Observation names are not unique. To make them unique, call `.obs_names_make_unique`.
  return fn(*args_all, **kw)
```

After this:

```console
❯ python -c 'import scanpy as sc; sc.datasets.krumsiek11()'
/…/scanpy/readwrite.py:815: UserWarning: Observation names are not unique. To make them unique, call `.obs_names_make_unique`.
  adata = read_text(filename, delimiter, first_column_names=first_column_names)
```