### PR TITLE
docs: fix rendering of `anndata.typing.*` types

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,10 +92,6 @@ nitpick_ignore = [  # APIs without an intersphinx entry
     ("py:class", "anndata._core.raw.Raw"),
     # TODO: remove zappy support; the zappy repo is archived
     ("py:class", "anndata.compat.ZappyArray"),
-    # TODO: remove once https://github.com/sphinx-doc/sphinx/pull/13508 is released
-    ("py:class", "anndata.typing.TypeAliasType"),
-    ("py:class", "anndata._types.TypeAliasType"),
-    ("py:class", "anndata._io.specs.registry.TypeAliasType"),
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,9 @@ doc = [
     "sphinx-toolbox>=3.8.0",
     "sphinxext.opengraph",
     "myst-nb",
-    "scanpydoc[theme,typehints] >=0.15.3",
+    "scanpydoc[theme,typehints] >=0.16",
     "awkward>=2.6.3",
-    "IPython",                             # For syntax highlighting in notebooks
+    "IPython",                           # For syntax highlighting in notebooks
     "myst_parser",
     "sphinx_design>=0.5.0",
     # for unreleased changes

--- a/src/anndata/typing.py
+++ b/src/anndata/typing.py
@@ -50,15 +50,17 @@ XDataType: TypeAlias = (  # noqa: UP040
 ArrayDataStructureTypes: TypeAlias = XDataType | AwkArray | XDataArray  # noqa: UP040
 
 
-type InMemoryArrayOrScalarType = (
+# TODO: use `type` syntax for all the below once https://github.com/sphinx-doc/sphinx/pull/13508 is released
+InMemoryArrayOrScalarType: TypeAlias = (  # noqa: UP040
     pd.DataFrame | np.number | str | ArrayDataStructureTypes
 )
 
-
-type AxisStorable = (
+AxisStorable: TypeAlias = (  # noqa: UP040
     InMemoryArrayOrScalarType | dict[str, "AxisStorable"] | list["AxisStorable"]
 )
 """A serializable object, excluding :class:`anndata.AnnData` objects i.e., something that can be stored in `uns` or `obsm`."""
 
-type RWAble = AxisStorable | AnnData | pd.Categorical | pd.api.extensions.ExtensionArray
+RWAble: TypeAlias = (  # noqa: UP040
+    AxisStorable | AnnData | pd.Categorical | pd.api.extensions.ExtensionArray
+)
 """A superset of :type:`anndata.typing.AxisStorable` (i.e., including :class:`anndata.AnnData`) which is everything can be read/written by :func:`anndata.io.read_elem` and :func:`anndata.io.write_elem`."""


### PR DESCRIPTION
Also make sure we use the patched scanpydoc versions so parameter types are also fixed.

<table>
<thead>
<tr>
 <td>
 <td>`anndata.AxisStorable`
 <td>`anndata.concat` param
<tbody>
<tr>
 <td>before
 <td><img width="813" height="149" alt="grafik" src="https://github.com/user-attachments/assets/f35439cc-bf74-4f50-80f9-98dc49c3ffde" />
 <td><img width="304" height="41" alt="grafik" src="https://github.com/user-attachments/assets/9830baad-0312-40b9-8998-435163bf4601" />
<tr>
 <td>after
 <td><img width="813" height="231" alt="grafik" src="https://github.com/user-attachments/assets/addcbc8e-2c29-4961-b2d2-864399629141" />
 <td><img width="401" height="41" alt="grafik" src="https://github.com/user-attachments/assets/7ec3b4c5-8653-4206-94b6-127c47e38fc9" />
</table>


