### PR TITLE
ci: allow skipping h5diff test when running locally

### DIFF
--- a/tests/test_io_backwards_compat.py
+++ b/tests/test_io_backwards_compat.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 from subprocess import run
 from typing import TYPE_CHECKING
@@ -49,6 +51,10 @@ def test_backwards_compat_files(archive_dir: Path) -> None:
     assert_equal(from_h5ad, from_zarr, exact=True)
 
 
+@pytest.mark.skipif(
+    not os.environ.get("CI") and shutil.which("h5diff") is None,
+    reason="not in CI and h5diff not installed",
+)
 def test_no_diff(tmp_path: Path, archive_dir: Path) -> None:
     if archive_dir.name in {"v0.7.8", "v0.7.0"}:
         pytest.skip("DataFrame encoding changed between 0.7 and now")


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #2230
- [x] Tests added
- [x] Release note added (or unnecessary)
