### PR TITLE
fix: add len check for categories comparison in `unify_dtypes`

### DIFF
--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -311,7 +311,9 @@ def try_unifying_dtype(
             dtype for dtype in dtypes if len(dtype.categories) > 0
         ]
         if dtypes_with_categories and all(
-            dtype.ordered and np.all(all_categories == dtype.categories)
+            len(dtype.categories) == len(all_categories)
+            and dtype.ordered
+            and np.all(all_categories == dtype.categories)
             for dtype in dtypes_with_categories
         ):
             return dtypes_with_categories[0]


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Fixes small bug in #2228
- [ ] Tests added
- [x] Release note added (or unnecessary)
