### PR TITLE
fix: gpu ci

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Nvidia SMI sanity check
         run: nvidia-smi
 
-      - name: Install yq
+      - name: Install yq # https://cirun.slack.com/archives/C09SNDRB3A8/p1766512487317849?thread_ts=1766512112.938459&cid=C09SNDRB3A8
         run: |
-          sudo snap install yq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
 
       - name: Extract max Python version from classifiers
         run: |


### PR DESCRIPTION
/edit by @flying-sheep since Slack links aren’t reliable:

> Snap has been problematic in CI environments because it requires specific cgroup configurations that many ephemeral runners don't provide.
>
> The fix could be just not using snap to install yq. Instead, download the binary directly.
>
> – @aktech 