### PR TITLE
ci: switch to dependency groups

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
       ASV_DIR: "./benchmarks"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # no blob filter so asv can checkout other commits

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       id-token: write # to authenticate as Trusted Publisher to pypi.org
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: blob:none

--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           filter: blob:none
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
       ENV_NAME: ${{ matrix.env.name }}
       IO_MARK: ${{ matrix.io_mark }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: blob:none
@@ -93,7 +93,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: blob:none

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -73,14 +73,12 @@ jobs:
       - name: Install AnnData
         run: |
           uv venv
-          uv pip install -e ".[dev,test,cu12]" -c ci/constraints.txt
+          uv pip install -e ".[cu12]" --group=test -c ci/constraints.txt
 
       - name: Env list
         run: uv pip list
 
-      - name: Run test
-        env:
-          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
+      - name: Run tests
         run: |
           uv run coverage run -m pytest -m gpu -n auto
           uv run coverage combine

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
   os: ubuntu-24.04
@@ -7,18 +8,17 @@ build:
     post_checkout:
       # unshallow so version can be derived from tag
       - git fetch --unshallow || true
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
     pre_build:
       # run towncrier to preview the next version’s release notes
       - ( find docs/release-notes -regex '[^.]+[.][^.]+.md' | grep -q . ) && towncrier build --keep || true
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: true # do not change or you will be fired
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - doc
+    build:
+      html:
+        - uvx hatch run docs:build
+        - mv docs/_build $READTHEDOCS_OUTPUT
 submodules:
   include:
     - "docs/tutorials/notebooks"

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,10 +1,10 @@
 [envs.default]
 installer = "uv"
-features = [ "dev" ]
+dependency-groups = [ "dev" ]
 
 [envs.docs]
-features = [ "doc" ]
-scripts.build = "sphinx-build -M html docs docs/_build -W --keep-going {args}"
+dependency-groups = [ "doc" ]
+scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
 scripts.open = "python3 -m webbrowser -t docs/_build/html/index.html"
 scripts.clean = "git clean -fdX -- {args:docs}"
 
@@ -15,7 +15,7 @@ scripts.clean = "git restore --source=HEAD --staged --worktree -- docs/release-n
 
 [envs.hatch-test]
 default-args = [  ]
-features = [ "dev", "test-min" ]
+dependency-groups = [ "dev", "test-min" ]
 extra-dependencies = [ "ipykernel" ]
 env-vars.UV_CONSTRAINT = "ci/constraints.txt"
 overrides.matrix.deps.env-vars = [
@@ -41,7 +41,7 @@ overrides.matrix.deps.python = [
     { if = [ "stable" ], value = "3.13" },
     { if = [ "pre" ], value = "3.14" },
 ]
-overrides.matrix.deps.features = [
+overrides.matrix.deps.dependency-groups = [
     { if = [ "stable", "pre" ], value = "test" },
 ]
 overrides.matrix.deps.extra-args = { if = [ "stable", "pre" ], value = [ "--strict-warnings" ] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,9 @@ Documentation = "https://anndata.readthedocs.io/"
 Source = "https://github.com/scverse/anndata"
 Home-page = "https://github.com/scverse/anndata"
 
-
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
-    "anndata[dev-doc]",
+    { include-group = "dev-doc" },
 ]
 doc = [
     "sphinx>=8.2.1,<9",                  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/586
@@ -73,10 +72,16 @@ doc = [
     "IPython",                           # For syntax highlighting in notebooks
     "myst_parser",
     "sphinx_design>=0.5.0",
+    "anndata[dask]",
     # for unreleased changes
-    "anndata[dev-doc,dask]",
+    { include-group = "dev-doc" },
 ]
 dev-doc = [ "towncrier>=24.8.0" ] # release notes tool
+test = [
+    "fast-array-utils>=1.2.3",
+    "anndata[lazy]",
+    { include-group = "test-min" },
+]
 test-min = [
     "pytest",
     "pytest-cov",           # only for VS Code
@@ -98,7 +103,8 @@ test-min = [
     "pyarrow",
     "anndata[dask]",
 ]
-test = [ "anndata[test-min,lazy]", "fast-array-utils>=1.2.3" ]
+
+[project.optional-dependencies]
 gpu = [ "cupy" ]
 cu12 = [ "cupy-cuda12x" ]
 cu11 = [ "cupy-cuda11x" ]


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [x] Tests added
- [x] Release note added (or unnecessary)

Considerations: scanpy and/or integration testing and/or other packages might try installing `anndata[test]` since they depend on anndata’s unofficial test utils.

Which isn’t a good idea, that extra is for `anndata`’s own test (and therefore being migrated to a dependency group)

So *if* the anndata test utils need anything the dependent packages’s tests don’t already depend on anyway, we have two routes:
1. merge this, fix other packages’ CI by adding the necessary deps for the unofficial test utils themselves, then implement #1699, and finally switch the other packages to the official test utils
2. Implement #1699, switch dependent packages over to the official test utils, merge this.

the second one might me one step less, but I don’t think it’s going to be any easier or harder.