### PR TITLE
feat: allow reading nullable arrays without mask on disk

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,6 +174,7 @@ qualname_overrides = {
     "numpy.dtypes.StringDType": ("py:attr", "numpy.dtypes.StringDType"),
     "pandas.DataFrame.iloc": ("py:attr", "pandas.DataFrame.iloc"),
     "pandas.DataFrame.loc": ("py:attr", "pandas.DataFrame.loc"),
+    "pandas.core.dtypes.dtypes.BaseMaskedDtype": "pandas.api.extensions.ExtensionDtype",
     # should be fixed soon: https://github.com/tox-dev/sphinx-autodoc-typehints/pull/516
     "types.EllipsisType": ("py:data", "types.EllipsisType"),
     "pathlib._local.Path": "pathlib.Path",

--- a/docs/fileformat-prose.md
+++ b/docs/fileformat-prose.md
@@ -543,31 +543,32 @@ nullable_integer/values <zarr.core.Array '/nullable_integer/values' (4,) int64>
 ```
 
 (nullable-integer)=
-### Nullable integer specifications (v0.1.0)
+### Nullable integer specifications (v0.1.1)
 
 * Nullable integers MUST be stored as a group
-* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-integer"`, `"encoding-version": "0.1.0"`
+* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-integer"`, `"encoding-version": "0.1.0" | "0.1.1"`
 * The group MUST contain an integer valued array under the key `"values"`
-* The group MUST contain an boolean valued array under the key `"mask"`
+* The group MAY contain a boolean valued array under the key `"mask"` (it MUST contain `"mask"` for `"encoding-version": "0.1.0"`)
+* The `"values"` and `"mask"` arrays MUST be the same shape if both exist
 
 (nullable-boolean)=
-### Nullable boolean specifications (v0.1.0)
+### Nullable boolean specifications (v0.1.1)
 
 * Nullable booleans MUST be stored as a group
-* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-boolean"`, `"encoding-version": "0.1.0"`
+* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-boolean"`, `"encoding-version": "0.1.0" | "0.1.1"`
 * The group MUST contain an boolean valued array under the key `"values"`
-* The group MUST contain an boolean valued array under the key `"mask"`
-* The `"values"` and `"mask"` arrays MUST be the same shape
+* The group MAY contain a boolean valued array under the key `"mask"` (it MUST contain `"mask"` for `"encoding-version": "0.1.0"`)
+* The `"values"` and `"mask"` arrays MUST be the same shape if both exist
 
 (nullable-string-array)=
-### Nullable string specifications (v0.1.0)
+### Nullable string specifications (v0.1.1)
 
 * Nullable strings MUST be stored as a group
-* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-string-array"`, `"encoding-version": "0.1.0"`
+* The group’s attributes MUST contain the encoding metadata `"encoding-type": "nullable-string-array"`, `"encoding-version": "0.1.0" | "0.1.1"`
 * The group’s attributes MAY contain `"na-value"` as an indicator for missing value semantics with the possible value `"NA"` or `"NaN"` described in [](#missing-value-semantics), and the default being `"NA"`
 * The group MUST contain a string valued array under the key `"values"`
-* The group MUST contain a boolean valued array under the key `"mask"`
-* The `"values"` and `"mask"` arrays MUST be the same shape
+* The group MAY contain a boolean valued array under the key `"mask"` (it MUST contain `"mask"` for `"encoding-version": "0.1.0"`)
+* The `"values"` and `"mask"` arrays MUST be the same shape if both exist
 
 (missing-value-semantics)=
 ### Missing value semantics

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -5,12 +5,17 @@ from functools import WRAPPER_ASSIGNMENTS, wraps
 from itertools import pairwise
 from typing import TYPE_CHECKING, Literal, cast
 
+import numpy as np
+
 from .._core.sparse_dataset import BaseCompressedSparseDataset
 from ..utils import warn
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from typing import Any, Literal
+
+    from pandas.core.arrays.masked import BaseMaskedArray
+    from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
     from .._types import StorageType, _WriteInternal
     from ..compat import H5Group, ZarrGroup
@@ -117,6 +122,16 @@ def check_key(key):
     else:
         msg = f"{key} of type {typ} is an invalid key. Should be str."
         raise TypeError(msg)
+
+
+def pandas_nullable_dtype(
+    array_type: type[BaseMaskedArray], dtype: np.dtype
+) -> BaseMaskedDtype:
+    """Infer nullable dtype from numpy dtype.
+
+    There is no public pandas API for this, so this is the cleanest way.
+    """
+    return array_type(np.ones(1, dtype), np.ones(1, bool)).dtype
 
 
 # -------------------------------------------------------------------------------

--- a/src/anndata/experimental/backed/_lazy_arrays.py
+++ b/src/anndata/experimental/backed/_lazy_arrays.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -23,8 +23,9 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Literal
 
+    from numpy.typing import NDArray
     from pandas._libs.missing import NAType
-    from pandas.core.dtypes.base import ExtensionDtype
+    from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
     from anndata.compat import ZarrGroup
 
@@ -143,7 +144,7 @@ class MaskedArray[K: (H5Array, ZarrArray)](XBackendArray):
     by :class:`xarray.backends.BackendArray`.
     """
 
-    _mask: ZarrOrHDF5Wrapper[K]
+    _mask: ZarrOrHDF5Wrapper[K] | None
     _values: ZarrOrHDF5Wrapper[K]
     _dtype_str: Literal["nullable-integer", "nullable-boolean", "nullable-string-array"]
     shape: tuple[int, ...]
@@ -152,15 +153,15 @@ class MaskedArray[K: (H5Array, ZarrArray)](XBackendArray):
 
     def __init__(
         self,
-        values: ZarrArray | H5Array,
+        values: K,
         dtype_str: Literal[
             "nullable-integer", "nullable-boolean", "nullable-string-array"
         ],
-        mask: ZarrArray | H5Array,
+        mask: K | None,
         base_path_or_zarr_group: Path | ZarrGroup,
         elem_name: str,
     ):
-        self._mask = ZarrOrHDF5Wrapper(mask)
+        self._mask = None if mask is None else ZarrOrHDF5Wrapper(mask)
         self._values = ZarrOrHDF5Wrapper(values)
         self._dtype_str = dtype_str
         self.shape = self._values.shape
@@ -168,28 +169,33 @@ class MaskedArray[K: (H5Array, ZarrArray)](XBackendArray):
         self.file_format = "zarr" if isinstance(mask, ZarrArray) else "h5"
         self.elem_name = elem_name
 
-    def __getitem__(self, key: ExplicitIndexer) -> PandasExtensionArray | np.ndarray:
-        from xarray.core.extension_array import PandasExtensionArray
-
+    def __getitem__(
+        self, key: ExplicitIndexer
+    ) -> PandasExtensionArray | NDArray[np.str_]:
         values = self._values[key]
-        mask = self._mask[key]
-        if self._dtype_str == "nullable-integer":
-            # numpy does not support nan ints
-            extension_array = pd.arrays.IntegerArray(values, mask=mask)
-        elif self._dtype_str == "nullable-boolean":
-            extension_array = pd.arrays.BooleanArray(values, mask=mask)
-        elif self._dtype_str == "nullable-string-array":
+        mask = None if self._mask is None else self._mask[key]
+
+        # numpy does not support nan ints
+        if self._dtype_str in {"nullable-integer", "nullable-boolean"}:
+            from xarray.core.extension_array import PandasExtensionArray
+
+            if mask is None:
+                mask = np.ones(len(values), dtype=bool)
+            cls = cast("BaseMaskedDtype", self.dtype).construct_array_type()
+            return PandasExtensionArray(cls(values, mask=mask))
+
+        if self._dtype_str == "nullable-string-array":
             # https://github.com/pydata/xarray/issues/10419
             values = values.astype(self.dtype)
-            values[mask] = pd.NA
+            if mask is not None:
+                values[mask] = pd.NA
             return values
-        else:
-            msg = f"Invalid dtype_str {self._dtype_str}"
-            raise RuntimeError(msg)
-        return PandasExtensionArray(extension_array)
+
+        msg = f"Invalid dtype_str {self._dtype_str}"
+        raise RuntimeError(msg)
 
     @cached_property
-    def dtype(self) -> np.dtypes.StringDType[NAType] | ExtensionDtype:
+    def dtype(self) -> np.dtypes.StringDType[NAType] | BaseMaskedDtype:
         if self._dtype_str == "nullable-integer":
             return pd.array(
                 [],

--- a/src/anndata/experimental/backed/_lazy_arrays.py
+++ b/src/anndata/experimental/backed/_lazy_arrays.py
@@ -10,6 +10,7 @@ from anndata._core.index import _subset
 from anndata._core.views import as_view
 from anndata._io.specs.lazy_methods import get_chunksize
 
+from ..._io.utils import pandas_nullable_dtype
 from ..._settings import settings
 from ...compat import (
     H5Array,
@@ -160,7 +161,7 @@ class MaskedArray[K: (H5Array, ZarrArray)](XBackendArray):
         mask: K | None,
         base_path_or_zarr_group: Path | ZarrGroup,
         elem_name: str,
-    ):
+    ) -> None:
         self._mask = None if mask is None else ZarrOrHDF5Wrapper(mask)
         self._values = ZarrOrHDF5Wrapper(values)
         self._dtype_str = dtype_str
@@ -197,10 +198,7 @@ class MaskedArray[K: (H5Array, ZarrArray)](XBackendArray):
     @cached_property
     def dtype(self) -> np.dtypes.StringDType[NAType] | BaseMaskedDtype:
         if self._dtype_str == "nullable-integer":
-            return pd.array(
-                [],
-                dtype=str(pd.api.types.pandas_dtype(self._values.dtype)).capitalize(),
-            ).dtype
+            return pandas_nullable_dtype(pd.arrays.IntegerArray, self._values.dtype)
         elif self._dtype_str == "nullable-boolean":
             return pd.BooleanDtype()
         elif self._dtype_str == "nullable-string-array":


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)

Discovered by @katosh in https://github.com/scverse/anndata/pull/2272#discussion_r2662018903

If the `mask` array is missing, we try to create a MaskedArray without mask. This draft shows how actually supporting that might look like.