### PR TITLE
ci: use Python 3.14 in more spots

### DIFF
--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -44,6 +44,8 @@ jobs:
       matrix:
         env: ${{ fromJSON(needs.get-environments.outputs.envs) }}
         io_mark: ["zarr_io", "not zarr_io", "dask_distributed"] # dask_distributed should not be run with -n auto as it uses a client with processes
+    permissions:
+      id-token: write  # for codecov OIDC
     env:  # environment variables for use in codecov’s env_vars tagging
       ENV_NAME: ${{ matrix.env.name }}
       IO_MARK: ${{ matrix.io_mark }}
@@ -72,23 +74,25 @@ jobs:
           hatch run ${{ matrix.env.name }}:run-cov -v --color=yes ${{ matrix.io_mark != 'dask_distributed' && '-n auto' || '' }} --junitxml=test-data/test-results.xml -m "${{ matrix.io_mark }}" ${{ matrix.env.args }}
           hatch run ${{ matrix.env.name }}:cov-combine
           hatch run ${{ matrix.env.name }}:coverage xml
+          hatch run ${{ matrix.env.name }}:cov-report
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           env_vars: ENV_NAME,IO_MARK
+          files: test-data/test-results.xml
+          use_oidc: true
           fail_ci_if_error: true
-          file: test-data/test-results.xml
 
       - name: Upload coverage data
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: ENV_NAME,IO_MARK
-          fail_ci_if_error: true
           files: test-data/coverage.xml
+          use_oidc: true
+          fail_ci_if_error: true
 
   build:
     runs-on: ubuntu-24.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     post_checkout:
       # unshallow so version can be derived from tag

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ napoleon_use_rtype = True  # having a separate entry generally helps readability
 napoleon_use_param = True
 napoleon_custom_sections = [("Params", "Parameters")]
 typehints_defaults = "braces"
+always_use_bars_union = True  # use `|`, not `Union` in types even when on Python ≤3.14
 todo_include_todos = False
 nitpicky = True  # Report broken links
 nitpick_ignore = [  # APIs without an intersphinx entry
@@ -134,9 +135,7 @@ intersphinx_mapping = dict(
     numpy=("https://numpy.org/doc/stable", None),
     obstore=("https://developmentseed.org/obstore/latest/", None),
     pandas=("https://pandas.pydata.org/pandas-docs/stable", None),
-    # TODO: switch to `/3` once docs are built with Python 3.14
-    # https://github.com/readthedocs/readthedocs.org/issues/12523
-    python=("https://docs.python.org/3.13", None),
+    python=("https://docs.python.org/3", None),
     scipy=("https://docs.scipy.org/doc/scipy", None),
     sklearn=("https://scikit-learn.org/stable", None),
     xarray=("https://docs.xarray.dev/en/stable", None),

--- a/hatch.toml
+++ b/hatch.toml
@@ -14,6 +14,7 @@ scripts.build = "python3 ci/scripts/towncrier_automation.py {args}"
 scripts.clean = "git restore --source=HEAD --staged --worktree -- docs/release-notes"
 
 [envs.hatch-test]
+python = "3.14"
 default-args = [  ]
 dependency-groups = [ "dev", "test-min" ]
 extra-dependencies = [ "ipykernel" ]
@@ -36,10 +37,6 @@ overrides.matrix.deps.pre-install-commands = [
 ]
 overrides.matrix.deps.python = [
     { if = [ "min" ], value = "3.12" },
-    # transitive test dep numba doesn’t support 3.14 in a stable release yet:
-    # https://github.com/numba/numba/issues/9957
-    { if = [ "stable" ], value = "3.13" },
-    { if = [ "pre" ], value = "3.14" },
 ]
 overrides.matrix.deps.dependency-groups = [
     { if = [ "stable", "pre" ], value = "test" },


### PR DESCRIPTION
See https://github.com/scverse/cookiecutter-scverse/pull/462

Also numba’s stable release now supports Python 3.14