### PR TITLE
docs: Sphinx 9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,6 @@ extensions = [
     "scanpydoc",  # needs to be before linkcode
     "sphinx.ext.linkcode",
     "IPython.sphinxext.ipython_console_highlighting",
-    "sphinx_toolbox.more_autodoc.autoprotocol",
     *(p.stem for p in _extension_dir.glob("*.py")),
 ]
 myst_enable_extensions = [
@@ -174,11 +173,9 @@ qualname_overrides = {
     "pandas.DataFrame.iloc": ("py:attr", "pandas.DataFrame.iloc"),
     "pandas.DataFrame.loc": ("py:attr", "pandas.DataFrame.loc"),
     "pandas.core.dtypes.dtypes.BaseMaskedDtype": "pandas.api.extensions.ExtensionDtype",
-    # should be fixed soon: https://github.com/tox-dev/sphinx-autodoc-typehints/pull/516
-    "types.EllipsisType": ("py:data", "types.EllipsisType"),
-    "pathlib._local.Path": "pathlib.Path",
 }
 autodoc_type_aliases = dict(
+    K="",  # https://github.com/python/cpython/issues/124089
     NDArray=":data:`~numpy.typing.NDArray`",
     AxisStorable=":data:`~anndata.typing.AxisStorable`",
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,10 +177,11 @@ qualname_overrides = {
 autodoc_type_aliases = dict(
     NDArray=":data:`~numpy.typing.NDArray`",
     AxisStorable=":data:`~anndata.typing.AxisStorable`",
+    # https://github.com/python/cpython/issues/124089
+    # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/580
+    K=":class:`zarr.Array` | :class:`h5py.Dataset`",
     S=":class:`anndata.experimental.StorageType`",
     RWAble=":class:`anndata.typing.RWAble`",
-    # https://github.com/python/cpython/issues/124089
-    K="",
 )
 
 # -- Social cards ---------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,9 +175,12 @@ qualname_overrides = {
     "pandas.core.dtypes.dtypes.BaseMaskedDtype": "pandas.api.extensions.ExtensionDtype",
 }
 autodoc_type_aliases = dict(
-    K="",  # https://github.com/python/cpython/issues/124089
     NDArray=":data:`~numpy.typing.NDArray`",
     AxisStorable=":data:`~anndata.typing.AxisStorable`",
+    S=":class:`anndata.experimental.StorageType`",
+    RWAble=":class:`anndata.typing.RWAble`",
+    # https://github.com/python/cpython/issues/124089
+    K="",
 )
 
 # -- Social cards ---------------------------------------------------------

--- a/docs/extensions/patch_autosummary.py
+++ b/docs/extensions/patch_autosummary.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import sys
 from traceback import walk_stack
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,11 @@ if TYPE_CHECKING:
 
     from sphinx.application import Sphinx
     from sphinx.ext.autodoc import Options
+
+if sys.version_info >= (3, 13):
+    from typing import get_protocol_members, is_protocol
+else:
+    from typing_extensions import get_protocol_members, is_protocol
 
 
 def skip_member(  # noqa: PLR0917
@@ -43,7 +49,7 @@ def skip_member(  # noqa: PLR0917
         return None
 
     # If we’re documenting a protocol attribute, include it
-    if name in getattr(parent, "__protocol_attrs__", ()):
+    if is_protocol(parent) and name in get_protocol_members(parent):
         return False
 
     # Skip if it’s not a member of the parent class

--- a/docs/extensions/patch_autosummary.py
+++ b/docs/extensions/patch_autosummary.py
@@ -9,16 +9,17 @@ import sys
 from traceback import walk_stack
 from typing import TYPE_CHECKING
 
+if sys.version_info >= (3, 13):
+    from typing import get_protocol_members, is_protocol
+else:
+    from typing_extensions import get_protocol_members, is_protocol
+
+
 if TYPE_CHECKING:
     from typing import Literal
 
     from sphinx.application import Sphinx
     from sphinx.ext.autodoc import Options
-
-if sys.version_info >= (3, 13):
-    from typing import get_protocol_members, is_protocol
-else:
-    from typing_extensions import get_protocol_members, is_protocol
 
 
 def skip_member(  # noqa: PLR0917

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,11 @@ dev = [
     { include-group = "dev-doc" },
 ]
 doc = [
-    "sphinx>=8.2.1,<9",                  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/586
+    "sphinx>=9.1.0",
     "sphinx-book-theme>=1.1.0",
-    "sphinx-autodoc-typehints>=2.2.0",
+    "sphinx-autodoc-typehints>=3.6.2",
     "sphinx-issues>=5.0.1",
     "sphinx-copybutton",
-    "sphinx-toolbox>=3.8.0",
     "sphinxext.opengraph",
     "myst-nb",
     "scanpydoc[theme,typehints] >=0.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ markers = [
 ]
 
 [tool.uv]
+# https://github.com/executablebooks/sphinx-design/issues/248
 override-dependencies = [ "sphinx>=9.0.1" ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
     "awkward>=2.6.3",
     "IPython",                           # For syntax highlighting in notebooks
     "myst-parser",
-    "sphinx-design>=0.5.0",
+    "sphinx-design",
     "anndata[dask]",
     # for unreleased changes
     { include-group = "dev-doc" },
@@ -180,10 +180,6 @@ markers = [
     "zarr_io: mark tests that involve zarr io",
     "dask_distributed: tests that need a distributed client with multiple processes",
 ]
-
-[tool.uv]
-# https://github.com/executablebooks/sphinx-design/issues/248
-override-dependencies = [ "sphinx>=9.0.1" ]
 
 [tool.ruff]
 src = [ "src" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ doc = [
     "scanpydoc[theme,typehints] >=0.16",
     "awkward>=2.6.3",
     "IPython",                           # For syntax highlighting in notebooks
-    "myst_parser",
-    "sphinx_design>=0.5.0",
+    "myst-parser",
+    "sphinx-design>=0.5.0",
     "anndata[dask]",
     # for unreleased changes
     { include-group = "dev-doc" },
@@ -180,6 +180,9 @@ markers = [
     "zarr_io: mark tests that involve zarr io",
     "dask_distributed: tests that need a distributed client with multiple processes",
 ]
+
+[tool.uv]
+override-dependencies = [ "sphinx>=9.0.1" ]
 
 [tool.ruff]
 src = [ "src" ]

--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -11,7 +11,7 @@ from .compat import H5Array, H5Group, ZarrArray, ZarrGroup
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from typing import Any
+    from typing import Any, TypeAlias
 
     from anndata._core.xarray import Dataset2D
 
@@ -33,13 +33,11 @@ __all__ = [
     "_WriteInternal",
 ]
 
-type ArrayStorageType = ZarrArray | H5Array
-type GroupStorageType = ZarrGroup | H5Group
-type StorageType = ArrayStorageType | GroupStorageType
+# These two are not exported, so we don’t make them `type`s
+ArrayStorageType: TypeAlias = ZarrArray | H5Array  # noqa: UP040
+GroupStorageType: TypeAlias = ZarrGroup | H5Group  # noqa: UP040
 
-# circumvent https://github.com/tox-dev/sphinx-autodoc-typehints/issues/580
-type S = StorageType
-type RWAble = typing.RWAble
+type StorageType = ArrayStorageType | GroupStorageType
 
 
 class Dataset2DIlocIndexer(Protocol):

--- a/src/anndata/experimental/backed/_lazy_arrays.py
+++ b/src/anndata/experimental/backed/_lazy_arrays.py
@@ -136,10 +136,6 @@ class CategoricalArray[K: (H5Array, ZarrArray)](XBackendArray):
         return pd.CategoricalDtype(categories=self.categories, ordered=self._ordered)
 
 
-# circumvent https://github.com/tox-dev/sphinx-autodoc-typehints/issues/580
-type K = H5Array | H5AsTypeView | ZarrArray
-
-
 class MaskedArray[K: (H5Array | H5AsTypeView, ZarrArray)](XBackendArray):
     """
     A wrapper class meant to enable working with lazy masked data.

--- a/src/anndata/typing.py
+++ b/src/anndata/typing.py
@@ -49,18 +49,15 @@ XDataType: TypeAlias = (  # noqa: UP040
 )
 ArrayDataStructureTypes: TypeAlias = XDataType | AwkArray | XDataArray  # noqa: UP040
 
-
-# TODO: use `type` syntax for all the below once https://github.com/sphinx-doc/sphinx/pull/13508 is released
+# this type is not exported, so we don’t make it a `type`
 InMemoryArrayOrScalarType: TypeAlias = (  # noqa: UP040
     pd.DataFrame | np.number | str | ArrayDataStructureTypes
 )
 
-AxisStorable: TypeAlias = (  # noqa: UP040
+type AxisStorable = (
     InMemoryArrayOrScalarType | dict[str, "AxisStorable"] | list["AxisStorable"]
 )
 """A serializable object, excluding :class:`anndata.AnnData` objects i.e., something that can be stored in `uns` or `obsm`."""
 
-RWAble: TypeAlias = (  # noqa: UP040
-    AxisStorable | AnnData | pd.Categorical | pd.api.extensions.ExtensionArray
-)
+type RWAble = AxisStorable | AnnData | pd.Categorical | pd.api.extensions.ExtensionArray
 """A superset of :type:`anndata.typing.AxisStorable` (i.e., including :class:`anndata.AnnData`) which is everything can be read/written by :func:`anndata.io.read_elem` and :func:`anndata.io.write_elem`."""


### PR DESCRIPTION
This makes use of the `type` support in Sphinx 9.

Merging it as-is would lose us support for the `protocol` document type though, so protocols are `class`es in our intersphinx inventory and it says **class** in front of their names:

- https://anndata.readthedocs.io/en/latest/generated/anndata.experimental.Read.html
- https://icb-anndata--2297.com.readthedocs.build/en/2297/generated/anndata.experimental.Read.html

Hmm, I like the way `autoprotocol` inlines things (which we don’t do because of our autosummary template). Maybe we can figure out how to use a template that adds methods inline for small classes (and protocols)?

Otherwise I think everything works!

https://github.com/sphinx-doc/sphinx/issues/14262