### PR TITLE
test: increase memory limit for flaky test_size_of_view

### DIFF
--- a/tests/test_dask_view_mem.py
+++ b/tests/test_dask_view_mem.py
@@ -74,10 +74,7 @@ def _alloc_cache():
 # if we put a 2 factor on 2**19
 # the results seems more accurate with the experimental results
 # For example from dask.random we allocate 1mb
-# Memory usage varies ~14% between runs due to allocator fragmentation,
-# lazy allocation, and Python/dask internal caching. This is expected
-# behavior per pytest-memray docs. Use 3.0 MB to accommodate variance
-# while still catching catastrophic regressions (e.g., loading full arrays).
+# See https://github.com/scverse/anndata/issues/2301 for why this limit is 3.0 MB
 @pytest.mark.usefixtures("_alloc_cache")
 @pytest.mark.limit_memory("3.0 MB")
 def test_size_of_view(mapping_name, give_chunks):

--- a/tests/test_dask_view_mem.py
+++ b/tests/test_dask_view_mem.py
@@ -74,10 +74,12 @@ def _alloc_cache():
 # if we put a 2 factor on 2**19
 # the results seems more accurate with the experimental results
 # For example from dask.random we allocate 1mb
-# As of 2025.09.* dask, this needs a bit more than the previous 1.5mb.
-# TODO: Why?
+# Memory usage varies ~14% between runs due to allocator fragmentation,
+# lazy allocation, and Python/dask internal caching. This is expected
+# behavior per pytest-memray docs. Use 3.0 MB to accommodate variance
+# while still catching catastrophic regressions (e.g., loading full arrays).
 @pytest.mark.usefixtures("_alloc_cache")
-@pytest.mark.limit_memory("2.2 MB")
+@pytest.mark.limit_memory("3.0 MB")
 def test_size_of_view(mapping_name, give_chunks):
     import dask.array as da
 


### PR DESCRIPTION
# test: increase memory limit for flaky test_size_of_view

- [x] Closes #2301
- [ ] Tests added (N/A - this fixes an existing test)
- [ ] Release note added (unnecessary - test-only change)

## Summary

Bump `test_size_of_view` memory limit from 2.2 MB to 3.0 MB to fix intermittent CI failures on Python 3.14.

## Root Cause

Two separate issues cause this flakiness:

### 1. Run-to-run variance (~14%)

This is **expected behavior** for memory profiling:

- **Allocator fragmentation**: Identical code requests different memory depending on fragmentation state
- **Lazy alloc/deferred dealloc**: Physical pages assigned on write, freed at allocator's discretion
- **Python 3.14 + mimalloc**: Free-threaded build uses mimalloc with different allocation strategies
- **pytest-xdist**: Parallel workers have different memory states

The [pytest-memray docs](https://pytest-memray.readthedocs.io/en/latest/usage.html) explicitly warn: *"tests using this marker may need to give some room to account for this."*

### 2. Baseline drift (67% over 8 months)

| Date | PR | Limit |
|------|-----|-------|
| May 2024 | #1459 | 1.5 MB |
| Sep 2025 | #2053 | 1.7 MB |
| Oct 2025 | #2158 | 2.2 MB |
| Jan 2026 | — | 2.5 MB (failing) |

This drift is caused by evolving dask/Python internals and won't stop for fixed limits.

## Solution

Increase limit to 3.0 MB. The test still catches catastrophic regressions (e.g., accidentally loading 100 MB arrays into memory) while accommodating expected variance.

## References

- [memray: Memory overview](https://bloomberg.github.io/memray/memory.html) — "two identical runs can have very different resident memory measurements"
- [pytest-memray: Usage](https://pytest-memray.readthedocs.io/en/latest/usage.html) — warns about allocator variance
- [Dask Worker Memory Management](https://distributed.dask.org/en/latest/worker-memory.html) — "memory is not immediately released to the system"
