### PR TITLE
chore: add warning for `zarr` format v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,12 +161,11 @@ filterwarnings_when_strict = [
     "default::scipy.sparse.SparseEfficiencyWarning",
     "default::dask.array.core.PerformanceWarning",
     "default:anndata will no longer support zarr v2:DeprecationWarning",
-    "default:The codec `vlen-utf8:UserWarning",
-    "default:The dtype `StringDType():UserWarning",
     "default:Consolidated metadata is:UserWarning",
     "default:.*Structured:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:Automatic shard shape inference is experimental",
+    "default:Writing zarr v2:UserWarning",
 ]
 python_files = [ "test_*.py" ]
 testpaths = [

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -148,8 +148,12 @@ def read_dataframe(group: zarr.Group | zarr.Array) -> pd.DataFrame:
 def open_write_group(
     store: StoreLike, *, mode: AccessModeLiteral = "w", **kwargs
 ) -> zarr.Group:
-    if not is_zarr_v2() and "zarr_format" not in kwargs:
-        kwargs["zarr_format"] = settings.zarr_write_format
+    if "zarr_format" not in kwargs:
+        if settings.zarr_write_format == 2 or is_zarr_v2():
+            msg = "Writing zarr v2 data will no longer be the default in the next minor release. v3 data will be written by default. If you are explicitly setting this configuration, consider migrating to zarr v3."
+            warn(msg, UserWarning)
+        if not is_zarr_v2():
+            kwargs["zarr_format"] = settings.zarr_write_format
     return zarr.open_group(store, mode=mode, **kwargs)
 
 

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -150,7 +150,7 @@ def open_write_group(
 ) -> zarr.Group:
     if "zarr_format" not in kwargs:
         if settings.zarr_write_format == 2 or is_zarr_v2():
-            msg = "Writing zarr v2 data will no longer be the default in the next minor release. v3 data will be written by default. If you are explicitly setting this configuration, consider migrating to zarr v3."
+            msg = "Writing zarr v2 data will no longer be the default in the next minor release. v3 data will be written by default. If you are explicitly setting this configuration, consider migrating to the zarr v3 file format."
             warn(msg, UserWarning)
         if not is_zarr_v2():
             kwargs["zarr_format"] = settings.zarr_write_format

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -376,6 +376,16 @@ def test_hdf5_compression_opts(tmp_path, compression, compression_opts):
     assert_equal(adata, expected)
 
 
+def test_write_zarr_v2_warns(tmp_path: Path):
+    with (
+        ad.settings.override(zarr_write_format=2),
+        pytest.warns(
+            UserWarning, match=r"Writing zarr v2 data will no longer be the default"
+        ),
+    ):
+        ad.AnnData(X=np.ones((5, 10))).write_zarr(tmp_path / "foo.zarr")
+
+
 @pytest.mark.parametrize("zarr_write_format", [2, 3])
 @pytest.mark.parametrize(
     "use_compression", [True, False], ids=["compressed", "uncompressed"]


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Begins migration to zarr v3 writing by default (will follow this up with a PR to remove zarr v2 the package as well)
- [x] Tests added
- [ ] Release note added (or unnecessary)
