### PR TITLE
fix: exclude `scipy==1.17.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "pandas >=2.2.2",
     "numpy>=2",
-    "scipy >=1.13",
+    "scipy >=1.13,!=1.17.0",
     "h5py>=3.11",
     "natsort",
     "packaging>=24.2",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] See #339
- [ ] Tests added
- [ ] Release note added (or unnecessary)
