### PR TITLE
Backport PR #2319 on branch 0.12.x (fix: exclude `scipy==1.17.0`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "pandas >=2.1.0, !=2.1.2, <3",
     "numpy>=1.26",
     # https://github.com/scverse/anndata/issues/1434
-    "scipy >=1.12",
+    "scipy >=1.12,!=1.17.0",
     "h5py>=3.8",
     "natsort",
     "packaging>=24.2",


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
