### PR TITLE
docs: clean up typing module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ __pycache__/
 .ipynb_checkpoints
 
 # docs
-/docs/generated/
+/docs/generated/*
+!/docs/generated/anndata.typing.Index.rst
 /docs/_build/
 
 # IDEs

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,7 @@ __pycache__/
 .ipynb_checkpoints
 
 # docs
-/docs/generated/*
-!/docs/generated/anndata.typing.Index.rst
+/docs/generated/
 /docs/_build/
 
 # IDEs

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,12 +253,17 @@ Types used by the former:
    abc.CSCDataset
 ```
 
-.. these are types, not classes
+<!-- these are types, not classes, so don’t use the above template -->
 
 ```{eval-rst}
-.. autosummary::
-   :toctree: generated/
+.. toctree::
+   :hidden:
 
+   typing
+
+.. autosummary::
+
+   typing.Index1D
    typing.Index
    typing.AxisStorable
    typing.RWAble

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,9 +145,10 @@ qualname_overrides = {
         for kind in ["", "View"]
     },
     # Can’t use `set_module` for `type`s. When moving out of .experimental, define in actual location.
-    "anndata.compat.Index": "anndata.typing.Index",
     "anndata._types.StorageType": "anndata.experimental.StorageType",
     # https://github.com/theislab/scanpydoc/issues/254
+    "anndata.typing.Index1D": "anndata.typing.Index1D",
+    "anndata.typing.Index": "anndata.typing.Index",
     "anndata.typing.RWAble": "anndata.typing.RWAble",
     "anndata.typing.AxisStorable": "anndata.typing.AxisStorable",
     #### h5py

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,0 +1,10 @@
+# anndata.typing
+
+```{eval-rst}
+.. currentmodule:: anndata.typing
+
+.. autotype:: Index1D
+.. autotype:: Index
+.. autotype:: AxisStorable
+.. autotype:: RWAble
+```

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,7 +1,7 @@
 # anndata.typing
 
 ```{eval-rst}
-.. currentmodule:: anndata.typing
+.. module:: anndata.typing
 
 .. autotype:: Index1D
 .. autotype:: Index

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -61,8 +61,8 @@ if TYPE_CHECKING:
 
     from zarr.storage import StoreLike
 
-    from ..compat import Index1D, Index1DNorm, XDataset
-    from ..typing import XDataType
+    from ..compat import XDataset
+    from ..typing import Index1D, _Index1DNorm, _XDataType
     from .aligned_mapping import AxisArraysView, LayersView, PairwiseArraysView
     from .index import Index
 
@@ -206,8 +206,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
 
     # view attributes
     _adata_ref: AnnData | None
-    _oidx: Index1DNorm | None
-    _vidx: Index1DNorm | None
+    _oidx: _Index1DNorm | None
+    _vidx: _Index1DNorm | None
 
     @old_positionals(
         "obsm",
@@ -222,14 +222,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
     )
     def __init__(  # noqa: PLR0913
         self,
-        X: XDataType | pd.DataFrame | None = None,
+        X: _XDataType | pd.DataFrame | None = None,
         obs: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         var: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         uns: Mapping[str, Any] | None = None,
         *,
         obsm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
-        layers: Mapping[str, XDataType] | None = None,
+        layers: Mapping[str, _XDataType] | None = None,
         raw: Mapping[str, Any] | None = None,
         dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
@@ -238,8 +238,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         asview: bool = False,
         obsp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
-        oidx: Index1DNorm | int | np.integer | None = None,
-        vidx: Index1DNorm | int | np.integer | None = None,
+        oidx: _Index1DNorm | int | np.integer | None = None,
+        vidx: _Index1DNorm | int | np.integer | None = None,
     ):
         # check for any multi-indices that aren’t later checked in coerce_array
         for attr, key in [(obs, "obs"), (var, "var"), (X, "X")]:
@@ -273,8 +273,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
     def _init_as_view(
         self,
         adata_ref: AnnData,
-        oidx: Index1DNorm | int | np.integer,
-        vidx: Index1DNorm | int | np.integer,
+        oidx: _Index1DNorm | int | np.integer,
+        vidx: _Index1DNorm | int | np.integer,
     ):
         if adata_ref.isbacked and adata_ref.is_view:
             msg = (
@@ -571,7 +571,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         return self.n_obs, self.n_vars
 
     @property
-    def X(self) -> XDataType | None:
+    def X(self) -> _XDataType | None:
         """Data matrix of shape :attr:`n_obs` × :attr:`n_vars`."""
         if self.isbacked:
             if not self.file.is_open:
@@ -602,7 +602,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         #     return X
 
     @X.setter
-    def X(self, value: XDataType | None):  # noqa: PLR0912
+    def X(self, value: _XDataType | None):  # noqa: PLR0912
         if value is None:
             if self.isbacked:
                 msg = "Cannot currently remove data matrix from backed object."
@@ -1066,7 +1066,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
 
     def _normalize_indices(
         self, index: Index | None
-    ) -> tuple[Index1DNorm | int | np.integer, Index1DNorm | int | np.integer]:
+    ) -> tuple[_Index1DNorm | int | np.integer, _Index1DNorm | int | np.integer]:
         return _normalize_indices(index, self.obs_names, self.var_names)
 
     # TODO: this is not quite complete...
@@ -1244,7 +1244,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         self._init_as_actual(adata_subset)
 
     # TODO: Update, possibly remove
-    def __setitem__(self, index: Index, val: float | XDataType):
+    def __setitem__(self, index: Index, val: float | _XDataType):
         if self.is_view:
             msg = "Object is view and cannot be accessed with `[]`."
             raise ValueError(msg)

--- a/src/anndata/_core/file_backing.py
+++ b/src/anndata/_core/file_backing.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from os import PathLike
     from typing import Literal
 
-    from .._types import ArrayStorageType
+    from .._types import _ArrayStorageType
     from . import anndata
 
 
@@ -143,7 +143,7 @@ def to_memory(x, *, copy: bool = False):
 
 @to_memory.register(ZarrArray)
 @to_memory.register(h5py.Dataset)
-def _(x: ArrayStorageType, *, copy: bool = False):
+def _(x: _ArrayStorageType, *, copy: bool = False):
     return x[...]
 
 

--- a/src/anndata/_core/raw.py
+++ b/src/anndata/_core/raw.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from typing import ClassVar
 
-    from ..compat import CSMatrix, Index, Index1DNorm
+    from ..compat import CSMatrix
+    from ..typing import Index, _Index1DNorm
     from .aligned_mapping import AxisArraysView
     from .anndata import AnnData
     from .sparse_dataset import BaseCompressedSparseDataset
@@ -171,7 +172,7 @@ class Raw:
 
     def _normalize_indices(
         self, packed_index: Index
-    ) -> tuple[Index1DNorm | int | np.integer, Index1DNorm | int | np.integer]:
+    ) -> tuple[_Index1DNorm | int | np.integer, _Index1DNorm | int | np.integer]:
         # deal with slicing with pd.Series
         if isinstance(packed_index, pd.Series):
             packed_index = packed_index.values

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -49,8 +49,7 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from .._types import ArrayStorageType, GroupStorageType
-    from ..compat import Index1DNorm
-    from .index import Index, Index1D
+    from ..typing import Index, Index1D, _Index1DNorm
 
 
 type DenseType = np.ndarray | CupyArray
@@ -668,6 +667,6 @@ def sparse_dataset(
 
 @_subset.register(BaseCompressedSparseDataset)
 def subset_sparsedataset(
-    d, subset_idx: tuple[Index1DNorm] | tuple[Index1DNorm, Index1DNorm]
+    d, subset_idx: tuple[_Index1DNorm] | tuple[_Index1DNorm, _Index1DNorm]
 ):
     return d[subset_idx]

--- a/src/anndata/_core/sparse_dataset.py
+++ b/src/anndata/_core/sparse_dataset.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Any, Literal
 
-    from .._types import ArrayStorageType, GroupStorageType
+    from .._types import _ArrayStorageType, _GroupStorageType
     from ..typing import Index, Index1D, _Index1DNorm
 
 
@@ -96,7 +96,7 @@ def slice_as_int(s: slice, l: int) -> int:
 
 
 @dataclass
-class BackedSparseMatrix[ArrayT: ArrayStorageType]:
+class BackedSparseMatrix[ArrayT: _ArrayStorageType]:
     """\
     Mixin class for backed sparse matrices.
 
@@ -309,7 +309,7 @@ class BackedSparseMatrix[ArrayT: ArrayStorageType]:
         )
 
 
-def _get_group_format(group: GroupStorageType) -> str:
+def _get_group_format(group: _GroupStorageType) -> str:
     if "h5sparse_format" in group.attrs:
         # TODO: Warn about an old format
         # If this is only just going to be public, I could insist it's not like this
@@ -330,7 +330,7 @@ def is_sparse_indexing_overridden(
     )
 
 
-class BaseCompressedSparseDataset[GroupT: GroupStorageType, ArrayT: ArrayStorageType](
+class BaseCompressedSparseDataset[GroupT: _GroupStorageType, ArrayT: _ArrayStorageType](
     abc._AbstractCSDataset, ABC
 ):
     _group: GroupT
@@ -596,7 +596,7 @@ class _CSCDataset(BaseCompressedSparseDataset, abc.CSCDataset):
 
 @doctest_filterwarnings("ignore", r"Moving element.*uns.*to.*obsp", FutureWarning)
 def sparse_dataset(
-    group: GroupStorageType,
+    group: _GroupStorageType,
     *,
     should_cache_indptr: bool = True,
 ) -> abc.CSRDataset | abc.CSCDataset:

--- a/src/anndata/_core/storage.py
+++ b/src/anndata/_core/storage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, get_args
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -12,6 +12,7 @@ from .._warnings import ImplicitModificationWarning
 from ..compat import XDataset
 from ..utils import (
     ensure_df_homogeneous,
+    get_union_members,
     join_english,
     raise_value_error_if_multiindex_columns,
     warn,
@@ -30,13 +31,13 @@ def coerce_array(
     allow_array_like: bool = False,
 ):
     """Coerce arrays stored in layers/X, and aligned arrays ({obs,var}{m,p})."""
-    from ..typing import ArrayDataStructureTypes
+    from ..typing import _ArrayDataStructureTypes
 
     # If value is a scalar and we allow that, return it
     if allow_array_like and np.isscalar(value):
         return value
     # If value is one of the allowed types, return it
-    array_data_structure_types = get_args(ArrayDataStructureTypes)
+    array_data_structure_types = get_union_members(_ArrayDataStructureTypes)
     if isinstance(value, XDataset):
         value = Dataset2D(value)
     if isinstance(value, (*array_data_structure_types, Dataset2D)):

--- a/src/anndata/_core/views.py
+++ b/src/anndata/_core/views.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
 
-    from ..compat import Index1DNorm
+    from ..typing import _Index1DNorm
 
 
 @contextmanager
@@ -437,22 +437,24 @@ except ImportError:
 
 
 def _resolve_idxs(
-    old: tuple[Index1DNorm, Index1DNorm],
-    new: tuple[Index1DNorm, Index1DNorm],
+    old: tuple[_Index1DNorm, _Index1DNorm],
+    new: tuple[_Index1DNorm, _Index1DNorm],
     adata: AnnData,
-) -> tuple[Index1DNorm, Index1DNorm]:
+) -> tuple[_Index1DNorm, _Index1DNorm]:
     o, v = (_resolve_idx(old[i], new[i], adata.shape[i]) for i in (0, 1))
     return o, v
 
 
 @singledispatch
-def _resolve_idx(old: Index1DNorm, new: Index1DNorm, l: Literal[0, 1]) -> Index1DNorm:
+def _resolve_idx(
+    old: _Index1DNorm, new: _Index1DNorm, l: Literal[0, 1]
+) -> _Index1DNorm:
     raise NotImplementedError
 
 
 @_resolve_idx.register(np.ndarray)
 def _resolve_idx_ndarray(
-    old: NDArray[np.bool_] | NDArray[np.integer], new: Index1DNorm, l: Literal[0, 1]
+    old: NDArray[np.bool_] | NDArray[np.integer], new: _Index1DNorm, l: Literal[0, 1]
 ) -> NDArray[np.bool_] | NDArray[np.integer]:
     if is_bool_dtype(old) and is_bool_dtype(new):
         mask_new = np.zeros_like(old)
@@ -465,7 +467,7 @@ def _resolve_idx_ndarray(
 
 @_resolve_idx.register(slice)
 def _resolve_idx_slice(
-    old: slice, new: Index1DNorm, l: Literal[0, 1]
+    old: slice, new: _Index1DNorm, l: Literal[0, 1]
 ) -> slice | NDArray[np.integer]:
     if isinstance(new, slice):
         return _resolve_idx_slice_slice(old, new, l)

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     from anndata._types import ArrayStorageType, GroupStorageType
     from anndata.compat import CSArray, CSMatrix
-    from anndata.typing import AxisStorable, InMemoryArrayOrScalarType
+    from anndata.typing import AxisStorable, _InMemoryArrayOrScalarType
 
     from .registry import Reader, Writer
 
@@ -152,7 +152,7 @@ def _to_cpu_mem_wrapper(write_func):
 @_REGISTRY.register_read(H5Array, IOSpec("", ""))
 def read_basic(
     elem: H5File | H5Group | H5Array, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
+) -> dict[str, _InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
     from anndata._io import h5ad
 
     msg = f"Element '{elem.name}' was written without encoding metadata."
@@ -171,7 +171,7 @@ def read_basic(
 @_REGISTRY.register_read(ZarrArray, IOSpec("", ""))
 def read_basic_zarr(
     elem: ZarrGroup | ZarrArray, *, _reader: Reader
-) -> dict[str, InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
+) -> dict[str, _InMemoryArrayOrScalarType] | npt.NDArray | CSMatrix | CSArray:
     from anndata._io import zarr
 
     msg = f"Element '{elem.name}' was written without encoding metadata."

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from numpy import typing as npt
     from numpy.typing import NDArray
 
-    from anndata._types import ArrayStorageType, GroupStorageType
+    from anndata._types import _ArrayStorageType, _GroupStorageType
     from anndata.compat import CSArray, CSMatrix
     from anndata.typing import AxisStorable, _InMemoryArrayOrScalarType
 
@@ -278,7 +278,7 @@ def _read_partial(group, *, items=None, indices=(slice(None), slice(None))):
 @_REGISTRY.register_write(ZarrGroup, AnnData, IOSpec("anndata", "0.1.0"))
 @_REGISTRY.register_write(H5Group, AnnData, IOSpec("anndata", "0.1.0"))
 def write_anndata(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     adata: AnnData,
     *,
@@ -305,7 +305,7 @@ def write_anndata(
 @_REGISTRY.register_read(H5File, IOSpec("raw", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("anndata", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("raw", "0.1.0"))
-def read_anndata(elem: GroupStorageType | H5File, *, _reader: Reader) -> AnnData:
+def read_anndata(elem: _GroupStorageType | H5File, *, _reader: Reader) -> AnnData:
     d = {}
     for k in [
         "X",
@@ -327,7 +327,7 @@ def read_anndata(elem: GroupStorageType | H5File, *, _reader: Reader) -> AnnData
 @_REGISTRY.register_write(H5Group, Raw, IOSpec("raw", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, Raw, IOSpec("raw", "0.1.0"))
 def write_raw(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     raw: Raw,
     *,
@@ -373,14 +373,16 @@ def write_null_zarr(f, k, _v, _writer, dataset_kwargs=MappingProxyType({})):
 
 @_REGISTRY.register_read(H5Group, IOSpec("dict", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("dict", "0.1.0"))
-def read_mapping(elem: GroupStorageType, *, _reader: Reader) -> dict[str, AxisStorable]:
+def read_mapping(
+    elem: _GroupStorageType, *, _reader: Reader
+) -> dict[str, AxisStorable]:
     return {k: _reader.read_elem(v) for k, v in dict(elem).items()}
 
 
 @_REGISTRY.register_write(H5Group, dict, IOSpec("dict", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, dict, IOSpec("dict", "0.1.0"))
 def write_mapping(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     v: dict[str, AxisStorable],
     *,
@@ -400,7 +402,7 @@ def write_mapping(
 @_REGISTRY.register_write(H5Group, list, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, list, IOSpec("array", "0.2.0"))
 def write_list(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     elem: list[AxisStorable],
     *,
@@ -422,7 +424,7 @@ def write_list(
 @_REGISTRY.register_write(ZarrGroup, H5Array, IOSpec("array", "0.2.0"))
 @zero_dim_array_as_scalar
 def write_basic(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     elem: views.ArrayView | np.ndarray | h5py.Dataset | np.ma.MaskedArray | ZarrArray,
     *,
@@ -446,7 +448,7 @@ def write_basic(
 
 
 def _iter_chunks_for_copy(
-    elem: ArrayStorageType, dest: ArrayStorageType
+    elem: _ArrayStorageType, dest: _ArrayStorageType
 ) -> Iterator[slice | tuple[list[slice]]]:
     """
     Returns an iterator of tuples of slices for copying chunks from `elem` to `dest`.
@@ -471,7 +473,7 @@ def _iter_chunks_for_copy(
 def write_chunked_dense_array_to_group(
     f: H5Group,
     k: str,
-    elem: ArrayStorageType,
+    elem: _ArrayStorageType,
     *,
     _writer: Writer,
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
@@ -527,7 +529,7 @@ def write_basic_dask_dask_dense(
 @_REGISTRY.register_read(H5Array, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_read(ZarrArray, IOSpec("array", "0.2.0"))
 @_REGISTRY.register_read(ZarrArray, IOSpec("string-array", "0.2.0"))
-def read_array(elem: ArrayStorageType, *, _reader: Reader) -> npt.NDArray:
+def read_array(elem: _ArrayStorageType, *, _reader: Reader) -> npt.NDArray:
     return elem[()]
 
 
@@ -630,7 +632,9 @@ def _to_hdf5_vlen_strings(value: np.ndarray) -> np.ndarray:
 
 @_REGISTRY.register_read(H5Array, IOSpec("rec-array", "0.2.0"))
 @_REGISTRY.register_read(ZarrArray, IOSpec("rec-array", "0.2.0"))
-def read_recarray(d: ArrayStorageType, *, _reader: Reader) -> np.recarray | npt.NDArray:
+def read_recarray(
+    d: _ArrayStorageType, *, _reader: Reader
+) -> np.recarray | npt.NDArray:
     value = d[()]
     value = _decode_structured_array(
         _from_fixed_length_strings(value), dtype=value.dtype
@@ -679,7 +683,7 @@ def write_recarray_zarr(
 
 
 def write_sparse_compressed(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     key: str,
     value: CSMatrix | CSArray,
     *,
@@ -770,7 +774,7 @@ for store_type, (cls, spec, func) in product(
 @_REGISTRY.register_write(ZarrGroup, _CSRDataset, IOSpec("csr_matrix", "0.1.0"))
 @_REGISTRY.register_write(ZarrGroup, _CSCDataset, IOSpec("csc_matrix", "0.1.0"))
 def write_sparse_dataset(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     elem: _CSCDataset | _CSRDataset,
     *,
@@ -797,7 +801,7 @@ def write_cupy_dask(f, k, elem, _writer, dataset_kwargs=MappingProxyType({})):
 
 
 def write_dask_sparse(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     elem: DaskArray,
     *,
@@ -870,7 +874,7 @@ for array_type, group_type in product(
 @_REGISTRY.register_read(H5Group, IOSpec("csr_matrix", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csc_matrix", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("csr_matrix", "0.1.0"))
-def read_sparse(elem: GroupStorageType, *, _reader: Reader) -> CSMatrix | CSArray:
+def read_sparse(elem: _GroupStorageType, *, _reader: Reader) -> CSMatrix | CSArray:
     return sparse_dataset(elem).to_memory()
 
 
@@ -896,7 +900,7 @@ def read_sparse_partial(elem, *, items=None, indices=(slice(None), slice(None)))
     ZarrGroup, views.AwkwardArrayView, IOSpec("awkward-array", "0.1.0")
 )
 def write_awkward(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     v: views.AwkwardArrayView | AwkArray,
     *,
@@ -919,7 +923,7 @@ def write_awkward(
 
 @_REGISTRY.register_read(H5Group, IOSpec("awkward-array", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("awkward-array", "0.1.0"))
-def read_awkward(elem: GroupStorageType, *, _reader: Reader) -> AwkArray:
+def read_awkward(elem: _GroupStorageType, *, _reader: Reader) -> AwkArray:
     from anndata.compat import awkward as ak
 
     form = _read_attr(elem.attrs, "form")
@@ -939,7 +943,7 @@ def read_awkward(elem: GroupStorageType, *, _reader: Reader) -> AwkArray:
 @_REGISTRY.register_write(ZarrGroup, views.DataFrameView, IOSpec("dataframe", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, pd.DataFrame, IOSpec("dataframe", "0.2.0"))
 def write_dataframe(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     key: str,
     df: views.DataFrameView | pd.DataFrame,
     *,
@@ -989,7 +993,7 @@ def write_dataframe(
 
 @_REGISTRY.register_read(H5Group, IOSpec("dataframe", "0.2.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("dataframe", "0.2.0"))
-def read_dataframe(elem: GroupStorageType, *, _reader: Reader) -> pd.DataFrame:
+def read_dataframe(elem: _GroupStorageType, *, _reader: Reader) -> pd.DataFrame:
     columns = list(_read_attr(elem.attrs, "column-order"))
     idx_key = _read_attr(elem.attrs, "_index")
     df = pd.DataFrame(
@@ -1030,7 +1034,7 @@ def read_dataframe_partial(
 
 @_REGISTRY.register_read(H5Group, IOSpec("dataframe", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("dataframe", "0.1.0"))
-def read_dataframe_0_1_0(elem: GroupStorageType, *, _reader: Reader) -> pd.DataFrame:
+def read_dataframe_0_1_0(elem: _GroupStorageType, *, _reader: Reader) -> pd.DataFrame:
     columns = _read_attr(elem.attrs, "column-order")
     idx_key = _read_attr(elem.attrs, "_index")
     df = pd.DataFrame(
@@ -1080,7 +1084,7 @@ def read_partial_dataframe_0_1_0(
 @_REGISTRY.register_write(H5Group, pd.Categorical, IOSpec("categorical", "0.2.0"))
 @_REGISTRY.register_write(ZarrGroup, pd.Categorical, IOSpec("categorical", "0.2.0"))
 def write_categorical(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     v: pd.Categorical,
     *,
@@ -1101,7 +1105,7 @@ def write_categorical(
 
 @_REGISTRY.register_read(H5Group, IOSpec("categorical", "0.2.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("categorical", "0.2.0"))
-def read_categorical(elem: GroupStorageType, *, _reader: Reader) -> pd.Categorical:
+def read_categorical(elem: _GroupStorageType, *, _reader: Reader) -> pd.Categorical:
     return pd.Categorical.from_codes(
         codes=_reader.read_elem(elem["codes"]),
         categories=_reader.read_elem(elem["categories"]),
@@ -1137,7 +1141,7 @@ def read_partial_categorical(elem, *, items=None, indices=(slice(None),)):
     ZarrGroup, pd.arrays.BooleanArray, IOSpec("nullable-boolean", "0.1.0")
 )
 def write_nullable(
-    f: GroupStorageType,
+    f: _GroupStorageType,
     k: str,
     v: pd.arrays.IntegerArray
     | pd.arrays.BooleanArray
@@ -1201,7 +1205,7 @@ for store_type, array_type in product([H5Group, ZarrGroup], PANDAS_STRING_ARRAY_
 
 
 def _read_nullable(
-    elem: GroupStorageType,
+    elem: _GroupStorageType,
     *,
     _reader: Reader,
     # BaseMaskedArray
@@ -1233,7 +1237,7 @@ _REGISTRY.register_read(ZarrGroup, IOSpec("nullable-boolean", "0.1.0"))(
 @_REGISTRY.register_read(H5Group, IOSpec("nullable-string-array", "0.1.0"))
 @_REGISTRY.register_read(ZarrGroup, IOSpec("nullable-string-array", "0.1.0"))
 def _read_nullable_string(
-    elem: GroupStorageType, *, _reader: Reader
+    elem: _GroupStorageType, *, _reader: Reader
 ) -> pd.api.extensions.ExtensionArray:
     values = _reader.read_elem(elem["values"])
     mask = _reader.read_elem(elem["mask"])
@@ -1262,7 +1266,7 @@ def _read_nullable_string(
 
 @_REGISTRY.register_read(H5Array, IOSpec("numeric-scalar", "0.2.0"))
 @_REGISTRY.register_read(ZarrArray, IOSpec("numeric-scalar", "0.2.0"))
-def read_scalar(elem: ArrayStorageType, *, _reader: Reader) -> np.number:
+def read_scalar(elem: _ArrayStorageType, *, _reader: Reader) -> np.number:
     # TODO: `item` ensures the return is in fact a scalar (needed after zarr v3 which now returns a 1 elem array)
     # https://github.com/zarr-developers/zarr-python/issues/2713
     return elem[()].item()

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
     from typing import Any
 
     from anndata._types import (
-        GroupStorageType,
         ReadCallback,
         StorageType,
         Write,
         WriteCallback,
+        _GroupStorageType,
         _WriteInternal,
     )
     from anndata.experimental.backed._lazy_arrays import CategoricalArray, MaskedArray
@@ -72,7 +72,7 @@ class IORegistryError(Exception):
 def write_spec[W: _WriteInternal](spec: IOSpec) -> Callable[[W], W]:
     def decorator(func: W) -> W:
         @wraps(func)
-        def wrapper(g: GroupStorageType, k: str, *args, **kwargs) -> None:
+        def wrapper(g: _GroupStorageType, k: str, *args, **kwargs) -> None:
             result = func(g, k, *args, **kwargs)
             g[k].attrs.setdefault("encoding-type", spec.encoding_type)
             g[k].attrs.setdefault("encoding-version", spec.encoding_version)
@@ -334,7 +334,7 @@ class Writer:
     @report_write_key_on_error
     def write_elem(
         self,
-        store: GroupStorageType,
+        store: _GroupStorageType,
         k: str,
         elem: RWAble,
         *,
@@ -488,7 +488,7 @@ def read_elem_lazy(
 
 
 def write_elem(
-    store: GroupStorageType,
+    store: _GroupStorageType,
     k: str,
     elem: RWAble,
     *,

--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -29,19 +29,19 @@ else:  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/580
 
 
 __all__ = [
-    "ArrayStorageType",
-    "GroupStorageType",
     "StorageType",
+    "_ArrayStorageType",
+    "_GroupStorageType",
     "_ReadInternal",
     "_ReadLazyInternal",
     "_WriteInternal",
 ]
 
-# These two are not exported, so we don’t make them `type`s
-ArrayStorageType: TypeAlias = ZarrArray | H5Array  # noqa: UP040
-GroupStorageType: TypeAlias = ZarrGroup | H5Group  # noqa: UP040
+# These two are not public, so we don’t make them `type`s
+_ArrayStorageType: TypeAlias = ZarrArray | H5Array  # noqa: UP040
+_GroupStorageType: TypeAlias = ZarrGroup | H5Group  # noqa: UP040
 
-type StorageType = ArrayStorageType | GroupStorageType
+type StorageType = _ArrayStorageType | _GroupStorageType
 
 
 @set_module("anndata.experimental")

--- a/src/anndata/abc.py
+++ b/src/anndata/abc.py
@@ -8,7 +8,8 @@ if TYPE_CHECKING:
 
     import numpy as np
 
-    from .compat import CSArray, CSMatrix, Index
+    from .compat import CSArray, CSMatrix
+    from .typing import Index
 
 
 __all__ = ["CSCDataset", "CSRDataset"]

--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from codecs import decode
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from enum import Enum, auto
 from functools import partial, singledispatch
 from importlib.metadata import version
 from importlib.util import find_spec
-from types import EllipsisType
 from typing import TYPE_CHECKING, overload
 
 import h5py
@@ -14,7 +13,6 @@ import numpy as np
 import pandas as pd
 import scipy.sparse
 from legacy_api_wrap import legacy_api  # noqa: TID251
-from numpy.typing import NDArray
 from packaging.version import Version
 from zarr import Array as ZarrArray  # noqa: F401
 from zarr import Group as ZarrGroup
@@ -38,38 +36,6 @@ class Empty(Enum):
     TOKEN = auto()
 
 
-Index1DNorm = slice | NDArray[np.bool_] | NDArray[np.integer]
-# TODO: pd.Index[???]
-Index1D = (
-    # 0D index
-    int
-    | str
-    | np.int64
-    # normalized 1D idex
-    | Index1DNorm
-    # different containers for mask, obs/varnames, or numerical index
-    | Sequence[int]
-    | Sequence[str]
-    | Sequence[bool]
-    | pd.Series  # bool, int, str
-    | pd.Index
-    | pd.api.extensions.ExtensionArray  # bool | int | str
-    | NDArray[np.str_]
-    | np.matrix  # bool
-    | CSMatrix  # bool
-    | CSArray  # bool
-)
-IndexRest = Index1D | EllipsisType
-type Index = (
-    IndexRest
-    | tuple[Index1D, IndexRest]
-    | tuple[IndexRest, Index1D]
-    | tuple[Index1D, Index1D, EllipsisType]
-    | tuple[EllipsisType, Index1D, Index1D]
-    | tuple[Index1D, EllipsisType, Index1D]
-    | CSMatrix
-    | CSArray
-)
 H5Group = h5py.Group
 H5Array = h5py.Dataset
 H5File = h5py.File

--- a/src/anndata/experimental/_dispatch_io.py
+++ b/src/anndata/experimental/_dispatch_io.py
@@ -8,10 +8,10 @@ if TYPE_CHECKING:
     from typing import Any
 
     from anndata._types import (
-        GroupStorageType,
         ReadCallback,
         StorageType,
         WriteCallback,
+        _GroupStorageType,
     )
     from anndata.typing import RWAble
 
@@ -40,7 +40,7 @@ def read_dispatched(elem: StorageType, callback: ReadCallback) -> RWAble:
 
 
 def write_dispatched(
-    store: GroupStorageType,
+    store: _GroupStorageType,
     key: str,
     elem: RWAble,
     callback: WriteCallback,

--- a/src/anndata/experimental/backed/_io.py
+++ b/src/anndata/experimental/backed/_io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,7 +15,7 @@ from ..._core.anndata import AnnData
 from ..._core.xarray import requires_xarray
 from ..._settings import settings
 from ...compat import ZarrGroup
-from ...utils import warn
+from ...utils import get_literal_members, warn
 from .. import read_dispatched
 
 if TYPE_CHECKING:
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
     from anndata._types import Read, StorageType
 
 
-ANNDATA_ELEMS: tuple[AnnDataElem, ...] = typing.get_args(AnnDataElem.__value__)
+ANNDATA_ELEMS: tuple[AnnDataElem, ...] = get_literal_members(AnnDataElem)
 
 
 @doctest_needs("xarray")

--- a/src/anndata/experimental/backed/_lazy_arrays.py
+++ b/src/anndata/experimental/backed/_lazy_arrays.py
@@ -29,9 +29,8 @@ if TYPE_CHECKING:
     from pandas._libs.missing import NAType
     from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
-    from anndata.compat import ZarrGroup
-
-    from ...compat import Index1DNorm
+    from ...compat import ZarrGroup
+    from ...typing import _Index1DNorm
 
     if TYPE_CHECKING:  # Double nesting so Sphinx can import the parent block
         from xarray.core.extension_array import PandasExtensionArray
@@ -201,7 +200,7 @@ class MaskedArray[K: (H5Array | H5AsTypeView, ZarrArray)](XBackendArray):
 
 @_subset.register(XDataArray)
 def _subset_masked(
-    a: XDataArray, subset_idx: tuple[Index1DNorm] | tuple[Index1DNorm, Index1DNorm]
+    a: XDataArray, subset_idx: tuple[_Index1DNorm] | tuple[_Index1DNorm, _Index1DNorm]
 ):
     return a[subset_idx]
 

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -50,8 +50,8 @@ if TYPE_CHECKING:
     from zarr.abc.store import ByteRequest
     from zarr.core.buffer import BufferPrototype
 
-    from .._types import ArrayStorageType
-    from ..compat import Index1D
+    from .._types import _ArrayStorageType
+    from ..typing import Index1D
 
     type _SubsetFunc = Callable[[pd.Index[str], int], Index1D]
 
@@ -658,7 +658,11 @@ def assert_equal_cupy_sparse(
 @assert_equal.register(h5py.Dataset)
 @assert_equal.register(ZarrArray)
 def assert_equal_h5py_dataset(
-    a: ArrayStorageType, b: object, *, exact: bool = False, elem_name: str | None = None
+    a: _ArrayStorageType,
+    b: object,
+    *,
+    exact: bool = False,
+    elem_name: str | None = None,
 ):
     a = asarray(a)
     assert_equal(b, a, exact=exact, elem_name=elem_name)

--- a/src/anndata/typing.py
+++ b/src/anndata/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from types import EllipsisType
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -23,10 +24,14 @@ from .compat import (
     ZarrArray,
 )
 
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+
 __all__ = ["AxisStorable", "Index", "Index1D", "RWAble"]
 
 
-_Index1DNorm = slice | NDArray[np.bool_] | NDArray[np.integer]
+_Index1DNorm: TypeAlias = slice | NDArray[np.bool_] | NDArray[np.integer]  # noqa: UP040
 # TODO: pd.Index[???]
 type Index1D = (
     # 0D index
@@ -61,7 +66,7 @@ type Index = (
 )
 """Index an :class:`~anndata.AnnData` object can be sliced with."""
 
-_XDataType = (
+_XDataType: TypeAlias = (  # noqa: UP040
     np.ndarray
     | ma.MaskedArray
     | CSMatrix
@@ -75,8 +80,10 @@ _XDataType = (
     | CupyArray
     | CupySparseMatrix
 )
-_ArrayDataStructureTypes = _XDataType | AwkArray | XDataArray
-_InMemoryArrayOrScalarType = pd.DataFrame | np.number | str | _ArrayDataStructureTypes
+_ArrayDataStructureTypes: TypeAlias = _XDataType | AwkArray | XDataArray  # noqa: UP040
+_InMemoryArrayOrScalarType: TypeAlias = (  # noqa: UP040
+    pd.DataFrame | np.number | str | _ArrayDataStructureTypes
+)
 type AxisStorable = (
     _InMemoryArrayOrScalarType | dict[str, "AxisStorable"] | list["AxisStorable"]
 )

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import partial
 from itertools import product
-from typing import TYPE_CHECKING, Literal, get_args
+from typing import TYPE_CHECKING, Literal
 
 import h5py
 import numpy as np
@@ -19,6 +19,7 @@ from anndata.compat import CSArray, CSMatrix, DaskArray, ZarrGroup
 from anndata.experimental import read_dispatched
 from anndata.tests import helpers as test_helpers
 from anndata.tests.helpers import AccessTrackingStore, assert_equal, subset_func
+from anndata.utils import get_literal_members
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 
     from anndata.abc import CSCDataset, CSRDataset
 
-    Idx = slice | int | NDArray[np.integer] | NDArray[np.bool_]
+    type Idx = slice | int | NDArray[np.integer] | NDArray[np.bool_]
 
 
 subset_func2 = subset_func
@@ -442,7 +443,7 @@ def width_idx_kinds(
 ) -> Generator[ParameterSet, None, None]:
     """Convert major (first) index into various identical kinds of indexing."""
     for (idx_maj_raw, idx_min, exp), maj_kind in product(
-        idxs, get_args(Kind.__value__)
+        idxs, get_literal_members(Kind)
     ):
         if (idx_maj := mk_idx_kind(idx_maj_raw, kind=maj_kind, l=l)) is None:
             continue

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Literal
 
-    from anndata._types import GroupStorageType
+    from anndata._types import _GroupStorageType
     from anndata.compat import H5Group
 
 
@@ -220,7 +220,7 @@ def create_sparse_store[G: (H5Group, ZarrGroup)](
         # pytest.param(bool, np.bool_(False), "bool", id="np_bool"),
     ],
 )
-def test_io_spec(store: GroupStorageType, value, encoding_type) -> None:
+def test_io_spec(store: _GroupStorageType, value, encoding_type) -> None:
     if callable(value):
         value = value()
 
@@ -652,7 +652,7 @@ PAT_IMPLICIT = r"allow_write_nullable_strings.*None.*future\.infer_string.*False
 @pytest.mark.parametrize("missing", [True, False], ids=["missing", "no_missing"])
 def test_write_nullable_string(
     *,
-    store: GroupStorageType,
+    store: _GroupStorageType,
     ad_setting: bool | None,
     pd_setting: bool,
     expected_missing: tuple[type[Exception], str] | str,
@@ -740,7 +740,7 @@ def test_override_specification():
         ),
     ],
 )
-def test_write_to_root(store: GroupStorageType, value):
+def test_write_to_root(store: _GroupStorageType, value):
     """
     Test that elements which are written as groups can we written to the root group.
     """
@@ -818,7 +818,7 @@ def test_dataframe_column_uniqueness(store):
     ],
 )
 def test_io_pd_cow(
-    *, exit_stack: ExitStack, store: GroupStorageType, copy_on_write: bool
+    *, exit_stack: ExitStack, store: _GroupStorageType, copy_on_write: bool
 ) -> None:
     """See <https://github.com/zarr-developers/numcodecs/issues/514>."""
     if not PANDAS_3:  # Setting copy_on_write always warns in pandas 3, and does nothing

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from types import EllipsisType, FunctionType
 
-    from anndata.compat import Index
+    from anndata.typing import Index
 
 
 IGNORE_SPARSE_EFFICIENCY_WARNING = pytest.mark.filterwarnings(


### PR DESCRIPTION
This PR makes our usage of `type`s clearer in our code:
- `type Public = ...`
- `_private: TypeAlias = ...`

If I figure out in the future how to make our docs build expand non-public types reliably (theislab/scanpydoc#254), we can make them all `type`s.

It also moves all the type aliases into one page, and exports Index1D so things are actually readable: https://icb-anndata--2325.com.readthedocs.build/en/2325/typing.html