### PR TITLE
chore: add `anndata.settings.copy_on_write_X`

### DIFF
--- a/docs/release-notes/2327.chore.md
+++ b/docs/release-notes/2327.chore.md
@@ -1,0 +1,1 @@
+Add {attr}`anndata.settings.copy_on_write_X` to allow for forward-compatibility with future copy-on-write behavior (release `0.13`). Currently, setting {attr}`~anndata.AnnData.X` on a view implicitly updates the object from which the view was created. {user}`ilan-gold`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,8 @@ filterwarnings_when_strict = [
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:Automatic shard shape inference is experimental",
     "default:Writing zarr v2:UserWarning",
+    # TODO: Remove in conjunction with or before https://github.com/scverse/anndata/pull/1707
+    "default:will obey copy-on-write semantics:FutureWarning",
 ]
 python_files = [ "test_*.py" ]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ filterwarnings_when_strict = [
     "default:Automatic shard shape inference is experimental",
     "default:Writing zarr v2:UserWarning",
     # TODO: Remove in conjunction with or before https://github.com/scverse/anndata/pull/1707
-    "default:will obey copy-on-write semantics:FutureWarning",
+    "default:.*will obey copy-on-write semantics:FutureWarning",
 ]
 python_files = [ "test_*.py" ]
 testpaths = [

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -587,13 +587,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         elif self.is_view and self._adata_ref.X is None:
             X = None
         elif self.is_view:
-            if self._X is not None:
-                X = self._X
-            else:
-                X = as_view(
-                    _subset(self._adata_ref.X, (self._oidx, self._vidx)),
-                    ElementRef(self, "X"),
-                )
+            X = as_view(
+                _subset(self._adata_ref.X, (self._oidx, self._vidx)),
+                ElementRef(self, "X"),
+            )
         else:
             X = self._X
         return X

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -625,7 +625,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
                 self._init_as_actual(new)
                 return None
             else:
-                msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release."
+                msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release. "
                 "In other words, this subset of your original `AnnData` will be copied-in-place and initialized with the value passed into this setter. "
                 "Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
                 warn(msg, FutureWarning)

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -608,13 +608,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
             if value is not None
             else None
         )
-        can_set_direct_non_none = value is not None and (
+        can_set_direct = value is None or (
             np.isscalar(value)
             or (hasattr(value, "shape") and (self.shape == value.shape))
             or (self.n_vars == 1 and self.n_obs == len(value))
             or (self.n_obs == 1 and self.n_vars == len(value))
         )
-        if not can_set_direct_non_none:
+        if not can_set_direct:
             msg = f"Data matrix has wrong shape {value.shape}, need to be {self.shape}."
             raise ValueError(msg)
         if self._is_view:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -625,7 +625,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
                 self._init_as_actual(new)
                 return None
             else:
-                msg = "Setting element `.X` of view will obey copy-on-write semantics in the next minor release. Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
+                msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release."
+                "In other words, this subset of your original `AnnData` will be copied-in-place and initialized with the value passed into this setter. "
+                "Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
                 warn(msg, FutureWarning)
         if value is None:
             if self.isbacked:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -624,11 +624,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
                 new = self._mutated_copy(X=value)
                 self._init_as_actual(new)
                 return None
-            else:
-                msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release. "
-                "In other words, this subset of your original `AnnData` will be copied-in-place and initialized with the value passed into this setter. "
-                "Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
-                warn(msg, FutureWarning)
+            msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release. "
+            "In other words, this subset of your original `AnnData` will be copied-in-place and initialized with the value passed into this setter. "
+            "Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
+            warn(msg, FutureWarning)
         if value is None:
             if self.isbacked:
                 msg = "Cannot currently remove data matrix from backed object."

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -608,13 +608,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
             if value is not None
             else None
         )
-        can_set_direct = value is None or (
+        can_set_direct_if_not_none = value is None or (
             np.isscalar(value)
             or (hasattr(value, "shape") and (self.shape == value.shape))
             or (self.n_vars == 1 and self.n_obs == len(value))
             or (self.n_obs == 1 and self.n_vars == len(value))
         )
-        if not can_set_direct:
+        if not can_set_direct_if_not_none:
             msg = f"Data matrix has wrong shape {value.shape}, need to be {self.shape}."
             raise ValueError(msg)
         if self._is_view:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -608,11 +608,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
                 warn(msg, ImplicitModificationWarning)
                 new = self._mutated_copy(X=value)
                 self._init_as_actual(new)
-                return None
+                return True
             msg = "Setting element `.X` of view of `AnnData` object will obey copy-on-write semantics in the next minor release. "
             "In other words, this subset of your original `AnnData` will be copied-in-place and initialized with the value passed into this setter. "
             "Set `anndata.settings.copy_on_write_X = True` to begin opting in to this behavior."
             warn(msg, FutureWarning)
+        return False
 
     @X.setter
     def X(self, value: _XDataType | None):  # noqa: PLR0912
@@ -630,7 +631,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         if not can_set_direct_if_not_none:
             msg = f"Data matrix has wrong shape {value.shape}, need to be {self.shape}."
             raise ValueError(msg)
-        self._handle_view_X_cow(value)
+        if self._handle_view_X_cow(value):
+            return None
         if value is None:
             if self.isbacked:
                 msg = "Cannot currently remove data matrix from backed object."

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -208,7 +208,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
     _adata_ref: AnnData | None
     _oidx: _Index1DNorm | None
     _vidx: _Index1DNorm | None
-    _X: None | _XDataType = None
 
     @old_positionals(
         "obsm",

--- a/src/anndata/_core/views.py
+++ b/src/anndata/_core/views.py
@@ -57,12 +57,9 @@ def view_update(adata_view: AnnData, attr_name: str, keys: tuple[str, ...]):
     `adata.attr[key1][key2][keyn]...`
     """
     new = adata_view.copy()
-    if attr_name == "X":
-        yield new
-    else:
-        attr = getattr(new, attr_name)
-        container = reduce(lambda d, k: d[k], keys, attr)
-        yield container
+    attr = getattr(new, attr_name)
+    container = reduce(lambda d, k: d[k], keys, attr)
+    yield container
     adata_view._init_as_actual(new)
 
 

--- a/src/anndata/_core/views.py
+++ b/src/anndata/_core/views.py
@@ -57,9 +57,12 @@ def view_update(adata_view: AnnData, attr_name: str, keys: tuple[str, ...]):
     `adata.attr[key1][key2][keyn]...`
     """
     new = adata_view.copy()
-    attr = getattr(new, attr_name)
-    container = reduce(lambda d, k: d[k], keys, attr)
-    yield container
+    if attr_name == "X":
+        yield new
+    else:
+        attr = getattr(new, attr_name)
+        container = reduce(lambda d, k: d[k], keys, attr)
+        yield container
     adata_view._init_as_actual(new)
 
 

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -529,7 +529,11 @@ settings.register(
 settings.register(
     "copy_on_write_X",
     default_value=False,
-    description="Whether to copy-on-write X. Currently `my_adata_view[subset].X = value` will write back to the original AnnData object at the `subset` location. `X` is the only element where this behavior is implemented though.",
+    description=(
+        "Whether to copy-on-write X. "
+        "Currently `my_adata_view[subset].X = value` will write back to the original AnnData object at the `subset` location. "
+        "`X` is the only element where this behavior is implemented though."
+    ),
     validate=validate_bool,
     get_from_env=check_and_get_bool,
 )

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -526,5 +526,14 @@ settings.register(
 )
 
 
+settings.register(
+    "copy_on_write_X",
+    default_value=False,
+    description="Whether to copy-on-write X. Currently `my_adata_view[subset].X = value` will write back to the original AnnData object at the `subset` location. `X` is the only element where this behavior is implemented though.",
+    validate=validate_bool,
+    get_from_env=check_and_get_bool,
+)
+
+
 ##################################################################################
 ##################################################################################

--- a/src/anndata/_settings.pyi
+++ b/src/anndata/_settings.pyi
@@ -39,6 +39,7 @@ class SettingsManager[T]:
 class _AnnDataSettingsManager(SettingsManager):
     remove_unused_categories: bool = True
     check_uniqueness: bool = True
+    copy_on_write_X: bool = False
     allow_write_nullable_strings: bool | None = None
     zarr_write_format: Literal[2, 3] = 2
     use_sparse_array_on_read: bool = False

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -51,34 +51,42 @@ def test_repeat_indices_view():
 @pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("copy_on_write_X", [True, False], ids=["CoW", "update"])
-def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool):
-    with ad.settings.override(copy_on_write_X=copy_on_write_X):
-        adata = gen_adata((10, 10), X_type=orig_array_type)
-        orig_X = adata.X
-        expected_X = asarray(orig_X.copy())
-        to_assign = new_array_type(np.ones((9, 9)))
-        if not copy_on_write_X:
-            expected_X[:9, :9] = asarray(to_assign)
-        if (
-            not copy_on_write_X
-            and isinstance(orig_X, np.ndarray)
-            and sparse.issparse(to_assign)
-        ):
-            # https://github.com/scverse/anndata/issues/500
-            pytest.xfail("Cannot set a dense array with a sparse array")
-        view = adata[:9, :9]
-        with pytest.warns(
-            ImplicitModificationWarning if copy_on_write_X else FutureWarning,
-            match=r"initializing view as actual"
-            if copy_on_write_X
-            else r"will obey copy-on-write semantics",
-        ):
-            view.X = to_assign
-        assert_equal(view.X, to_assign)
-        assert isinstance(view.X, type(to_assign) if copy_on_write_X else type(orig_X))
-        assert_equal(adata.X, expected_X)
-        # If cow, then not a view and if not cow, it is a view
-        assert view.is_view != copy_on_write_X
+def test_setter_view(
+    orig_array_type,
+    new_array_type,
+    *,
+    copy_on_write_X: bool,
+    request: pytest.FixtureRequest,
+):
+    ad.settings.copy_on_write_X = copy_on_write_X
+    adata = gen_adata((10, 10), X_type=orig_array_type)
+    orig_X = adata.X
+    expected_X = asarray(orig_X.copy())
+    to_assign = new_array_type(np.ones((9, 9)))
+    if not copy_on_write_X:
+        expected_X[:9, :9] = asarray(to_assign)
+    if (
+        not copy_on_write_X
+        and isinstance(orig_X, np.ndarray)
+        and sparse.issparse(to_assign)
+    ):
+        # https://github.com/scverse/anndata/issues/500
+        request.applymarker(
+            pytest.mark.xfail("Cannot set a dense array with a sparse array")
+        )
+    view = adata[:9, :9]
+    with pytest.warns(
+        ImplicitModificationWarning if copy_on_write_X else FutureWarning,
+        match=r"initializing view as actual"
+        if copy_on_write_X
+        else r"will obey copy-on-write semantics",
+    ):
+        view.X = to_assign
+    assert_equal(view.X, to_assign)
+    assert isinstance(view.X, type(to_assign) if copy_on_write_X else type(orig_X))
+    assert_equal(adata.X, expected_X)
+    # If cow, then not a view and if not cow, it is a view
+    assert view.is_view != copy_on_write_X
 
 
 ###############################

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -50,17 +50,33 @@ def test_repeat_indices_view():
 
 @pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
-def test_setter_view(orig_array_type, new_array_type):
-    adata = gen_adata((10, 10), X_type=orig_array_type)
-    orig_X = adata.X
-    to_assign = new_array_type(np.ones((9, 9)))
-    if isinstance(orig_X, np.ndarray) and sparse.issparse(to_assign):
-        # https://github.com/scverse/anndata/issues/500
-        pytest.xfail("Cannot set a dense array with a sparse array")
-    view = adata[:9, :9]
-    view.X = to_assign
-    np.testing.assert_equal(asarray(view.X), np.ones((9, 9)))
-    assert isinstance(view.X, type(orig_X))
+@pytest.mark.parametrize("copy_on_write_X", [True, False], ids=["CoW", "update"])
+def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool):
+    with ad.settings.override(copy_on_write_X=copy_on_write_X):
+        adata = gen_adata((10, 10), X_type=orig_array_type)
+        orig_X = adata.X
+        expected_X = asarray(orig_X.copy())
+        to_assign = new_array_type(np.ones((9, 9)))
+        if not copy_on_write_X:
+            expected_X[:9, :9] = asarray(to_assign)
+        if (
+            not copy_on_write_X
+            and isinstance(orig_X, np.ndarray)
+            and sparse.issparse(to_assign)
+        ):
+            # https://github.com/scverse/anndata/issues/500
+            pytest.xfail("Cannot set a dense array with a sparse array")
+        view = adata[:9, :9]
+        with pytest.warns(
+            ImplicitModificationWarning if copy_on_write_X else FutureWarning,
+            match=r"initializing view as actual"
+            if copy_on_write_X
+            else r"will obey copy-on-write semantics",
+        ):
+            view.X = to_assign
+        assert_equal(view.X, to_assign)
+        assert isinstance(view.X, type(to_assign) if copy_on_write_X else type(orig_X))
+        assert_equal(adata.X, expected_X)
 
 
 ###############################

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -65,14 +65,12 @@ def test_setter_view(
     to_assign = new_array_type(np.ones((9, 9)))
     if not copy_on_write_X:
         expected_X[:9, :9] = asarray(to_assign)
-    if (
-        not copy_on_write_X
-        and isinstance(orig_X, np.ndarray)
-        and sparse.issparse(to_assign)
-    ):
         # https://github.com/scverse/anndata/issues/500
         request.applymarker(
-            pytest.mark.xfail("Cannot set a dense array with a sparse array")
+            pytest.mark.xfail(
+                condition=isinstance(orig_X, np.ndarray) and sparse.issparse(to_assign),
+                reason="Cannot set a dense array with a sparse array",
+            )
         )
     view = adata[:9, :9]
     with pytest.warns(

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -51,7 +51,7 @@ def test_repeat_indices_view():
 @pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("copy_on_write_X", [True, False], ids=["CoW", "update"])
-def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool, f):
+def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool):
     ad.settings.copy_on_write_X = copy_on_write_X
     adata = gen_adata((10, 10), X_type=orig_array_type)
     orig_X = adata.X

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -77,6 +77,8 @@ def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool):
         assert_equal(view.X, to_assign)
         assert isinstance(view.X, type(to_assign) if copy_on_write_X else type(orig_X))
         assert_equal(adata.X, expected_X)
+        # If cow, then not a view and if not cow, it is a view
+        assert view.is_view != copy_on_write_X
 
 
 ###############################

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -65,13 +65,6 @@ def test_setter_view(
     to_assign = new_array_type(np.ones((9, 9)))
     if not copy_on_write_X:
         expected_X[:9, :9] = asarray(to_assign)
-        # https://github.com/scverse/anndata/issues/500
-        request.applymarker(
-            pytest.mark.xfail(
-                condition=isinstance(orig_X, np.ndarray) and sparse.issparse(to_assign),
-                reason="Cannot set a dense array with a sparse array",
-            )
-        )
     view = adata[:9, :9]
     with pytest.warns(
         ImplicitModificationWarning if copy_on_write_X else FutureWarning,

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -51,13 +51,7 @@ def test_repeat_indices_view():
 @pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("copy_on_write_X", [True, False], ids=["CoW", "update"])
-def test_setter_view(
-    orig_array_type,
-    new_array_type,
-    *,
-    copy_on_write_X: bool,
-    request: pytest.FixtureRequest,
-):
+def test_setter_view(orig_array_type, new_array_type, *, copy_on_write_X: bool, f):
     ad.settings.copy_on_write_X = copy_on_write_X
     adata = gen_adata((10, 10), X_type=orig_array_type)
     orig_X = adata.X


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

`copy_on_write_X` will be `False` and then the setting will be removed in the next minor release (i.e., `True`).
 
- [x] Grossly simplifies https://github.com/scverse/anndata/pull/1707 because we will remove the implicit modification of `X`
- [x] Tests added
- [x] Release note added (or unnecessary)
