### PR TITLE
fix: scalar setting/`reshape` on CoW `.X`

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -53,8 +53,9 @@ jobs:
         run: nvidia-smi
 
       - name: Install yq # https://cirun.slack.com/archives/C09SNDRB3A8/p1766512487317849?thread_ts=1766512112.938459&cid=C09SNDRB3A8
+        # https://github.com/mikefarah/yq/issues/2592 forces version pin
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq http://github.com/mikefarah/yq/releases/download/v4.49.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Extract max Python version from classifiers

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -601,6 +601,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         if self._is_view:
             if settings.copy_on_write_X:
                 if np.isscalar(value) and value is not None:
+                    msg = "The ability to set with a scalar value will be removed in the future.  Initializing as an `np.array` with the shape of the current view."
+                    warnings.warn(msg, FutureWarning, stacklevel=2)
                     value = np.full(self.shape, fill_value=value)
                 if hasattr(value, "shape") and value.shape != self.shape:
                     value = value.reshape(self.shape)

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -600,6 +600,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
     def _handle_view_X_cow(self, value: XDataType | None):
         if self._is_view:
             if settings.copy_on_write_X:
+                if np.isscalar(value) and value is not None:
+                    value = np.full(self.shape, fill_value=value)
+                if hasattr(value, "shape") and value.shape != self.shape:
+                    value = value.reshape(self.shape)
                 msg = "Setting element `.X` of view, initializing view as actual."
                 warnings.warn(msg, ImplicitModificationWarning, stacklevel=2)
                 new = self._mutated_copy(X=value)

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -601,10 +601,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         if self._is_view:
             if settings.copy_on_write_X:
                 if np.isscalar(value) and value is not None:
-                    msg = "The ability to set with a scalar value will be removed in the future.  Initializing as an `np.array` with the shape of the current view."
+                    msg = "The ability to set X with a scalar value will be removed in the future.  Initializing as an `np.array` with the shape of the current view."
                     warnings.warn(msg, FutureWarning, stacklevel=2)
                     value = np.full(self.shape, fill_value=value)
                 if hasattr(value, "shape") and value.shape != self.shape:
+                    msg = "Automatic reshaping when setting X will be removed in the future."
+                    warnings.warn(msg, FutureWarning, stacklevel=2)
                     value = value.reshape(self.shape)
                 msg = "Setting element `.X` of view, initializing view as actual."
                 warnings.warn(msg, ImplicitModificationWarning, stacklevel=2)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -146,7 +146,7 @@ def test_views(*, copy_on_write_X: bool):
             pytest.warns(FutureWarning, match=r"Automatic reshaping"),
         )
         if copy_on_write_X
-        else (nullcontext(),)
+        else ()
     )
     with ExitStack() as stack:
         for mgr in ctx_managers:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -437,7 +437,7 @@ def test_set_scalar_subset_X(matrix_type, subset_func, *, copy_on_write_X: bool)
         asarray((adata_subset if copy_on_write_X else adata[subset_idx, :]).X) == 1
     )
     if copy_on_write_X:
-        assert asarray(orig_X_val == adata.X).all()
+        assert (asarray(orig_X_val) == asarray(adata.X)).all()
     elif isinstance(adata.X, CupyCSCMatrix):
         # Comparison broken for CSC matrices
         # https://github.com/cupy/cupy/issues/7757

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -425,7 +425,7 @@ def test_set_scalar_subset_X(matrix_type, subset_func, *, copy_on_write_X: bool)
             ),
         )
         if copy_on_write_X
-        else (nullcontext(),)
+        else ()
     )
     with ExitStack() as stack:
         for mgr in ctx_managers:


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

@flying-sheep I'm ready to merge #2338 but noticed I hadn't backported this feature with the `CoW` branch.  I'm actually not even 100% sure we should support these shortcuts.  WDYT? I'll hold off on merging the other PR until I hear back.

- [ ] Closes #
- [ ] Tests added
- [ ] Release note added (or unnecessary)
