### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1289,7 +1289,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         deprecation_msg(
             "obs_vector",
             "anndata.acc.A",
-            "E.g. `vec = A.obs['foo'](adata)` or `vec = A.layers['l']['bar', :](adata)`",
+            "E.g. `vec = adata[A.obs['foo']]` or `vec = adata[A.layers['l']['bar', :]]`",
         )
     )
     def obs_vector(self, k: str, /, *, layer: str | None = None) -> np.ndarray:
@@ -1318,7 +1318,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         deprecation_msg(
             "var_vector",
             "anndata.acc.A",
-            "E.g. `vec = A.var['foo'](adata)` or `vec = A.layers['l'][:, 'bar'](adata)`",
+            "E.g. `vec = adata[A.var['foo']]` or `vec = adata[A.layers['l'][:, 'bar']]`",
         )
     )
     def var_vector(self, k: str, /, *, layer: str | None = None) -> np.ndarray:


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] The deprecation warning was wrong after #2290 removed `__get__` from `AdRef`
- [ ] Tests added
- [x] Release note added (or unnecessary)
