### PR TITLE
fix: allow membership test for 2D GraphAcc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,6 @@
 
 - [ ] Closes #
 - [ ] Tests added
-- [ ] Release note added (or unnecessary)
+
+<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
+- [ ] Release note not necessary because:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -34,12 +34,12 @@ jobs:
         uses: flying-sheep/check@v1
         with:
           success: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' || github.event.pull_request.milestone != null || contains(env.LABELS, 'no milestone') }}
-      - name: Check if the “Release notes” checkbox is checked and filled
+      - name: Check if release notes are necessary
         uses: kaisugi/action-regex-match@v1.0.2
         id: checked-relnotes
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: '^\s*- \[x\].*Release note'
+          regex: '^\s*- \[x\].*Release note not necessary because:\s*(.*)$'
           flags: m
       - name: Check if PR title is valid
         id: check-title
@@ -47,14 +47,14 @@ jobs:
         env: # Needs repo options: “Squash and merge” with commit message set to “PR title”
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
-      allow-no-relnotes: ${{ steps.checked-relnotes.outputs.match && true || false }}
+      no-relnotes-reason: ${{ steps.checked-relnotes.outputs.group1 }}
       type: ${{ steps.check-title.outputs.type }}
   # This job verifies that the relevant release notes file has been modified.
   check-relnotes:
     name: Check for release notes
     runs-on: ubuntu-latest
     needs: check-milestone
-    if: github.event.pull_request.user.login != 'pre-commit-ci[bot]' && needs.check-milestone.outputs.allow-no-relnotes && !contains(fromJSON('["style","refactor","test","build","ci"]'), needs.check-milestone.outputs.type)
+    if: github.event.pull_request.user.login != 'pre-commit-ci[bot]' && needs.check-milestone.outputs.no-relnotes-reason == '' && !contains(fromJSON('["style","refactor","test","build","ci"]'), needs.check-milestone.outputs.type)
     steps:
       - uses: actions/checkout@v6
         with: { filter: 'blob:none', fetch-depth: 0 }

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -499,8 +499,11 @@ class GraphAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D]):
             return False
         if idx is None:
             return True
-        [i] = (i for i in idx if isinstance(i, str))
-        return i in getattr(adata, self.dim).index
+        match [i for i in idx if isinstance(i, str)]:
+            case []:
+                return True
+            case [i]:
+                return i in getattr(adata, self.dim).index
 
     def get(self, adata: AnnData, idx: Idx2D, /) -> InMemoryArray:
         df = cast("pd.DataFrame", getattr(adata, self.dim))

--- a/tests/accessors/test_accessors.py
+++ b/tests/accessors/test_accessors.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Collection
     from typing import Literal
 
-    from anndata.acc import AdRef
+    from anndata.acc import AdRef, MapAcc
 
 
 type AdRefSer = Sequence[str | int | None]
@@ -36,6 +36,7 @@ PATHS: list[tuple[AdRef, AdRefSer]] = [
     (A.layers["a"]["cell-77", :], ["layers", "a", "cell-77", None]),
     (A.obsm["umap"][0], ["obsm", "umap", 0]),
     (A.obsm["umap"][1], ["obsm", "umap", 1]),
+    (A.varp["cons"][:, :], ["varp", "cons", None, None]),
     (A.varp["cons"]["gene-46", :], ["varp", "cons", "gene-46", None]),
     (A.varp["cons"][:, "gene-46"], ["varp", "cons", None, "gene-46"]),
 ]
@@ -216,7 +217,7 @@ def test_special[C](
 
 
 @pytest.mark.parametrize(
-    "ad_ref",
+    "ref_or_acc",
     [
         *(p[0] for p in PATHS),
         A.X,
@@ -230,12 +231,12 @@ def test_special[C](
     ],
     ids=str,
 )
-def test_in(adata: AnnData, ad_ref: AdRef) -> None:
-    assert ad_ref in adata
+def test_in(adata: AnnData, ref_or_acc: AdRef | MapAcc) -> None:
+    assert ref_or_acc in adata
 
 
 @pytest.mark.parametrize(
-    "ad_ref",
+    "ref_or_acc",
     [
         A.layers["a"]["gene-0", :],  # not an obs name
         A.layers["a"][:, "cell-3"],  # not a var name
@@ -250,8 +251,8 @@ def test_in(adata: AnnData, ad_ref: AdRef) -> None:
     ],
     ids=str,
 )
-def test_not_in(adata: AnnData, ad_ref: AdRef) -> None:
-    assert ad_ref not in adata
+def test_not_in(adata: AnnData, ref_or_acc: AdRef | MapAcc) -> None:
+    assert ref_or_acc not in adata
 
 
 def test_not_in_empty(ad_ref: AdRef) -> None:

--- a/tests/accessors/test_get.py
+++ b/tests/accessors/test_get.py
@@ -47,6 +47,7 @@ ND_PATHS: list[tuple[AdRef, Callable[[AnnData], InMemoryArray]]] = [
     (A.layers["a"]["cell-77", :], lambda ad: ad["cell-77"].layers["a"]),
     (A.obsm["umap"][0], lambda ad: asarray(ad.obsm["umap"])[:, 0]),
     (A.obsm["umap"][1], lambda ad: asarray(ad.obsm["umap"])[:, 1]),
+    (A.varp["cons"][:, :], lambda ad: asarray(ad.varp["cons"])),
     (A.varp["cons"]["gene-46", :], lambda ad: asarray(ad.varp["cons"])[46, :]),
     (A.varp["cons"][:, "gene-46"], lambda ad: asarray(ad.varp["cons"])[:, 46]),
 ]


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [x] Tests added
- [x] Release note not necessary because: unreleased

fixes an oversight in #2189 where `A.{obs,var}p[k][:, :] in adata` would crash