### PR TITLE
Replace `use_cuda` with `device` parameter in AnnLoader

### DIFF
--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -71,7 +71,9 @@ class BatchIndexSampler(Sampler):
         return length
 
 
-def default_converter(arr: Array, *, device: Literal["cpu", "cuda", "mps"] = "cpu", pin_memory: bool):
+def default_converter(
+    arr: Array, *, device: Literal["cpu", "cuda", "mps"] = "cpu", pin_memory: bool
+):
     if isinstance(arr, torch.Tensor):
         arr = arr.to(device)
         if device == "cpu" and pin_memory:

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy.sparse import issparse
 
 from ..._core.anndata import AnnData
+from ..._warnings import warn
 from ...compat import old_positionals
 from ..multi_files._anncollection import AnnCollection, _ConcatViewMixin
 
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
     type Array = torch.Tensor | np.ndarray | spmatrix
+
+_UNSET = object()
 
 
 # Custom sampler to get proper batches instead of joined separate indices
@@ -70,21 +73,17 @@ class BatchIndexSampler(Sampler):
         return length
 
 
-# maybe replace use_cuda with explicit device option
-def default_converter(arr: Array, *, use_cuda: bool, pin_memory: bool):
+def default_converter(arr: Array, *, device: str = "cpu", pin_memory: bool):
     if isinstance(arr, torch.Tensor):
-        if use_cuda:
-            arr = arr.cuda()
-        elif pin_memory:
+        arr = arr.to(device)
+        if device == "cpu" and pin_memory:
             arr = arr.pin_memory()
     elif arr.dtype.name != "category" and np.issubdtype(arr.dtype, np.number):
         if issparse(arr):
             arr = arr.toarray()
-        if use_cuda:
-            arr = torch.tensor(arr, device="cuda")
-        else:
-            arr = torch.tensor(arr)
-            arr = arr.pin_memory() if pin_memory else arr
+        arr = torch.tensor(arr, device=device)
+        if device == "cpu" and pin_memory:
+            arr = arr.pin_memory()
     return arr
 
 
@@ -135,12 +134,15 @@ class AnnLoader(DataLoader):
         Set to `True` to have the data reshuffled at every epoch.
     use_default_converter
         Use the default converter to convert arrays to pytorch tensors, transfer to
-        the default cuda device (if `use_cuda=True`), do memory pinning (if `pin_memory=True`).
+        the specified device (if `device` is set), do memory pinning (if `pin_memory=True`).
         If you pass an AnnCollection object with prespecified converters, the default converter
         won't overwrite these converters but will be applied on top of them.
+    device
+        Transfer pytorch tensors to the specified device after conversion.
+        Only works if `use_default_converter=True`.
     use_cuda
-        Transfer pytorch tensors to the default cuda device after conversion.
-        Only works if `use_default_converter=True`
+        .. deprecated::
+            Use `device='cuda'` instead.
     **kwargs
         Arguments for PyTorch DataLoader. If `adatas` is not an `AnnCollection` object, then also
         arguments for `AnnCollection` initialization.
@@ -154,9 +156,24 @@ class AnnLoader(DataLoader):
         batch_size: int = 1,
         shuffle: bool = False,
         use_default_converter: bool = True,
-        use_cuda: bool = False,
+        device: str = "cpu",
+        use_cuda: bool = _UNSET,
         **kwargs,
     ):
+        if use_cuda is not _UNSET:
+            if device != "cpu":
+                msg = (
+                    "Cannot specify both 'device' and 'use_cuda'. "
+                    "Use 'device' instead."
+                )
+                raise ValueError(msg)
+            warn(
+                "'use_cuda' is deprecated, use 'device' instead. "
+                "Pass device='cuda' instead of use_cuda=True.",
+                FutureWarning,
+            )
+            device = "cuda" if use_cuda else "cpu"
+
         if isinstance(adatas, AnnData):
             adatas = [adatas]
 
@@ -191,7 +208,7 @@ class AnnLoader(DataLoader):
         if use_default_converter:
             pin_memory = kwargs.pop("pin_memory", False)
             _converter = partial(
-                default_converter, use_cuda=use_cuda, pin_memory=pin_memory
+                default_converter, device=device, pin_memory=pin_memory
             )
             dataset.convert = _convert_on_top(
                 dataset.convert, _converter, dict(dataset.attrs_keys, X=[])

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -5,14 +5,14 @@ from copy import copy
 from functools import partial
 from importlib.util import find_spec
 from math import ceil
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from scipy.sparse import issparse
 
 from ..._core.anndata import AnnData
 from ..._warnings import warn
-from ...compat import old_positionals
+from ...compat import Empty, old_positionals
 from ..multi_files._anncollection import AnnCollection, _ConcatViewMixin
 
 if find_spec("torch") or TYPE_CHECKING:
@@ -27,8 +27,6 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
     type Array = torch.Tensor | np.ndarray | spmatrix
-
-_UNSET = object()
 
 
 # Custom sampler to get proper batches instead of joined separate indices
@@ -73,7 +71,7 @@ class BatchIndexSampler(Sampler):
         return length
 
 
-def default_converter(arr: Array, *, device: str = "cpu", pin_memory: bool):
+def default_converter(arr: Array, *, device: Literal["cpu", "cuda", "mps"] = "cpu", pin_memory: bool):
     if isinstance(arr, torch.Tensor):
         arr = arr.to(device)
         if device == "cpu" and pin_memory:
@@ -156,11 +154,11 @@ class AnnLoader(DataLoader):
         batch_size: int = 1,
         shuffle: bool = False,
         use_default_converter: bool = True,
-        device: str = "cpu",
-        use_cuda: bool = _UNSET,
+        device: Literal["cpu", "cuda", "mps"] = "cpu",
+        use_cuda: bool = Empty.TOKEN,
         **kwargs,
     ):
-        if use_cuda is not _UNSET:
+        if use_cuda is not Empty.TOKEN:
             if device != "cpu":
                 msg = (
                     "Cannot specify both 'device' and 'use_cuda'. Use 'device' instead."

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -5,7 +5,7 @@ from copy import copy
 from functools import partial
 from importlib.util import find_spec
 from math import ceil
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.sparse import issparse
@@ -23,6 +23,7 @@ else:
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
+    from typing import Literal
 
     from scipy.sparse import spmatrix
 

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -163,8 +163,7 @@ class AnnLoader(DataLoader):
         if use_cuda is not _UNSET:
             if device != "cpu":
                 msg = (
-                    "Cannot specify both 'device' and 'use_cuda'. "
-                    "Use 'device' instead."
+                    "Cannot specify both 'device' and 'use_cuda'. Use 'device' instead."
                 )
                 raise ValueError(msg)
             warn(

--- a/tests/test_annloader.py
+++ b/tests/test_annloader.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import anndata as ad
+
+pytest.importorskip("torch")
+
+from anndata.experimental.pytorch import AnnLoader
+
+
+@pytest.fixture
+def adata():
+    return ad.AnnData(X=np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))
+
+
+def test_annloader_default_device(adata):
+    """AnnLoader with default device='cpu' produces CPU tensors."""
+    loader = AnnLoader(adata, batch_size=2)
+    batch = next(iter(loader))
+    assert batch.X.device.type == "cpu"
+
+
+def test_annloader_explicit_cpu_device(adata):
+    """AnnLoader with explicit device='cpu' produces CPU tensors."""
+    loader = AnnLoader(adata, batch_size=2, device="cpu")
+    batch = next(iter(loader))
+    assert batch.X.device.type == "cpu"
+
+
+def test_annloader_use_cuda_deprecation_warning(adata):
+    """Passing use_cuda emits a FutureWarning."""
+    with pytest.warns(FutureWarning, match="use_cuda.*deprecated"):
+        # use_cuda=False should still emit warning (parameter was explicitly passed)
+        AnnLoader(adata, batch_size=2, use_cuda=False)
+
+
+def test_annloader_use_cuda_and_device_conflict(adata):
+    """Passing both use_cuda and device raises ValueError."""
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        AnnLoader(adata, batch_size=2, use_cuda=True, device="cuda")


### PR DESCRIPTION
## Summary

- Replace `use_cuda: bool` with `device: str = "cpu"` in `default_converter` and `AnnLoader.__init__`, addressing the TODO comment in the code (`# maybe replace use_cuda with explicit device option`).
- `use_cuda` is kept for backward compatibility but emits a `FutureWarning` when explicitly passed. Passing both `use_cuda` and `device` raises a `ValueError`.
- `pin_memory` logic is now correctly guarded to only apply on CPU (it is a CPU-only operation).

## Motivation

The existing `use_cuda` boolean is limiting — it only supports CPU or CUDA. The new `device` parameter accepts any PyTorch device string (e.g., `"cpu"`, `"cuda"`, `"cuda:1"`, `"mps"`), making the API more flexible and consistent with PyTorch conventions.

## Test plan

- [x] `test_annloader_default_device` — default `device="cpu"` produces CPU tensors
- [x] `test_annloader_explicit_cpu_device` — explicit `device="cpu"` works
- [x] `test_annloader_use_cuda_deprecation_warning` — `use_cuda` emits `FutureWarning`
- [x] `test_annloader_use_cuda_and_device_conflict` — both params raises `ValueError`