### PR TITLE
chore: add sparse index dtype checks to assert_equal

### DIFF
--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -688,6 +688,13 @@ def assert_equal_sparse(
     exact: bool = False,
     elem_name: str | None = None,
 ):
+    if exact and sparse.issparse(b) and hasattr(a, "indptr") and hasattr(b, "indptr"):
+        assert a.indptr.dtype == b.indptr.dtype, (
+            f"{elem_name}: indptr dtype mismatch: {a.indptr.dtype} vs {b.indptr.dtype}"
+        )
+        assert a.indices.dtype == b.indices.dtype, (
+            f"{elem_name}: indices dtype mismatch: {a.indices.dtype} vs {b.indices.dtype}"
+        )
     a = asarray(a)
     assert_equal(b, a, exact=exact, elem_name=elem_name)
 

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -690,10 +690,10 @@ def assert_equal_sparse(
 ):
     if exact and sparse.issparse(b) and hasattr(a, "indptr") and hasattr(b, "indptr"):
         assert a.indptr.dtype == b.indptr.dtype, (
-            f"{elem_name}: indptr dtype mismatch: {a.indptr.dtype} vs {b.indptr.dtype}"
+            f"{elem_name}: indptr dtype mismatch"
         )
         assert a.indices.dtype == b.indices.dtype, (
-            f"{elem_name}: indices dtype mismatch: {a.indices.dtype} vs {b.indices.dtype}"
+            f"{elem_name}: indices dtype mismatch"
         )
     a = asarray(a)
     assert_equal(b, a, exact=exact, elem_name=elem_name)

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -689,9 +689,7 @@ def assert_equal_sparse(
     elem_name: str | None = None,
 ):
     if exact and sparse.issparse(b) and hasattr(a, "indptr") and hasattr(b, "indptr"):
-        assert a.indptr.dtype == b.indptr.dtype, (
-            f"{elem_name}: indptr dtype mismatch"
-        )
+        assert a.indptr.dtype == b.indptr.dtype, f"{elem_name}: indptr dtype mismatch"
         assert a.indices.dtype == b.indices.dtype, (
             f"{elem_name}: indices dtype mismatch"
         )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -253,7 +253,7 @@ def test_assert_equal_sparse_index_dtype(attr):
     """assert_equal(exact=True) should detect indptr/indices dtype mismatches."""
     a = sparse.csr_matrix(np.eye(3))
     b = sparse.csr_matrix(np.eye(3))
-    setattr(b, attr, getattr(b, attr).astype(np.int32))
+    setattr(b, attr, getattr(b, attr).astype(np.int64))
 
     # Non-exact comparison should pass (values are identical)
     assert_equal(a, b, exact=False)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -248,6 +248,21 @@ def test_assert_equal_dask_arrays():
     assert_equal(c, d)
 
 
+def test_assert_equal_sparse_index_dtype():
+    """assert_equal(exact=True) should detect indptr/indices dtype mismatches."""
+    a = sparse.random(10, 10, format="csr", density=0.3)
+    b = a.copy()
+    b.indptr = b.indptr.astype(np.int64)
+    b.indices = b.indices.astype(np.int64)
+
+    # Non-exact comparison should pass (values are identical)
+    assert_equal(a, b, exact=False)
+
+    # Exact comparison should catch the dtype mismatch
+    with pytest.raises(AssertionError, match="indptr dtype mismatch"):
+        assert_equal(a, b, exact=True)
+
+
 def test_assert_equal_dask_sparse_arrays():
     import dask.array as da
     from scipy import sparse

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -248,18 +248,18 @@ def test_assert_equal_dask_arrays():
     assert_equal(c, d)
 
 
-def test_assert_equal_sparse_index_dtype():
+@pytest.mark.parametrize("attr", ["indices", "indptr"])
+def test_assert_equal_sparse_index_dtype(attr):
     """assert_equal(exact=True) should detect indptr/indices dtype mismatches."""
-    a = sparse.random(10, 10, format="csr", density=0.3)
-    b = a.copy()
-    b.indptr = b.indptr.astype(np.int64)
-    b.indices = b.indices.astype(np.int64)
+    a = sparse.csr_matrix(np.eye(3))
+    b = sparse.csr_matrix(np.eye(3))
+    setattr(b, attr, getattr(b, attr).astype(np.int32))
 
     # Non-exact comparison should pass (values are identical)
     assert_equal(a, b, exact=False)
 
     # Exact comparison should catch the dtype mismatch
-    with pytest.raises(AssertionError, match="indptr dtype mismatch"):
+    with pytest.raises(AssertionError, match=attr):
         assert_equal(a, b, exact=True)
 
 


### PR DESCRIPTION
## Summary
- Enhanced `assert_equal` for sparse matrices to check `indptr` and `indices` dtype consistency when `exact=True`
- Previously, sparse matrices were converted to dense via `asarray()` before comparison, silently losing index dtype information (e.g. int32 vs int64 mismatches went undetected)
- Added test verifying the new check catches dtype mismatches

## Changes
- `src/anndata/tests/helpers.py`: Added `indptr`/`indices` dtype assertions in `assert_equal_sparse` before dense conversion, gated on `exact=True` and both operands being sparse
- `tests/test_helpers.py`: Added `test_assert_equal_sparse_index_dtype` — creates CSR matrices with identical values but different index dtypes, verifies exact comparison catches the mismatch

## Test plan
- [x] `pytest tests/test_helpers.py::test_assert_equal_sparse_index_dtype` — passes
- [x] All non-awkward tests in `test_helpers.py` pass (awkward failures are pre-existing env issue)

Fixes #860