### PR TITLE
Backport PR #2358: fix: lazy `index.name` not destroyed

### DIFF
--- a/docs/release-notes/2358.fix.md
+++ b/docs/release-notes/2358.fix.md
@@ -1,0 +1,1 @@
+Ensure the index name along `obs` and `var` are not lost when reading/writing to disk after reading with {func}`~anndata.experimental.read_lazy` {user}`ilan-gold`

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -1275,7 +1275,8 @@ def make_xarray_extension_dtypes_dask(
         )
 
 
-DS_CONCAT_DUMMY_INDEX_NAME = "concat_index"
+DS_CONCAT_DUMMY_INDEX_NAME = "_anndata_concat_index"
+DS_MERGE_DUMMY_INDEX_NAME = "_anndata_merge_index"
 
 
 def concat_dataset2d_on_annot_axis(
@@ -1687,7 +1688,7 @@ def concat(  # noqa: PLR0912, PLR0913, PLR0915
             if a.true_index_dim != a.index_dim:
                 a.index = a.true_index
         annotations_with_only_dask = [
-            a.ds.rename({a.true_index_dim: "merge_index"})
+            a.ds.rename({a.true_index_dim: DS_MERGE_DUMMY_INDEX_NAME})
             for a in annotations_with_only_dask
         ]
         alt_annot = Dataset2D(

--- a/src/anndata/_core/xarray.py
+++ b/src/anndata/_core/xarray.py
@@ -252,6 +252,11 @@ class Dataset2D:
         -------
             :class:`pandas.DataFrame` with index set accordingly.
         """
+        from anndata._core.merge import (
+            DS_CONCAT_DUMMY_INDEX_NAME,
+            DS_MERGE_DUMMY_INDEX_NAME,
+        )
+
         index_key = self.ds.attrs.get("indexing_key", None)
         all_columns = {*self.columns, *([] if index_key is None else [index_key])}
         # https://github.com/pydata/xarray/issues/10419
@@ -267,7 +272,12 @@ class Dataset2D:
             )
         if df.index.name != index_key and index_key is not None:
             df = df.set_index(index_key)
-        df.index.name = None  # matches old AnnData object
+        if df.index.name in {
+            "_index",
+            DS_CONCAT_DUMMY_INDEX_NAME,
+            DS_MERGE_DUMMY_INDEX_NAME,
+        }:
+            df.index.name = None  # matches old AnnData object
         return df
 
     @property

--- a/src/anndata/tests/helpers.py
+++ b/src/anndata/tests/helpers.py
@@ -1115,10 +1115,6 @@ class AccessTrackingStoreBase(LocalStore):
     _accessed_keys: defaultdict[str, list[str]]
 
     def __init__(self, *args, **kwargs):
-        # Needed for zarr v3 to prevent a read-only copy being made
-        # https://github.com/zarr-developers/zarr-python/pull/3156
-        if not is_zarr_v2() and "read_only" not in kwargs:
-            kwargs["read_only"] = True
         super().__init__(*args, **kwargs)
         self._access_count = Counter()
         self._accessed = defaultdict(set)

--- a/tests/lazy/conftest.py
+++ b/tests/lazy/conftest.py
@@ -129,7 +129,8 @@ def adata_remote_with_store_tall_skinny_path(
     orig_path = tmp_path_factory.mktemp(f"orig_{worker_id}.zarr")
     M = 1000
     N = 5
-    obs_names = pd.Index(f"cell{i}" for i in range(M))
+    # One named, one unnamed
+    obs_names = pd.Index((f"cell{i}" for i in range(M)), name="obs_names")
     var_names = pd.Index(f"gene{i}" for i in range(N))
     obs = gen_typed_df(M, obs_names)
     var = gen_typed_df(N, var_names)

--- a/tests/lazy/test_read.py
+++ b/tests/lazy/test_read.py
@@ -95,16 +95,16 @@ def test_access_count_index(
 ) -> None:
     adata_orig = read_zarr(adata_remote_with_store_tall_skinny_path)
 
-    remote_store_tall_skinny.initialize_key_trackers(["obs/_index"])
+    remote_store_tall_skinny.initialize_key_trackers(["obs/obs_names"])
     read_lazy(remote_store_tall_skinny, load_annotation_index=False)
-    remote_store_tall_skinny.assert_access_count("obs/_index", 0)
+    remote_store_tall_skinny.assert_access_count("obs/obs_names", 0)
 
     read_lazy(remote_store_tall_skinny)
     n_chunks = 4
     count_expected = (  # *2 when mask exists
         n_chunks * 2 if adata_orig.obs.index.dtype == "string" else n_chunks
     )
-    remote_store_tall_skinny.assert_access_count("obs/_index", count_expected)
+    remote_store_tall_skinny.assert_access_count("obs/obs_names", count_expected)
 
 
 def test_access_count_dtype(

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -86,7 +86,6 @@ def test_true_index_dim_column_subset(dataset2d, df):
     df_expected = dataset2d[cols].to_memory()
     # account for the fact that we manually set `true_index_dim`
     df.index = df[col]
-    df.index.name = None
     pd.testing.assert_frame_equal(df_expected, df[cols])
 
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
