### PR TITLE
fix!: remove `__delitem__` and `__setitem__` from the `AnnData` object

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -63,7 +63,7 @@ jobs:
         id: changes
         with:
           filters: | # this is intentionally a string
-            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.${{ (contains(needs.check-milestone.outputs.type, '!') && 'breaking') || needs.check-milestone.outputs.type }}.md'
+            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.${{ (contains(github.event.pull_request.title, '!') && 'breaking') || needs.check-milestone.outputs.type }}.md'
       - name: Check if a relevant release fragment is added
         uses: flying-sheep/check@v1
         with:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -63,7 +63,7 @@ jobs:
         id: changes
         with:
           filters: | # this is intentionally a string
-            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.$${{ (contains(needs.check-milestone.outputs.type, '!') && 'breaking') || needs.check-milestone.outputs.type }}.md'
+            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.${{ (contains(needs.check-milestone.outputs.type, '!') && 'breaking') || needs.check-milestone.outputs.type }}.md'
       - name: Check if a relevant release fragment is added
         uses: flying-sheep/check@v1
         with:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -63,7 +63,7 @@ jobs:
         id: changes
         with:
           filters: | # this is intentionally a string
-            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.${{ needs.check-milestone.outputs.type }}.md'
+            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.$${{ (contains(needs.check-milestone.outputs.type, '!') && 'breaking') || needs.check-milestone.outputs.type }}.md'
       - name: Check if a relevant release fragment is added
         uses: flying-sheep/check@v1
         with:

--- a/docs/release-notes/2367.breaking.md
+++ b/docs/release-notes/2367.breaking.md
@@ -1,0 +1,1 @@
+Remove `Anndata.__{set,del}item__` {user}`ilan-gold`

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1023,21 +1023,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
     ) -> tuple[_Index1DNorm | int | np.integer, _Index1DNorm | int | np.integer]:
         return _normalize_indices(index, self.obs_names, self.var_names)
 
-    # TODO: this is not quite complete...
-    def __delitem__(self, index: Index) -> None:
-        obs, var = self._normalize_indices(index)
-        # TODO: does this really work?
-        if not self.isbacked:
-            del self._X[obs, var]
-        else:
-            X = self.file["X"]
-            del X[obs, var]
-            self._set_backed("X", X)
-        if var == slice(None):
-            del self._obs.iloc[obs, :]
-        if obs == slice(None):
-            del self._var.iloc[var, :]
-
     @overload
     def __getitem__(self, index: AdRef) -> Array: ...
     @overload
@@ -1205,19 +1190,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):  # noqa: PLW1641
         adata_subset = self[index].copy()
 
         self._init_as_actual(adata_subset)
-
-    # TODO: Update, possibly remove
-    def __setitem__(self, index: Index, val: float | _XDataType):
-        if self.is_view:
-            msg = "Object is view and cannot be accessed with `[]`."
-            raise ValueError(msg)
-        obs, var = self._normalize_indices(index)
-        if not self.isbacked:
-            self._X[obs, var] = val
-        else:
-            X = self.file["X"]
-            X[obs, var] = val
-            self._set_backed("X", X)
 
     def __len__(self) -> int:
         return self.shape[0]


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
Towards making `backed` mode simpler, we remove these two methods

- [ ] See https://github.com/scverse/anndata/issues/2369
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
