### PR TITLE
fix: `obs` i.e., `axis=0` column joining + `anndata.concat` is undersp

### DIFF
--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -1689,7 +1689,7 @@ def concat(  # noqa: PLR0912, PLR0913, PLR0915
         )
         concat_annot = pd.concat(
             unify_dtypes(annotations_in_memory),
-            join=join,
+            join="outer",
             ignore_index=True,
         )
         concat_annot.index = concat_indices


### PR DESCRIPTION
## Summary

Fixes #2374

Fix for issue #2374.

## Changed Files

- `src/anndata/_core/merge.py`

## Verification

Existing tests pass after this change.

---
*Generated by an automated system. Please review and provide feedback.*
