### PR TITLE
fix: don't repeat deprecation message

### DIFF
--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -371,10 +371,7 @@ def warn_once(msg: str, category: type[Warning]) -> None:
 def deprecation_msg(
     name: LiteralString, new_name: LiteralString, add_msg: LiteralString | None = None
 ) -> LiteralString:
-    msg = (
-        f"Use {new_name} instead of {name}, "
-        f"{name} is deprecated and will be removed in the future."
-    )
+    msg = f"Use {new_name} instead of {name}."
     if add_msg is not None:
         msg += f" {add_msg}"
     return msg


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

The deprecation part of the warning is already present: https://github.com/scverse/scverse-misc/blob/a77c3d6381cf780b3b2f8cada2fca900103107ca/src/scverse_misc/_deprecated.py#L55

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: dev
