### PR TITLE
fix: revert iteration order to make `scanpy`'s upstream tests happy

### DIFF
--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -40,7 +40,6 @@ If we split this object up by clusters of observations, then stack those subsets
     AnnData object with n_obs × n_vars = 700 × 765
         obs: 'bulk_labels', 'n_genes', 'percent_mito', 'n_counts', 'S_score', 'G2M_score', 'phase', 'louvain'
         var: 'n_counts', 'means', 'dispersions', 'dispersions_norm', 'highly_variable'
-        uns: 'pca'
         obsm: 'X_pca', 'X_umap'
         varm: 'PCs'
 

--- a/docs/concatenation.rst
+++ b/docs/concatenation.rst
@@ -26,6 +26,7 @@ Let's start off with an example:
     AnnData object with n_obs × n_vars = 700 × 765
         obs: 'bulk_labels', 'n_genes', 'percent_mito', 'n_counts', 'S_score', 'G2M_score', 'phase', 'louvain'
         var: 'n_counts', 'means', 'dispersions', 'dispersions_norm', 'highly_variable'
+        uns: 'bulk_labels_colors', 'louvain', 'louvain_colors', 'neighbors', 'pca', 'rank_genes_groups'
         obsm: 'X_pca', 'X_umap'
         varm: 'PCs'
         obsp: ...
@@ -39,6 +40,7 @@ If we split this object up by clusters of observations, then stack those subsets
     AnnData object with n_obs × n_vars = 700 × 765
         obs: 'bulk_labels', 'n_genes', 'percent_mito', 'n_counts', 'S_score', 'G2M_score', 'phase', 'louvain'
         var: 'n_counts', 'means', 'dispersions', 'dispersions_norm', 'highly_variable'
+        uns: 'pca'
         obsm: 'X_pca', 'X_umap'
         varm: 'PCs'
 
@@ -164,9 +166,9 @@ First, our example case:
     >>> blobs
     AnnData object with n_obs × n_vars = 640 × 30
         obs: 'blobs'
+        uns: 'pca'
         obsm: 'X_pca'
         varm: 'PCs'
-        uns: 'pca'
 
 Now we will split this object by the categorical `"blobs"` and recombine it to illustrate different merge strategies.
 
@@ -180,9 +182,9 @@ Now we will split this object by the categorical `"blobs"` and recombine it to i
     >>> adatas[0]
     AnnData object with n_obs × n_vars = 128 × 30
         obs: 'blobs'
+        uns: 'pca'
         obsm: 'X_pca', 'qc'
         varm: 'PCs', '0_qc'
-        uns: 'pca'
 
 `adatas` is now a list of datasets with disjoint sets of observations and a common set of variables.
 Each object has had QC metrics computed, with observation-wise metrics stored under `"qc"` in `.obsm`, and variable-wise metrics stored with a unique key for each subset.

--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -448,12 +448,12 @@ def iter_outer(
         "X",
         "obs",
         "var",
+        "uns",
         "obsm",
         "varm",
         "obsp",
         "varp",
         "layers",
-        "uns",
         "raw",
     ]:
         was_closed = adata.isbacked and not adata.file.is_open


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Reverting this so that scanpy's upstream test can work: https://github.com/scverse/scanpy/actions/runs/24469840400/job/71506863689?pr=4038

Otherwise we're going to break a lot of doctests and there's no need really.

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: dev change
