### PR TITLE
feat(utils): expose `STANDARD_SECTIONS` as the canonical section order

### DIFF
--- a/src/anndata/utils.py
+++ b/src/anndata/utils.py
@@ -438,24 +438,38 @@ def module_get_attr_redirect(
     raise AttributeError(msg)
 
 
+#: Canonical order of the standard ``AnnData`` section attributes as used
+#: by :func:`iter_outer`, the text repr and the HTML repr. Exposed as a
+#: public constant so consumers that only need the names (e.g. membership
+#: checks, ordering decisions, introspecting layout without accessing the
+#: data) can reference it directly without driving :func:`iter_outer`,
+#: which reconstructs aligned mappings and reopens the backing file per
+#: yield.
+STANDARD_SECTIONS: tuple[AnnDataElem, ...] = (
+    "X",
+    "obs",
+    "var",
+    "uns",
+    "obsm",
+    "varm",
+    "obsp",
+    "varp",
+    "layers",
+    "raw",
+)
+
+
 def iter_outer(
     adata,
 ) -> Generator[
     tuple[AnnDataElem, AxisStorable | _XDataType | Dataset2D | pd.DataFrame]
 ]:
-    """Iterate over key-value pairs of the parent "elems" like aw, obs, varp etc"""
-    for attr_name in [
-        "X",
-        "obs",
-        "var",
-        "uns",
-        "obsm",
-        "varm",
-        "obsp",
-        "varp",
-        "layers",
-        "raw",
-    ]:
+    """Iterate over key-value pairs of the parent "elems" like ``X``, ``obs``,
+    ``varp`` etc.
+
+    The section order is :data:`STANDARD_SECTIONS`.
+    """
+    for attr_name in STANDARD_SECTIONS:
         was_closed = adata.isbacked and not adata.file.is_open
         yield (attr_name, getattr(adata, attr_name))
         if was_closed:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from itertools import repeat
 
+import numpy as np
 import pandas as pd
 import pytest
 from scipy import sparse
 
 import anndata as ad
 from anndata.tests.helpers import gen_typed_df
-from anndata.utils import make_index_unique
+from anndata.utils import STANDARD_SECTIONS, iter_outer, make_index_unique
 
 
 def test_make_index_unique() -> None:
@@ -59,3 +60,23 @@ def test_adata_unique_indices() -> None:
 
     pd.testing.assert_index_equal(v.obsm["df"].index, v.obs_names)
     pd.testing.assert_index_equal(v.varm["df"].index, v.var_names)
+
+
+def test_standard_sections_is_iter_outer_order() -> None:
+    """``STANDARD_SECTIONS`` must match the section order ``iter_outer`` yields.
+
+    Consumers that need only names (membership tests, layout introspection)
+    rely on this equivalence to avoid the extra cost of actually driving the
+    generator.
+    """
+    adata = ad.AnnData(np.zeros((3, 4)))
+    assert tuple(name for name, _ in iter_outer(adata)) == STANDARD_SECTIONS
+
+
+def test_standard_sections_contents() -> None:
+    """Every name in ``STANDARD_SECTIONS`` is accessible on a plain AnnData."""
+    adata = ad.AnnData(np.zeros((3, 4)))
+    for name in STANDARD_SECTIONS:
+        assert hasattr(adata, name), (
+            f"STANDARD_SECTIONS contains {name!r} but AnnData has no such attribute"
+        )


### PR DESCRIPTION
Expose the canonical section order as a public tuple alongside `iter_outer` so consumers that only need the names can read it directly — no generator, no per-section `getattr`, no backing-file toggling.

Closes #2401.

## What changes

- New `STANDARD_SECTIONS: tuple[AnnDataElem, ...]` in `src/anndata/utils.py` — names the order `iter_outer` currently yields in.
- `iter_outer` now iterates `STANDARD_SECTIONS` instead of an inline list. Yield order, exception semantics, and the backing-file reopen/close behaviour are unchanged.
- Unit tests in `tests/test_utils.py` verify the constant matches the generator's yield order and that every name resolves to an attribute on a plain `AnnData`.

## What does not change

- `iter_outer`'s contract for every existing caller (`AnnData._gen_repr`, `to_memory`, `_reduce`). Same yields, same exception propagation.
- No new flags on `iter_outer`. Callers that want resilience against broken sections (the second motivation in #2401) iterate `STANDARD_SECTIONS` directly with their own per-section `try/except`.

## Usage

```python
from anndata.utils import STANDARD_SECTIONS

# Membership / ordering without driving the iterator or name-only listing
if section in STANDARD_SECTIONS: ...
```

## Design notes

The section names are now declared in two places: the `AnnDataElem` `Literal` in `src/anndata/_types.py` (the type) and `STANDARD_SECTIONS` here (the order used by `iter_outer`). This is a deliberate trade, not a single source of truth. Alternatives considered:

1. **Reorder `AnnDataElem` to match `iter_outer`'s order; drop `STANDARD_SECTIONS`; iterate `get_literal_members(AnnDataElem)`.** This is genuinely one source of truth for both names and order. A grep of the repo shows no consumer of the current declaration order depends on it — `ANNDATA_ELEMS` in `experimental/backed/_io.py` is only used as `**kwargs` into `AnnData(...)` and as `pytest.mark.parametrize` values / `filter(...)` inputs. The cost is that `AnnDataElem`'s member order becomes load-bearing: a stylistic reorder of the `Literal` silently changes `iter_outer`'s yield order (and `AnnData.__repr__` with it). Acceptable if documented with a comment and a test, but it overloads a typing construct with iteration semantics.

2. **Replace `AnnDataElem` with a `StrEnum`.** Also one source of truth, with native iteration. Changes the public shape of `AnnDataElem` (breaks `typing.get_args` consumers) — a larger blast radius than this PR warrants.

3. **This PR: two declarations, consistency pinned by tests.** The `Literal` stays a pure type (set of valid names), the tuple carries order. Names duplicated, but the concerns are decoupled — if `AnnDataElem` ever narrows (e.g., excludes `X`/`raw`/`uns` because they aren't aligned mappings), `iter_outer`'s order doesn't silently break.

Happy to switch to option 1 if reviewers prefer the tighter coupling — it's a one-commit refactor. Flagging the trade rather than burying it in a single line.

## Test plan

- [x] `pytest tests/test_utils.py` — 4 passed (2 pre-existing, 2 new).
- [x] Existing `iter_outer` call sites (`AnnData._gen_repr`, `to_memory`, `_reduce`) continue to work: the refactor is a pure loop-variable substitution.
- [x] CI (`pre-commit.ci` + full test matrix).