### PR TITLE
ci: broaden zarr `UnstableSpecificationWarning` filter to match `Struct(…)` repr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ filterwarnings_when_strict = [
     "default::dask.array.core.PerformanceWarning",
     "default:anndata will no longer support zarr v2:DeprecationWarning",
     "default:Consolidated metadata is:UserWarning",
-    "default:.*Structured:zarr.core.dtype.common.UnstableSpecificationWarning",
+    "default:.*Struct:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:Automatic shard shape inference is experimental",
     "default:Writing zarr v2:UserWarning",


### PR DESCRIPTION
## Summary

zarr `3.1.7.dev44` changed its data-type `repr` from `Structured` to `Struct(fields=…)`, so the existing `.*Structured` message filter in `pyproject.toml` (added in 926667b0) no longer matches. Under `--strict-warnings`, the `UnstableSpecificationWarning` now propagates and fails tests using compound dtypes in `uns` (e.g. `pbmc68k`).

Widening the pattern to `.*Struct` matches both the old (`Structured`) and new (`Struct(fields=…)`) forms, with the category filter (`zarr.core.dtype.common.UnstableSpecificationWarning`) unchanged.

## Why main looks green

Main's last CI run was pinned (by install-time resolution) to `zarr 3.1.7.dev42`, which still used the old repr. Any fresh run on main against the current pre-release reproduces the failure; main is sitting on a stale green.

## Failing CI run (observed on #2236)

- Run: https://github.com/scverse/anndata/actions/runs/24748987690
- Job: [`test (hatch-test.pre, 3.14, --strict-warnings, zarr_io)`](https://github.com/scverse/anndata/actions/runs/24748987690/job/72407593660)
- Failing tests:
  - `tests/test_readwrite.py::test_scanpy_pbmc68k[zarr3]`
  - `tests/test_io_partial.py::test_read_partial_adata[zarr3]`
- Warning text: ``UnstableSpecificationWarning: The data type (Struct(fields=((...)))) does not have a Zarr V3 specification``

## Test plan

- [x] `ci:` prefix → release-note check exempted
- [x] `hatch-test.pre` zarr_io CI passes against current pre-release zarr