### PR TITLE
refactor: simplify usage of AlignedMappingProperty

### DIFF
--- a/src/anndata/_core/aligned_mapping.py
+++ b/src/anndata/_core/aligned_mapping.py
@@ -393,12 +393,12 @@ class AlignedMappingProperty[T: AlignedMapping](property):
     The actual data is stored as `f'_{self.name}'` in the parent object.
     """
 
-    name: str
-    """Name of the attribute in the parent object."""
     cls: type[T]
     """Concrete type that will be constructed."""
     axis: Literal[0, 1] | None = None
     """Axis of the parent to align to."""
+    name: str | None = None
+    """Name of the attribute in the parent object."""
 
     def construct(self, obj: AnnData, *, store: MutableMapping[str, Value]) -> T:
         if self.axis is None:
@@ -413,6 +413,9 @@ class AlignedMappingProperty[T: AlignedMapping](property):
 
         fake.__annotations__ = {"return": self.cls._actual_class | self.cls._view_class}
         return fake
+
+    def __set_name__(self, owner: AnnData, name: str):
+        self.name = name
 
     def __get__(self, obj: None | AnnData, objtype: type | None = None) -> T:
         if obj is None:

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -647,9 +647,7 @@ class AnnData:  # noqa: PLW1641
     def X(self):
         self.X = None
 
-    layers: AlignedMappingProperty[Layers | LayersView] = AlignedMappingProperty(
-        "layers", Layers
-    )
+    layers: AlignedMappingProperty[Layers | LayersView] = AlignedMappingProperty(Layers)
     """\
     Dictionary-like object with values of the same dimensions as :attr:`X`.
 
@@ -865,7 +863,7 @@ class AnnData:  # noqa: PLW1641
         self.uns = OrderedDict()
 
     obsm: AlignedMappingProperty[AxisArrays | AxisArraysView] = AlignedMappingProperty(
-        "obsm", AxisArrays, 0
+        AxisArrays, 0
     )
     """\
     Multi-dimensional annotation of observations
@@ -877,7 +875,7 @@ class AnnData:  # noqa: PLW1641
     """
 
     varm: AlignedMappingProperty[AxisArrays | AxisArraysView] = AlignedMappingProperty(
-        "varm", AxisArrays, 1
+        AxisArrays, 1
     )
     """\
     Multi-dimensional annotation of variables/features
@@ -889,7 +887,7 @@ class AnnData:  # noqa: PLW1641
     """
 
     obsp: AlignedMappingProperty[PairwiseArrays | PairwiseArraysView] = (
-        AlignedMappingProperty("obsp", PairwiseArrays, 0)
+        AlignedMappingProperty(PairwiseArrays, 0)
     )
     """\
     Pairwise annotation of observations,
@@ -901,7 +899,7 @@ class AnnData:  # noqa: PLW1641
     """
 
     varp: AlignedMappingProperty[PairwiseArrays | PairwiseArraysView] = (
-        AlignedMappingProperty("varp", PairwiseArrays, 1)
+        AlignedMappingProperty(PairwiseArrays, 1)
     )
     """\
     Pairwise annotation of variables/features,

--- a/src/anndata/_core/raw.py
+++ b/src/anndata/_core/raw.py
@@ -116,7 +116,7 @@ class Raw:
         return self._n_obs
 
     varm: AlignedMappingProperty[AxisArrays | AxisArraysView] = AlignedMappingProperty(
-        "varm", AxisArrays, 1
+        AxisArrays, 1
     )
 
     @property


### PR DESCRIPTION
use the `__set_name__` method of the descriptor class instead of having to pass the variable name by hand

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added (not necessary, covered by existing tests)

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: not user-visible
