### PR TITLE
fix: disallow `copy` for "backed" objects

### DIFF
--- a/docs/release-notes/2406.fix.md
+++ b/docs/release-notes/2406.fix.md
@@ -1,1 +1,1 @@
-Fix {meth}`anndata.AnnData.copy` so that it provides an informative error when trying to `copy` and object that contains {class}`h5py.Dataset`, {class}`zarr.Array` ,{class}`anndata.abc.CSRDataset`, or {class}`anndata.abc.CSCDataset` {user}`ilan-gold`
+Fix {meth}`anndata.AnnData.copy` so that it provides an informative error when trying to `copy` and object that contains {class}`h5py.Dataset`, {class}`zarr.Array`, {class}`anndata.abc.CSRDataset`, or {class}`anndata.abc.CSCDataset` {user}`ilan-gold`

--- a/docs/release-notes/2406.fix.md
+++ b/docs/release-notes/2406.fix.md
@@ -1,0 +1,1 @@
+Fix {meth}`anndata.AnnData.copy` so that it provides an informative error when trying to `copy` and object that contains {class}`h5py.Dataset`, {class}`zarr.Array` ,{class}`anndata.abc.CSRDataset`, or {class}`anndata.abc.CSCDataset` {user}`ilan-gold`

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from scipy import sparse
     from zarr.storage import StoreLike
 
+    from anndata._types import AnnDataElem
     from anndata.typing import RWAble
 
     from .._types import ReduceFunc
@@ -1412,9 +1413,32 @@ class AnnData:  # noqa: PLW1641
 
         return AnnData(**new)
 
+    def _has_raw_zarr_or_h5_array(self) -> bool:
+        def predicate(
+            elem: RWAble,
+            *,
+            accumulate: bool,
+            attr_name: AnnDataElem | None = None,
+        ):
+            if isinstance(elem, MutableMapping):
+                return accumulate or any(
+                    isinstance(
+                        v, ZarrArray | BaseCompressedSparseDataset | h5py.Dataset
+                    )
+                    for v in elem.values()
+                )
+            return accumulate or isinstance(
+                elem, ZarrArray | BaseCompressedSparseDataset | h5py.Dataset
+            )
+
+        return self._reduce(predicate, init=False)
+
     def copy(self, filename: PathLike[str] | str | None = None) -> AnnData:
         """Full copy, optionally on disk."""
         if not self.isbacked:
+            if self._has_raw_zarr_or_h5_array():
+                msg = "Copy is not implemented for anndatas which have backing raw h5 (not in backed mode) or zarr arrays"
+                raise NotImplementedError(msg)
             if self.is_view and self._has_X():
                 # TODO: How do I unambiguously check if this is a copy?
                 # Subsetting this way means we don’t have to have a view type
@@ -1490,7 +1514,7 @@ class AnnData:  # noqa: PLW1641
             elem: RWAble,
             *,
             accumulate: bool,
-            attr_name: str | None = None,  # TODO: type
+            attr_name: AnnDataElem | None = None,
         ):
             if elem is None:
                 return accumulate

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -42,6 +42,47 @@ adata_sparse = AnnData(
 )
 
 
+@pytest.fixture(params=["zarr", "h5ad"], scope="session")
+def diskfmt(request) -> Literal["zarr", "h5ad"]:
+    return request.param
+
+
+@pytest.fixture(
+    params=[adata_sparse, adata_dense], ids=["sparse", "dense"], scope="session"
+)
+def adata(request) -> AnnData:
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def adata_on_disk(
+    diskfmt: Literal["h5ad", "zarr"],
+    adata: AnnData,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    path = (
+        tmp_path_factory.mktemp("disk_backed")
+        / f"{'sparse' if adata is adata_sparse else 'dense'}.{diskfmt}"
+    )
+    getattr(adata, f"write_{diskfmt}")(path)
+    return path
+
+
+@pytest.mark.parametrize("elem_name", ["X", "obsm", "layers"])
+def test_cant_copy_disk_backed(
+    adata_on_disk: Path, elem_name: Literal["X", "obsm", "layers"]
+):
+    is_sparse = "sparse" in str(adata_on_disk)
+    is_zarr = adata_on_disk.suffix == ".zarr"
+    root = (zarr.open if is_zarr else h5py.File)(adata_on_disk)
+    X = ad.io.sparse_dataset(root["X"]) if is_sparse else root["X"]
+    adata = AnnData(**{elem_name: (X if elem_name == "X" else {"X": X})})
+    with pytest.raises(NotImplementedError, match=r"Copy is not implemented"):
+        adata.copy()
+    if not is_zarr:
+        root.close()
+
+
 def test_creation():
     AnnData(np.array([[1, 2], [3, 4]]))
     AnnData(np.array([[1, 2], [3, 4]]), {}, {})


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

You could argue that taking a `filename` keyword should trigger a copy even in this case, but the problem is how we "reconstitute the object." We would have to track _which_ elements were "backed" and reopen them identically, non-trivial.  Furthermore, this function wraps such trivial functionality for `backed` mode (as it exists now), that I would argue we shouldn't be encoding this behavior anyway.

In any case, this is a bug since you can't copy zarr/h5py objects.

- [x] Continuing with #2369
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
