### PR TITLE
refactor: allow multi-indexed backed mode

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -283,12 +283,6 @@ class AnnData:  # noqa: PLW1641
         oidx: _Index1DNorm | int | np.integer,
         vidx: _Index1DNorm | int | np.integer,
     ):
-        if adata_ref.isbacked and adata_ref.is_view:
-            msg = (
-                "Currently, you cannot index repeatedly into a backed AnnData, "
-                "that is, you cannot make a view of a view."
-            )
-            raise ValueError(msg)
         self._is_view = True
         if isinstance(oidx, int | np.integer):
             if not (-adata_ref.n_obs <= oidx < adata_ref.n_obs):

--- a/tests/test_backed_dense.py
+++ b/tests/test_backed_dense.py
@@ -74,13 +74,19 @@ def test_create_delete(
         del getattr(adata, attr)["a"]
 
 
-def test_assign_x_subset(file: h5py.File | zarr.Group):
+@pytest.mark.parametrize(
+    "num_indexing_ops", [1, 2], ids=["single_index", "double_index"]
+)
+def test_assign_x_subset(file: h5py.File | zarr.Group, num_indexing_ops: Literal[1, 2]):
     x = np.ones((10, 10))
     write_elem(file, "a", x)
 
     adata = AnnData(file["a"])
-
-    view = adata[3:7, 6:8]
+    if num_indexing_ops == 1:
+        view = adata[3:7, 6:8]
+    else:
+        view = adata[0:8, 0:8]
+        view = view[3:7, 6:8]
     view.X = np.zeros((4, 2))
 
     expected = x.copy()

--- a/tests/test_backed_dense.py
+++ b/tests/test_backed_dense.py
@@ -83,10 +83,10 @@ def test_assign_x_subset(file: h5py.File | zarr.Group, num_indexing_ops: Literal
 
     adata = AnnData(file["a"])
     if num_indexing_ops == 1:
-        view = adata[3:7, 6:8]
+        view = adata[3:7, 6:8]  # (3 : 7-3=4), (6 : 8-6=2)
     else:
-        view = adata[0:8, 0:8]
-        view = view[3:7, 6:8]
+        view = adata[2:8, 1:8]  # first a wider window …
+        view = view[1:5, 5:7]  # (2+1=3 : 5-1=4), (1+5=6 : 7-5=2)
     view.X = np.zeros((4, 2))
 
     expected = x.copy()

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -290,10 +290,10 @@ def test_to_memory_full(
 
 
 def test_double_index(adata: ad.AnnData, backing_h5ad: Path):
+    adata_mem = adata.to_memory(copy=True)
+    adata_mem.strings_to_categoricals()
     adata.filename = backing_h5ad
-    with pytest.raises(ValueError, match=r"cannot make a view of a view"):
-        # no view of view of backed object currently
-        adata[:2][:, 0]
+    assert_equal(adata[:2][:, [0, 2]].to_memory(), adata_mem[:2][:, [0, 2]])
 
     # close backing file
     adata.write()

--- a/tests/test_backed_sparse.py
+++ b/tests/test_backed_sparse.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Literal
@@ -488,6 +489,7 @@ def width_idx_kinds(
     ],
     ids=["sparse_dataset", "read_elem_lazy"],
 )
+@pytest.mark.parametrize("read_data", [True, False], ids=["read", "no_read"])
 def test_data_access(
     tmp_path: Path,
     sparse_format: Callable[[ArrayLike], CSMatrix],
@@ -495,12 +497,16 @@ def test_data_access(
     idx_min: Idx,
     exp: list[str],
     open_func: Callable[[ZarrGroup], CSRDataset | CSCDataset | DaskArray],
-    zarr_metadata_key,
-    zarr_separator,
+    zarr_metadata_key: str,
+    zarr_separator: str,
+    *,
+    read_data: bool,
 ):
     exp = [
         e.format(zarr_metadata_key=zarr_metadata_key, zarr_separator=zarr_separator)
         for e in exp
+        if ((is_data := (len(re.findall(r"/\d(?!\d)", e)) == 1)) and read_data)
+        or (not is_data)
     ]
     path = tmp_path / "test.zarr"
     a = sparse_format(np.eye(10, 10))
@@ -519,8 +525,13 @@ def test_data_access(
     store.initialize_key_trackers(["X/data"])
     f = zarr.open_group(store, mode="r")
     a_disk = AnnData(X=open_func(f["X"]))
-    subset = a_disk[idx_maj, idx_min] if a.format == "csr" else a_disk[idx_min, idx_maj]
-    if isinstance(subset.X, DaskArray):
+    subset = (
+        a_disk[idx_maj, :][:, idx_min]
+        if a.format == "csr"
+        else a_disk[idx_min, :][:, idx_maj]
+    )
+    # Accessing X reads data if backed, otherwise call compute
+    if read_data and isinstance(subset.X, DaskArray):
         subset.X.compute(scheduler="single-threaded")
     # zarr v2 fetches all and not just metadata for that node in 3.X.X python package
     # TODO: https://github.com/zarr-developers/zarr-python/discussions/2760


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

This one I don't fully get.  All of our views are lazy so why would multiple indexing be bad? I even added a test to check specifically that we're not doing "too many" disk accesses if we index multiple times but don't "access" `X`.  Am I missing something? @ivirshup perhaps? Maybe this was for writing back to the store?

Does this need more tests?

- [x] For #2369 part 1
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: I don't think this needs a note given that the operation works on "normal" non-backed zarr/hdf5 objects (see the altered test in `test_backed_sparse.py` for evidence of this fact)
