### PR TITLE
fix: benchmark timeout for too much outer joins on concat

### DIFF
--- a/benchmarks/benchmarks/sparse_dataset.py
+++ b/benchmarks/benchmarks/sparse_dataset.py
@@ -113,7 +113,7 @@ class SparseCSRDaskConcat:
                 ),
                 X=read_elem_lazy(self.group["X"]),
             )
-            for i in range(10)
+            for i in range(5)
         ]
 
     def time_concat(self, join: Literal["inner", "outer"], fill_value: Literal[0, -1]):

--- a/benchmarks/benchmarks/sparse_dataset.py
+++ b/benchmarks/benchmarks/sparse_dataset.py
@@ -107,7 +107,7 @@ class SparseCSRDaskConcat:
             AnnData(
                 var=pd.DataFrame(
                     index=[
-                        f"gene_{j}{f'_{i}' if (j % 100 == 0) else ''}"
+                        f"gene_{j}{f'_{i}' if (j % 500 == 0) else ''}"
                         for j in range(10_000)
                     ]
                 ),


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
See https://github.com/scverse/anndata/actions/runs/24782425669/job/72516966006?pr=2407 where we were timing out

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: dev change
