### PR TITLE
fix: `unwriteable` was still `can_write` in all but name

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1478,7 +1478,7 @@ class AnnData:  # noqa: PLW1641
             accumulate = func(attr, accumulate=accumulate, attr_name=attr_name)
         return accumulate
 
-    def unwriteable(self, *, store_type: Literal["h5", "zarr"] | None) -> bool:
+    def unwriteable(self, *, store_type: Literal["h5", "zarr"] | None = None) -> bool:
         """Whether or not an `AnnData` object can be written to disk for a given store type.
 
         Parameters
@@ -1511,25 +1511,28 @@ class AnnData:  # noqa: PLW1641
             if elem is None:
                 return accumulate
             if isinstance(elem, AnnData):
-                return accumulate and elem.unwriteable(store_type=store_type)
+                return accumulate or elem.unwriteable(store_type=store_type)
             if isinstance(elem, pd.Categorical):
-                return accumulate and predicate(elem.categories, accumulate=accumulate)
+                return accumulate or predicate(elem.categories, accumulate=accumulate)
             if isinstance(elem, pd.Series | pd.Index):
                 # matches behavior in methods.py
-                return accumulate and predicate(elem._values, accumulate=accumulate)
+                return accumulate or predicate(elem._values, accumulate=accumulate)
             if isinstance(elem, AwkArray):
                 import awkward as ak
 
                 container = ak.to_buffers(ak.to_packed(elem))
-                return accumulate and all(
+                return accumulate or any(
                     predicate(v, accumulate=accumulate) for v in container[2].values()
                 )
             if attr_name == "raw":
-                accumulate = accumulate and type(elem.X) in writeable_elems
-                return accumulate and all(
-                    predicate(e[attr], accumulate=accumulate)
-                    for e in [elem.var, elem.varm]
-                    for attr in e
+                return (
+                    accumulate
+                    or any(
+                        predicate(e[attr], accumulate=accumulate)
+                        for e in [elem.var, elem.varm]
+                        for attr in e
+                    )
+                    or predicate(elem.X, accumulate=accumulate)
                 )
             if attr_name in {
                 "obs",
@@ -1541,12 +1544,16 @@ class AnnData:  # noqa: PLW1641
                 "obsp",
                 "uns",
             } or isinstance(elem, pd.DataFrame | XDataset | MutableMapping):
-                return accumulate and all(
+                accumulate = accumulate or any(
                     predicate(elem[k], accumulate=accumulate) for k in elem
                 )
-            return accumulate and type(elem) in writeable_elems
+                if isinstance(elem, pd.DataFrame):
+                    return accumulate or predicate(elem.index, accumulate=accumulate)
+                return accumulate
 
-        return self._reduce(predicate, init=True)
+            return accumulate or type(elem) not in writeable_elems
+
+        return self._reduce(predicate, init=False)
 
     def var_names_make_unique(self, join: str = "-") -> None:
         # Important to go through the setter so obsm dataframes are updated too

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -22,6 +22,7 @@ from scipy.sparse import issparse
 from scverse_misc import Deprecation, deprecated
 
 from anndata._warnings import ImplicitModificationWarning
+from anndata.types import SupportsArrayApi
 
 from .. import utils
 from .._settings import settings
@@ -1550,8 +1551,11 @@ class AnnData:  # noqa: PLW1641
                 if isinstance(elem, pd.DataFrame):
                     return accumulate or predicate(elem.index, accumulate=accumulate)
                 return accumulate
-
-            return accumulate or type(elem) not in writeable_elems
+            return (
+                (accumulate or type(elem) not in writeable_elems)
+                if not isinstance(elem, SupportsArrayApi)
+                else accumulate
+            )
 
         return self._reduce(predicate, init=False)
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -62,6 +62,7 @@ def test_write_error_info(diskfmt, tmp_path):
 
     # Assuming we don't define a writer for tuples
     a = ad.AnnData(uns={"a": {"b": {"c": (1, 2, 3)}}})
+    assert a.unwriteable()
 
     with pytest.raises(
         IORegistryError, match=r"Error raised while writing key 'c'.*to /uns/a/b"

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -130,7 +130,7 @@ def test_can_write(
     rw: tuple[ad.AnnData, ad.AnnData], store_type: Literal["h5", "zarr"] | None
 ):
     adata, _ = rw
-    assert adata.unwriteable(store_type=store_type)
+    assert not adata.unwriteable(store_type=store_type)
 
 
 @pytest.mark.parametrize("store_type", ["h5", "zarr", None])
@@ -143,7 +143,7 @@ def test_can_not_write_bad_categorical(
         [i % 2 for i in range(adata.shape[1])],
         categories=pd.arrays.IntervalArray.from_tuples([(0, 10), (20, 30)]),
     )
-    assert not adata.unwriteable(store_type=store_type)
+    assert adata.unwriteable(store_type=store_type)
 
 
 @pytest.mark.parametrize("store_type", ["h5", "zarr", None])
@@ -169,7 +169,7 @@ def test_can_not_write_with_custom_array(
     getter(adata.uns["adata"] if should_nest else adata)["arrow_array"] = (
         pd.arrays.ArrowExtensionArray(pa.array([{"x": 1, "y": True}] * adata.shape[1]))
     )
-    assert not adata.unwriteable(store_type=store_type)
+    assert adata.unwriteable(store_type=store_type)
 
 
 @pytest.mark.parametrize("typ", ARRAY_TYPES)
@@ -346,6 +346,8 @@ def test_readwrite_equivalent_h5ad_zarr(tmp_path: Path, typ) -> None:
 
     M, N = 100, 101
     adata = gen_adata((M, N), X_type=typ, **GEN_ADATA_NO_XARRAY_ARGS)
+    assert not adata.unwriteable()
+
     adata.raw = adata.copy()
 
     adata.write_h5ad(h5ad_pth)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->
When I made the change, I just `ctrl` + F'ed this, but forgot that we inverted the semantics from `can_write`. We also were never checking the index, which I discovered in #2379 

- [ ] Closes #
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: Unreleased feature fix
