### PR TITLE
Backport PR #2419: fix: `anndata.experimental.read_lazy` index fixes (checking uniqueness + unnecessary dask loading)

### DIFF
--- a/docs/release-notes/2419.fix.md
+++ b/docs/release-notes/2419.fix.md
@@ -1,0 +1,1 @@
+Don't force {attr}`anndata.settings.check_uniqueness` if user loads an annotation index with {func}`anndata.experimental.read_lazy` {user}`ilan-gold`.

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -24,6 +24,7 @@ from anndata.compat import (
     XVariable,
     ZarrArray,
     ZarrGroup,
+    pandas_as_str,
 )
 
 from .registry import _LAZY_REGISTRY, IOSpec, read_elem
@@ -292,12 +293,11 @@ def read_dataframe(
     use_range_index: bool = False,
     chunks: tuple[int] | None = None,
 ) -> Dataset2D:
-    from xarray.core.indexing import BasicIndexer
-
-    from ...experimental.backed._lazy_arrays import MaskedArray
-
+    # going through dask for reading into memory the index doesn't make sense, hence the ternary.
     elem_dict = {
         k: _reader.read_elem(elem[k], chunks=chunks)
+        if (use_range_index and k == elem.attrs["_index"]) or k != elem.attrs["_index"]
+        else pandas_as_str(pd.Index(ad.io.read_elem(elem[k])))
         for k in [*elem.attrs["column-order"], elem.attrs["_index"]]
     }
     # If we use a range index, the coord axis needs to have the special dim name
@@ -305,12 +305,7 @@ def read_dataframe(
     if not use_range_index:
         dim_name = elem.attrs["_index"]
         # no sense in reading this in multiple times since xarray requires an in-memory index
-        if isinstance(elem_dict[dim_name], DaskArray):
-            index = elem_dict[dim_name].compute()
-        elif isinstance(elem_dict[dim_name], MaskedArray):
-            index = elem_dict[dim_name][BasicIndexer((slice(None),))]
-        else:
-            raise NotImplementedError()
+        index = elem_dict[dim_name]
     else:
         dim_name = DUMMY_RANGE_INDEX_KEY
         index = pd.RangeIndex(len(elem_dict[elem.attrs["_index"]])).astype("str")

--- a/src/anndata/experimental/backed/_io.py
+++ b/src/anndata/experimental/backed/_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 import warnings
+from contextlib import nullcontext
 from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -161,7 +162,11 @@ def read_lazy(
             }
         return func(elem)
 
-    with settings.override(check_uniqueness=load_annotation_index):
+    with (
+        settings.override(check_uniqueness=False)
+        if not load_annotation_index
+        else nullcontext()
+    ):
         adata: AnnData = read_dispatched(f, callback=callback)
     if is_store_arg_h5_path and not is_store_arg_h5_store:
         adata.file = AnnDataFileManager(adata, file_obj=f)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
