### PR TITLE
fix: correct IO types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,4 +25,6 @@
     ],
     "python.terminal.activateEnvironment": true,
     "python.analysis.include": ["src/**/*", "ci/scripts/**/*", "tests/**/*"],
+    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
+    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
 }

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -196,10 +196,7 @@ def resolve_chunks(
 # In the long run, it might be good to figure out what exactly is going on here but for now, this will do.
 @_LAZY_REGISTRY.register_read(H5Array, IOSpec("string-array", "0.2.0"))
 def read_h5_string_array(
-    elem: H5Array,
-    *,
-    _reader: LazyReader,
-    chunks: tuple[int] | None = None,
+    elem: H5Array, *, _reader: LazyReader, chunks: tuple[int, ...] | None = None
 ) -> DaskArray:
     import dask.array as da
 
@@ -243,7 +240,7 @@ def read_zarr_array(
 def _gen_xarray_dict_iterator_from_elems(
     elem_dict: dict[str, LazyDataStructures],
     dim_name: str,
-    index: np.NDArray,
+    index: np.typing.NDArray,
 ) -> Generator[tuple[str, XVariable], None, None]:
     from anndata.experimental.backed._lazy_arrays import CategoricalArray, MaskedArray
 
@@ -284,7 +281,7 @@ def read_dataframe(
     *,
     _reader: LazyReader,
     use_range_index: bool = False,
-    chunks: tuple[int] | None = None,
+    chunks: tuple[int, ...] | None = None,
 ) -> Dataset2D:
     # going through dask for reading into memory the index doesn't make sense, hence the ternary.
     elem_dict = {
@@ -330,8 +327,11 @@ def read_categorical(
     elem: H5Group | ZarrGroup,
     *,
     _reader: LazyReader,
+    chunks: tuple[int, ...] | None = None,
 ) -> CategoricalArray:
     from anndata.experimental.backed._lazy_arrays import CategoricalArray
+
+    del chunks  # ignored when reading groups
 
     base_path_or_zarr_group = (
         Path(filename(elem)) if isinstance(elem, H5Group) else elem
@@ -354,8 +354,11 @@ def read_nullable(
         "nullable-integer", "nullable-boolean", "nullable-string-array"
     ],
     _reader: LazyReader,
+    chunks: tuple[int, ...] | None = None,
 ) -> MaskedArray:
     from anndata.experimental.backed._lazy_arrays import MaskedArray
+
+    del chunks  # ignored when reading groups
 
     base_path_or_zarr_group = (
         Path(filename(elem)) if isinstance(elem, H5Group) else elem

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -291,10 +291,7 @@ def write_anndata(
             if sub_key == "layers":
                 if None in elem:
                     _writer.write_elem(
-                        g,
-                        "X",
-                        elem[None],
-                        dataset_kwargs=dataset_kwargs,
+                        g, "X", elem[None], dataset_kwargs=dataset_kwargs
                     )
                 elem = {k: v for k, v in elem.items() if k is not None}
             _writer.write_elem(

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -5,7 +5,7 @@ from copy import copy
 from functools import partial
 from itertools import product
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import h5py
 import numpy as np
@@ -45,7 +45,7 @@ from ...utils import iter_outer, warn
 from .registry import _REGISTRY, IOSpec, read_elem, read_elem_partial
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
     from os import PathLike
     from typing import Any, Literal
 
@@ -1210,14 +1210,14 @@ for store_type, array_type in product([H5Group, ZarrGroup], PANDAS_STRING_ARRAY_
     )(write_nullable)
 
 
+class _BaseMaskedArray(Protocol):
+    def __call__(
+        self, values: NDArray[np.number], /, *, mask: NDArray[np.bool_]
+    ) -> pd.api.extensions.ExtensionArray: ...
+
+
 def _read_nullable(
-    elem: _GroupStorageType,
-    *,
-    _reader: Reader,
-    # BaseMaskedArray
-    array_type: Callable[
-        [NDArray[np.number], NDArray[np.bool_]], pd.api.extensions.ExtensionArray
-    ],
+    elem: _GroupStorageType, *, _reader: Reader, array_type: _BaseMaskedArray
 ) -> pd.api.extensions.ExtensionArray:
     return array_type(
         _reader.read_elem(elem["values"]),

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -438,7 +438,7 @@ def write_basic(
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ):
     """Write methods which underlying library handles natively."""
-    dataset_kwargs = dataset_kwargs.copy()
+    dataset_kwargs = dict(dataset_kwargs)
     dtype = dataset_kwargs.pop("dtype", elem.dtype)
     if isinstance(f, H5Group):
         f.create_dataset(k, data=elem, shape=elem.shape, dtype=dtype, **dataset_kwargs)
@@ -520,7 +520,7 @@ def write_basic_dask_dask_dense(
 ):
     import dask.array as da
 
-    dataset_kwargs = dataset_kwargs.copy()
+    dataset_kwargs = dict(dataset_kwargs)
     is_h5 = isinstance(f, H5Group)
     if not is_h5:
         dataset_kwargs = zarr_v3_compressor_compat(dataset_kwargs)
@@ -602,7 +602,7 @@ def write_vlen_string_array_zarr(
     _writer: Writer,
     dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ):
-    dataset_kwargs = dataset_kwargs.copy()
+    dataset_kwargs = dict(dataset_kwargs)
     dataset_kwargs = zarr_v3_compressor_compat(dataset_kwargs)
     dtype = VariableLengthUTF8()
     filters, fill_value = None, None
@@ -674,7 +674,7 @@ def write_recarray_zarr(
     from anndata.compat import _to_fixed_length_strings
 
     elem = _to_fixed_length_strings(elem)
-    dataset_kwargs = dataset_kwargs.copy()
+    dataset_kwargs = dict(dataset_kwargs)
     dataset_kwargs = zarr_v3_compressor_compat(dataset_kwargs)
     # https://github.com/zarr-developers/zarr-python/issues/3546
     # if "shards" not in dataset_kwargs and ad.settings.auto_shard_zarr_v3:
@@ -1377,7 +1377,7 @@ def write_string(
     _writer: Writer,
     dataset_kwargs: Mapping[str, Any],
 ):
-    dataset_kwargs = dataset_kwargs.copy()
+    dataset_kwargs = dict(dataset_kwargs)
     dataset_kwargs.pop("compression", None)
     dataset_kwargs.pop("compression_opts", None)
     f.create_dataset(

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -112,13 +112,13 @@ class IORegistry[RI: (_ReadInternal, _ReadLazyInternal), R: (Read, ReadLazy)]:
         self.write = {}
         self.write_specs = {}
 
-    def register_write[T](
+    def register_write[S: StorageType, T: RWAble](
         self,
         dest_type: type,
         src_type: type | tuple[type, str],
         spec: IOSpec | Mapping[str, str],
         modifiers: Iterable[str] = frozenset(),
-    ) -> Callable[[_WriteInternal[T]], _WriteInternal[T]]:
+    ) -> Callable[[_WriteInternal[S, T]], _WriteInternal[S, T]]:
         spec = proc_spec(spec)
         modifiers = frozenset(modifiers)
 
@@ -134,7 +134,7 @@ class IORegistry[RI: (_ReadInternal, _ReadLazyInternal), R: (Read, ReadLazy)]:
         else:
             self.write_specs[src_type] = spec
 
-        def _register(func: _WriteInternal[T]) -> _WriteInternal[T]:
+        def _register(func: _WriteInternal[S, T]) -> _WriteInternal[S, T]:
             self.write[(dest_type, src_type, modifiers)] = write_spec(spec)(func)
             return func
 

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -312,7 +312,9 @@ def _read_legacy_raw(
     return raw
 
 
-def zero_dim_array_as_scalar(func: _WriteInternal):
+def zero_dim_array_as_scalar[S: StorageType, T: RWAble](
+    func: _WriteInternal[S, T],
+) -> _WriteInternal[S, T]:
     """\
     A decorator for write_elem implementations of arrays where zero-dimensional arrays need special handling.
     """

--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -35,7 +35,14 @@ else:  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/580
 
 
 __all__ = [
+    "AnnDataElem",
+    "Dataset2DIlocIndexer",
+    "Read",
+    "ReadCallback",
+    "ReadLazy",
     "StorageType",
+    "Write",
+    "WriteCallback",
     "_ArrayStorageType",
     "_GroupStorageType",
     "_ReadInternal",
@@ -52,17 +59,18 @@ type StorageType = _ArrayStorageType | _GroupStorageType
 
 @set_module("anndata.experimental")
 class Dataset2DIlocIndexer(Protocol):
-    def __getitem__(self, idx: Any) -> Dataset2D: ...
+    def __getitem__(self, idx: Any, /) -> Dataset2D: ...
 
 
 class _ReadInternal[S: StorageType, RWAble: typing.RWAble](Protocol):
-    def __call__(self, elem: S, *, _reader: Reader) -> RWAble: ...
+    def __call__(self, elem: S, /, *, _reader: Reader) -> RWAble: ...
 
 
 class _ReadLazyInternal[S: StorageType](Protocol):
     def __call__(
         self,
         elem: S,
+        /,
         *,
         _reader: LazyReader,
         chunks: tuple[int, ...] | None = None,
@@ -71,7 +79,7 @@ class _ReadLazyInternal[S: StorageType](Protocol):
 
 @set_module("anndata.experimental")
 class Read[S: StorageType, RWAble: typing.RWAble](Protocol):
-    def __call__(self, elem: S) -> RWAble:
+    def __call__(self, elem: S, /) -> RWAble:
         """Low-level reading function for an element.
 
         Parameters
@@ -87,7 +95,7 @@ class Read[S: StorageType, RWAble: typing.RWAble](Protocol):
 
 class ReadLazy[S](Protocol):
     def __call__(
-        self, elem: S, *, chunks: tuple[int, ...] | None = None
+        self, elem: S, /, *, chunks: tuple[int, ...] | None = None
     ) -> LazyDataStructures:
         """Low-level reading function for a lazy element.
 
@@ -104,12 +112,13 @@ class ReadLazy[S](Protocol):
         ...
 
 
-class _WriteInternal[RWAble: typing.RWAble](Protocol):
+class _WriteInternal[S: StorageType, RWAble: typing.RWAble](Protocol):
     def __call__(
         self,
-        f: StorageType,
+        f: S,
         k: str,
         v: RWAble,
+        /,
         *,
         _writer: Writer,
         dataset_kwargs: Mapping[str, Any],
@@ -123,6 +132,7 @@ class Write[RWAble: typing.RWAble](Protocol):
         f: StorageType,
         k: str,
         v: RWAble,
+        /,
         *,
         dataset_kwargs: Mapping[str, Any],
     ) -> None:
@@ -228,6 +238,7 @@ class ReduceFunc[T](Protocol):
     def __call__(
         self,
         elem: _XDataType | AxisStorable | DataFrame | XDataset,
+        /,
         *,
         accumulate: T,
         attr_name: AnnDataElem | None,


### PR DESCRIPTION
before I start working on it, this stops the `_io/specs/methods.py` module from lighting up like a christmas tree.

“positional or keyword” arguments can take the role of either positional-only or keyword-only arguments in the protocol, which is how the `@_REGISTRY.register_write`-decorated functions still typecheck.

- [x] Release note not necessary because: types-only fix
