### PR TITLE
chore: switch `disallow_forward_slash_in_h5ad` default to `True`

### DIFF
--- a/docs/release-notes/0.12.3.md
+++ b/docs/release-notes/0.12.3.md
@@ -10,5 +10,7 @@
 - Deprecate `__version__` and use standard {func}`~importlib.metadata.version` API {user}`flying-sheep` ({pr}`1318`)
 - Allow writing of views of {class}`dask.array.Array` {user}`ilan-gold` ({pr}`2084`)
 - Enable writing of views of {class}`~anndata.AnnData` in backed mode {user}`ilan-gold` ({pr}`2092`)
-- Reallow writing of keys in `h5ad` files with forward slashes instead of erroring.  Now a warning will be raised that the behavior will be disallowed in the future.  To enable the new behavior, use {attr}`anndata.settings.disallow_forward_slash_in_h5ad`. {user}`ilan-gold` ({pr}`2097`)
+- Reallow writing of keys in `h5ad` files with forward slashes instead of erroring.
+  Now a warning will be raised that the behavior will be disallowed in the future.
+  To enable the new behavior, use {attr}`anndata.settings.disallow_forward_slash_in_h5ad`. {user}`ilan-gold` ({pr}`2097`)
 - Respect off-axis merge options in {func}`anndata.experimental.concat_on_disk` {user}`ilan-gold` ({pr}`2122`)

--- a/docs/release-notes/2436.chore.md
+++ b/docs/release-notes/2436.chore.md
@@ -1,0 +1,1 @@
+Flip default for {attr}`anndata.settings.disallow_forward_slash_in_h5ad` {user}`flying-sheep`

--- a/docs/release-notes/2436.chore.md
+++ b/docs/release-notes/2436.chore.md
@@ -1,1 +1,2 @@
-Flip default for {attr}`anndata.settings.disallow_forward_slash_in_h5ad` {user}`flying-sheep`
+Flip default for {attr}`anndata.settings.disallow_forward_slash_in_h5ad`.
+Document writing to `k="/"` in {func}`~anndata.io.write_elem` and check `k` more strictly {user}`flying-sheep`

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -28,6 +28,7 @@ from ..utils import iter_outer, warn
 from .specs import read_elem, write_elem
 from .specs.registry import IOSpec, write_spec
 from .utils import (
+    _check_has_no_slash_key,
     _read_legacy_raw,
     idx_chunks_along_axis,
     no_write_dataset_2d,
@@ -86,6 +87,8 @@ def write_h5ad(
         f.attrs.setdefault("encoding-type", "anndata")
         f.attrs.setdefault("encoding-version", "0.1.0")
         for k, elem in iter_outer(adata):
+            _check_has_no_slash_key(k, elem)
+
             if k == "raw":
                 _write_raw(
                     f, adata.raw, as_dense=as_dense, dataset_kwargs=dataset_kwargs

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -139,9 +139,10 @@ def _write_raw(
     if "raw/X" in as_dense and isinstance(
         raw.X, CSMatrix | BaseCompressedSparseDataset
     ):
-        write_sparse_as_dense(f, "raw/X", raw.X, dataset_kwargs=dataset_kwargs)
-        write_elem(f, "raw/var", raw.var, dataset_kwargs=dataset_kwargs)
-        write_elem(f, "raw/varm", dict(raw.varm), dataset_kwargs=dataset_kwargs)
+        g = f.require_group("raw")
+        write_sparse_as_dense(g, "X", raw.X, dataset_kwargs=dataset_kwargs)
+        write_elem(g, "var", raw.var, dataset_kwargs=dataset_kwargs)
+        write_elem(g, "varm", dict(raw.varm), dataset_kwargs=dataset_kwargs)
     elif raw is not None:
         write_elem(f, "raw", raw, dataset_kwargs=dataset_kwargs)
 

--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -20,7 +20,11 @@ from anndata._core import views
 from anndata._core.index import _normalize_indices
 from anndata._core.merge import intersect_keys
 from anndata._core.sparse_dataset import _CSCDataset, _CSRDataset, sparse_dataset
-from anndata._io.utils import check_key, zero_dim_array_as_scalar
+from anndata._io.utils import (
+    _check_has_no_slash_key,
+    check_key,
+    zero_dim_array_as_scalar,
+)
 from anndata._warnings import OldFormatWarning
 from anndata.compat import (
     AwkArray,
@@ -287,19 +291,19 @@ def write_anndata(
 ):
     g = f.require_group(k)
     for sub_key, elem in iter_outer(adata):
-        if not (sub_key == "X" and elem is None):
-            if sub_key == "layers":
-                if None in elem:
-                    _writer.write_elem(
-                        g, "X", elem[None], dataset_kwargs=dataset_kwargs
-                    )
-                elem = {k: v for k, v in elem.items() if k is not None}
-            _writer.write_elem(
-                g,
-                sub_key,
-                dict(elem) if isinstance(elem, MutableMapping) else elem,
-                dataset_kwargs=dataset_kwargs,
-            )
+        if sub_key == "X" and elem is None:
+            continue
+        _check_has_no_slash_key(sub_key, elem)
+        if sub_key == "layers":
+            if None in elem:
+                _writer.write_elem(g, "X", elem[None], dataset_kwargs=dataset_kwargs)
+            elem = {k: v for k, v in elem.items() if k is not None}
+        _writer.write_elem(
+            g,
+            sub_key,
+            dict(elem) if isinstance(elem, MutableMapping) else elem,
+            dataset_kwargs=dataset_kwargs,
+        )
 
 
 @_REGISTRY.register_read(H5Group, IOSpec("anndata", "0.1.0"))

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -364,16 +364,18 @@ class Writer:
 
         from anndata._io.zarr import is_group_consolidated
 
-        # Normalize k to absolute path
-        if not k.startswith("/"):
-            k = str(PurePosixPath("/") / store.name / k)
+        # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
+        if k.startswith(store.name) and k != "/":
+            k = str(PurePosixPath(k).relative_to(store.name))
 
-        # len() may be 0 (`.`) or 1 (`some-key`)
-        if len(PurePosixPath(k).relative_to(store.name).parts) > 1:
+        if "/" in k and k != "/":
             if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)
-            pass  # TODO: escape forward slashes  # noqa: PIE790
+            warn(
+                "Forward slashes will be written differently in a future anndata version",
+                UserWarning,
+            )
 
         if isinstance(store, h5py.File):
             store = store["/"]

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -364,41 +364,47 @@ class Writer:
 
         from anndata._io.zarr import is_group_consolidated
 
-        # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
-        if k.startswith(store.name) and k != "/":
-            k = str(PurePosixPath(k).relative_to(store.name))
-
-        # Apart from this code, we also ban keys containing slashes in `write_adata`/`write_h5ad`
-        # for AnnData elements other than `obs`, `var`, and `uns`.
-        if "/" in k and k != "/":
-            if isinstance(store, ZarrGroup) or settings.disallow_forward_slash_in_h5ad:
-                msg = f"Forward slashes are not allowed in keys in {type(store)}"
-                raise ValueError(msg)
-            msg = "Forward slashes will be written differently in a future anndata version"
-            warn(msg, FutureWarning)
-
         if isinstance(store, h5py.File):
             store = store["/"]
-
-        dest_type = type(store)
-
-        if is_group_consolidated(store, strict=False):
+        elif is_group_consolidated(store, strict=False):
             msg = "Cannot overwrite/edit a store with consolidated metadata"
             raise ValueError(msg)
+
         if k == "/":
+            if store.name != "/":
+                msg = f"'/' is not in the subpath of {store.name!r}"
+                raise ValueError(msg)
+
             if isinstance(store, ZarrGroup):
                 from zarr.core.sync import sync
 
                 sync(store.store.clear())
             else:
                 store.clear()
-        elif k in store:
-            del store[k]
+        else:
+            # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
+            if k.startswith("/"):
+                k = str(PurePosixPath(k).relative_to(store.name, walk_up=False))
+
+            # Apart from this code, we also ban keys containing slashes in `write_adata`/`write_h5ad`
+            # for AnnData elements other than `obs`, `var`, and `uns`.
+            if "/" in k:
+                if (
+                    isinstance(store, ZarrGroup)
+                    or settings.disallow_forward_slash_in_h5ad
+                ):
+                    msg = f"Forward slashes are not allowed in keys in {type(store)}"
+                    raise ValueError(msg)
+                msg = "Forward slashes will be written differently in a future anndata version"
+                warn(msg, FutureWarning)
+
+            if k in store:
+                del store[k]
 
         # Normalize array-API (e.g., JAX/CuPy) even if not AnnData
         elem = normalize_nested(elem)
 
-        write_func = self.find_write_func(dest_type, elem, modifiers)
+        write_func = self.find_write_func(type(store), elem, modifiers)
 
         if self.callback is None:
             return write_func(store, k, elem, dataset_kwargs=dataset_kwargs)

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -365,8 +365,8 @@ class Writer:
         from anndata._io.zarr import is_group_consolidated
 
         # Normalize k to absolute path
-        if not k.startswith(store.name):
-            k = str(PurePosixPath(store.name) / k)
+        if not k.startswith("/"):
+            k = str(PurePosixPath("/") / store.name / k)
 
         # len() may be 0 (`.`) or 1 (`some-key`)
         if len(PurePosixPath(k).relative_to(store.name).parts) > 1:

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -521,8 +521,9 @@ def write_elem(
     store
         The group to write to.
     k
-        The key to write to in the group. Note that absolute paths will be written
-        from the root.
+        The key to write into the group.
+        If the group is the root, set `k` to `"/"` to write directly into it.
+        Passing an absolute path referring to a direct child of the group is also allowed.
     elem
         The element to write. Typically an in-memory object, e.g. an AnnData, pandas
         dataframe, scipy sparse matrix, etc.

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -358,18 +358,13 @@ class Writer:
         dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
         modifiers: frozenset[str] = frozenset(),
     ):
-        from pathlib import PurePosixPath
 
         import h5py
 
         from anndata._io.zarr import is_group_consolidated
 
-        # Normalize k to absolute path
-        if isinstance(store, h5py.Group) and not k.startswith("/"):
-            k = str(PurePosixPath(store.name) / k)
-
-        parts = PurePosixPath(k).relative_to(store.name).parts
-        if len(parts) > 1:
+        # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
+        if "/" in k.rsplit(store.name, maxsplit=1)[-1][1:]:
             if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -364,26 +364,23 @@ class Writer:
 
         from anndata._io.zarr import is_group_consolidated
 
-        # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
-        is_zarr_group = isinstance(store, ZarrGroup)
-        if "/" in k.rsplit(store.name, maxsplit=1)[-1][1:]:
-            if is_zarr_group or settings.disallow_forward_slash_in_h5ad:
+        # Normalize k to absolute path
+        if isinstance(store, h5py.Group) and not k.startswith("/"):
+            k = str(PurePosixPath(store.name) / k)
+
+        parts = PurePosixPath(k).relative_to(store.name).parts
+        if len(parts) > 1:
+            if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)
-            else:
-                msg = "Forward slashes will be disallowed in h5 stores in the next minor release"
-                warn(msg, FutureWarning)
+            pass  # TODO: escape forward slashes  # noqa: PIE790
 
         if isinstance(store, h5py.File):
             store = store["/"]
 
         dest_type = type(store)
 
-        # Normalize k to absolute path
-        if isinstance(store, h5py.Group) and not PurePosixPath(k).is_absolute():
-            k = str(PurePosixPath(store.name) / k)
-        is_consolidated = is_group_consolidated(store) if is_zarr_group else False
-        if is_consolidated:
+        if is_group_consolidated(store, strict=False):
             msg = "Cannot overwrite/edit a store with consolidated metadata"
             raise ValueError(msg)
         if k == "/":

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -372,10 +372,8 @@ class Writer:
             if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)
-            warn(
-                "Forward slashes will be written differently in a future anndata version",
-                UserWarning,
-            )
+            msg = "Forward slashes will be written differently in a future anndata version"
+            warn(msg, FutureWarning)
 
         if isinstance(store, h5py.File):
             store = store["/"]

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -368,8 +368,10 @@ class Writer:
         if k.startswith(store.name) and k != "/":
             k = str(PurePosixPath(k).relative_to(store.name))
 
+        # Apart from this code, we also ban keys containing slashes in `write_adata`/`write_h5ad`
+        # for AnnData elements other than `obs`, `var`, and `uns`.
         if "/" in k and k != "/":
-            if settings.disallow_forward_slash_in_h5ad:
+            if isinstance(store, ZarrGroup) or settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)
             msg = "Forward slashes will be written differently in a future anndata version"

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -364,11 +364,12 @@ class Writer:
 
         from anndata._io.zarr import is_group_consolidated
 
-        # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
-        if k.startswith(store.name) and k != "/":
-            k = str(PurePosixPath(k).relative_to(store.name))
+        # Normalize k to absolute path
+        if not k.startswith(store.name):
+            k = str(PurePosixPath(store.name) / k)
 
-        if "/" in k and k != "/":
+        # len() may be 0 (`.`) or 1 (`some-key`)
+        if len(PurePosixPath(k).relative_to(store.name).parts) > 1:
             if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)

--- a/src/anndata/_io/specs/registry.py
+++ b/src/anndata/_io/specs/registry.py
@@ -358,13 +358,17 @@ class Writer:
         dataset_kwargs: Mapping[str, Any] = MappingProxyType({}),
         modifiers: frozenset[str] = frozenset(),
     ):
+        from pathlib import PurePosixPath
 
         import h5py
 
         from anndata._io.zarr import is_group_consolidated
 
         # we allow stores to have a prefix like /uns which are then written to with keys like /uns/foo
-        if "/" in k.rsplit(store.name, maxsplit=1)[-1][1:]:
+        if k.startswith(store.name) and k != "/":
+            k = str(PurePosixPath(k).relative_to(store.name))
+
+        if "/" in k and k != "/":
             if settings.disallow_forward_slash_in_h5ad:
                 msg = f"Forward slashes are not allowed in keys in {type(store)}"
                 raise ValueError(msg)

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import WRAPPER_ASSIGNMENTS, cache, wraps
 from itertools import pairwise
 from typing import TYPE_CHECKING, Literal, cast
@@ -12,7 +12,7 @@ from .._core.sparse_dataset import BaseCompressedSparseDataset
 from ..utils import warn
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
     from typing import Any, Literal
 
     from pandas.core.dtypes.dtypes import BaseMaskedDtype
@@ -277,6 +277,16 @@ def report_write_key_on_error(func):
             raise
 
     return func_wrapper
+
+
+def _check_has_no_slash_key(attr: str, elem: object) -> None:
+    """Only attempt to write slash keys where people rely on it for backwards compatibility."""
+    if attr in {"obs", "var", "uns", "raw"}:
+        return  # separate check for `settings.disallow_forward_slash_in_h5ad` is done in `write_elem`
+    assert isinstance(elem, Mapping)
+    if any("/" in k for k in elem if k not in {"/", None}):
+        msg = f"Forward slashes are not allowed in keys in {attr}"
+        raise ValueError(msg)
 
 
 # -------------------------------------------------------------------------------

--- a/src/anndata/_io/utils.py
+++ b/src/anndata/_io/utils.py
@@ -257,6 +257,7 @@ def report_write_key_on_error(func):
 
     @wraps(func)
     def func_wrapper(*args, **kwargs):
+        __tracebackhide__ = True
         from anndata._io.specs import Writer
 
         # Figure out signature (method vs function) by going through args

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from zarr.core.common import AccessModeLiteral
     from zarr.storage import StoreLike
 
+    from .._types import _GroupStorageType
+
 
 @contextmanager
 def zarrs_context():
@@ -175,8 +177,10 @@ def open_write_group(
     return zarr.open_group(store, mode=mode, **kwargs)
 
 
-def is_group_consolidated(group: zarr.Group) -> bool:
+def is_group_consolidated(group: _GroupStorageType, *, strict: bool = True) -> bool:
     if not isinstance(group, zarr.Group):
-        msg = f"Expected zarr.Group, got {type(group)}"
-        raise TypeError(msg)
+        if strict:
+            msg = f"Expected zarr.Group, got {type(group)}"
+            raise TypeError(msg)
+        return False
     return group.metadata.consolidated_metadata is not None

--- a/src/anndata/_settings.py
+++ b/src/anndata/_settings.py
@@ -501,7 +501,7 @@ settings.register(
 
 settings.register(
     "disallow_forward_slash_in_h5ad",
-    default_value=False,
+    default_value=True,
     description="Whether or not to disallow the `/` character in keys for h5ad files",
     validate=validate_bool,
     get_from_env=check_and_get_bool,

--- a/src/anndata/_settings.pyi
+++ b/src/anndata/_settings.pyi
@@ -44,7 +44,7 @@ class _AnnDataSettingsManager(SettingsManager):
     zarr_write_format: Literal[2, 3] = 2
     use_sparse_array_on_read: bool = False
     min_rows_for_chunked_h5_copy: int = 1000
-    disallow_forward_slash_in_h5ad: bool = False
+    disallow_forward_slash_in_h5ad: bool = True
     write_csr_csc_indices_with_min_possible_dtype: bool = False
     auto_shard_zarr_v3: bool = False
 

--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -156,10 +156,10 @@ class Write[RWAble: typing.RWAble](Protocol):
 class ReadCallback[S: StorageType, RWAble: typing.RWAble](Protocol):
     def __call__(
         self,
-        /,
         read_func: Read[S, RWAble],
         elem_name: str,
         elem: StorageType,
+        /,
         *,
         iospec: IOSpec,
     ) -> RWAble:
@@ -188,11 +188,11 @@ class ReadCallback[S: StorageType, RWAble: typing.RWAble](Protocol):
 class WriteCallback[RWAble: typing.RWAble](Protocol):
     def __call__(
         self,
-        /,
         write_func: Write[RWAble],
         store: StorageType,
         elem_name: str,
         elem: RWAble,
+        /,
         *,
         iospec: IOSpec,
         dataset_kwargs: Mapping[str, Any],

--- a/tests/test_concatenate_disk.py
+++ b/tests/test_concatenate_disk.py
@@ -20,6 +20,7 @@ from anndata.tests.helpers import assert_equal, check_all_sharded, gen_adata
 from anndata.utils import asarray
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
     from pathlib import Path
     from typing import Literal
 
@@ -70,31 +71,23 @@ def max_loaded_elems(request) -> int:
     return request.param
 
 
-def _adatas_to_paths(adatas, tmp_path, file_format):
-    """
-    Gets list of adatas, writes them and returns their paths as zarr
-    """
-    paths = None
-
-    if isinstance(adatas, Mapping):
-        paths = {}
-        for k, v in adatas.items():
-            p = tmp_path / (f"{k}." + file_format)
-            with as_group(p, mode="a") as f:
-                write_elem(f, "", v)
-            paths[k] = p
-    else:
-        paths = []
-        for i, a in enumerate(adatas):
-            p = tmp_path / (f"{i}." + file_format)
-            with as_group(p, mode="a") as f:
-                write_elem(f, "", a)
-            paths += [p]
-    return paths
+def _adatas_to_paths(
+    adatas: Mapping[str, AnnData] | Collection[AnnData],
+    tmp_path: Path,
+    file_format: str,
+) -> dict[str, Path] | list[Path]:
+    """Gets list of adatas, writes them and returns their paths as zarr."""
+    paths = {}
+    for k, v in adatas.items() if isinstance(adatas, Mapping) else enumerate(adatas):
+        p = tmp_path / f"{k}.{file_format}"
+        with as_group(p, mode="a") as f:
+            write_elem(f, "/", v)
+        paths[k] = p
+    return paths if isinstance(adatas, Mapping) else list(paths.values())
 
 
 def assert_eq_concat_on_disk(
-    adatas,
+    adatas: Mapping[str, AnnData] | Collection[AnnData],
     tmp_path: Path,
     file_format: Literal["zarr", "h5ad"],
     max_loaded_elems: int | None = None,

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -141,7 +141,7 @@ def test_dask_distributed_write(
         adata.varm["a"] = da.random.random((N, 10))
         orig = adata
         with ad.settings.override(auto_shard_zarr_v3=auto_shard_zarr_v3):
-            ad.io.write_elem(g, "", orig)
+            ad.io.write_elem(g, "/", orig)
         # TODO: See https://github.com/zarr-developers/zarr-python/issues/2716
         with as_group(pth, mode="r") as g:
             if auto_shard_zarr_v3:

--- a/tests/test_io_conversion.py
+++ b/tests/test_io_conversion.py
@@ -4,6 +4,8 @@ This file contains tests for conversion made during io.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import h5py
 import numpy as np
 import pytest
@@ -12,6 +14,10 @@ from scipy import sparse
 import anndata as ad
 from anndata.compat import CSMatrix
 from anndata.tests.helpers import GEN_ADATA_NO_XARRAY_ARGS, assert_equal, gen_adata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Literal
 
 
 @pytest.fixture(
@@ -64,7 +70,7 @@ def test_sparse_to_dense_disk(tmp_path, mtx_format, to_convert):
         assert_equal(disk, from_disk)
 
 
-def test_sparse_to_dense_inplace(tmp_path, spmtx_format):
+def test_sparse_to_dense_inplace(tmp_path: Path, spmtx_format: Literal["csc", "csr"]):
     pth = tmp_path / "adata.h5ad"
     orig = gen_adata((50, 50), spmtx_format, **GEN_ADATA_NO_XARRAY_ARGS)
     orig.raw = orig.copy()

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from functools import partial
 from typing import TYPE_CHECKING
 
 import h5py
@@ -194,24 +195,23 @@ def test_io_dispatched_keys(tmp_path: Path):
     h5ad_path = tmp_path / "test.h5ad"
     zarr_path = tmp_path / "test.zarr"
 
-    def writer(func, store, k, elem, dataset_kwargs, iospec):
-        assert k.startswith(store.name)
-        h5ad_write_keys.append(k.strip("/"))
+    def writer(func, store, k, elem, dataset_kwargs, iospec, keys):
+        keys.append(f"{store.name}/{k}")
         func(store, k, elem, dataset_kwargs=dataset_kwargs)
 
-    def reader(func, elem_name: str, elem, iospec):
-        h5ad_read_keys.append(elem_name.strip("/"))
+    def reader(func, elem_name: str, elem, iospec, keys):
+        keys.append(elem_name)
         return func(elem)
 
     adata = gen_adata((50, 100), **GEN_ADATA_NO_XARRAY_ARGS)
 
     with h5py.File(h5ad_path, "w") as f:
-        write_dispatched(f, "/", adata, callback=writer)
-        _ = read_dispatched(f, reader)
+        write_dispatched(f, "/", adata, callback=partial(writer, keys=h5ad_write_keys))
+        _ = read_dispatched(f, partial(reader, keys=h5ad_read_keys))
 
     f = open_write_group(zarr_path)
-    write_dispatched(f, "/", adata, callback=writer)
-    _ = read_dispatched(f, reader)
+    write_dispatched(f, "/", adata, callback=partial(writer, keys=zarr_write_keys))
+    _ = read_dispatched(f, partial(reader, keys=zarr_read_keys))
 
     assert sorted(h5ad_read_keys) == sorted(zarr_read_keys)
     assert sorted(h5ad_write_keys) == sorted(zarr_write_keys)

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -194,31 +194,23 @@ def test_io_dispatched_keys(tmp_path: Path):
     h5ad_path = tmp_path / "test.h5ad"
     zarr_path = tmp_path / "test.zarr"
 
-    def h5ad_writer(func, store, k, elem, dataset_kwargs, iospec):
-        h5ad_write_keys.append(k.strip("/"))
+    def writer(func, store, k, elem, dataset_kwargs, iospec):
+        h5ad_write_keys.append(f"{store.name.strip('/')}/{k.strip('/')}".strip("/"))
         func(store, k, elem, dataset_kwargs=dataset_kwargs)
 
-    def zarr_writer(func, store, k, elem, dataset_kwargs, iospec):
-        zarr_write_keys.append(f"{store.name.strip('/')}/{k.strip('/')}".strip("/"))
-        func(store, k, elem, dataset_kwargs=dataset_kwargs)
-
-    def h5ad_reader(func, elem_name: str, elem, iospec):
+    def reader(func, elem_name: str, elem, iospec):
         h5ad_read_keys.append(elem_name.strip("/"))
-        return func(elem)
-
-    def zarr_reader(func, elem_name: str, elem, iospec):
-        zarr_read_keys.append(elem_name.strip("/"))
         return func(elem)
 
     adata = gen_adata((50, 100), **GEN_ADATA_NO_XARRAY_ARGS)
 
     with h5py.File(h5ad_path, "w") as f:
-        write_dispatched(f, "/", adata, callback=h5ad_writer)
-        _ = read_dispatched(f, h5ad_reader)
+        write_dispatched(f, "/", adata, callback=writer)
+        _ = read_dispatched(f, reader)
 
     f = open_write_group(zarr_path)
-    write_dispatched(f, "/", adata, callback=zarr_writer)
-    _ = read_dispatched(f, zarr_reader)
+    write_dispatched(f, "/", adata, callback=writer)
+    _ = read_dispatched(f, reader)
 
     assert sorted(h5ad_read_keys) == sorted(zarr_read_keys)
     assert sorted(h5ad_write_keys) == sorted(zarr_write_keys)

--- a/tests/test_io_dispatched.py
+++ b/tests/test_io_dispatched.py
@@ -195,7 +195,8 @@ def test_io_dispatched_keys(tmp_path: Path):
     zarr_path = tmp_path / "test.zarr"
 
     def writer(func, store, k, elem, dataset_kwargs, iospec):
-        h5ad_write_keys.append(f"{store.name.strip('/')}/{k.strip('/')}".strip("/"))
+        assert k.startswith(store.name)
+        h5ad_write_keys.append(k.strip("/"))
         func(store, k, elem, dataset_kwargs=dataset_kwargs)
 
     def reader(func, elem_name: str, elem, iospec):

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -765,7 +765,7 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     adata = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
 
     z = open_write_group(pth)
-    write_elem(z, "table/table", adata)
+    write_elem(z.create_group("table"), "table", adata)
 
     if consolidated:
         zarr.consolidate_metadata(z.store)

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -690,9 +690,7 @@ def test_categorical_order_type(store):
 
 
 def test_override_specification():
-    """
-    Test that trying to overwrite an existing encoding raises an error.
-    """
+    """Test that trying to overwrite an existing encoding raises an error."""
     from copy import deepcopy
 
     registry = deepcopy(_REGISTRY)

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -55,7 +55,9 @@ def exit_stack() -> Generator[ExitStack, None, None]:
 
 
 @pytest.fixture
-def store(diskfmt, tmp_path) -> Generator[H5Group | ZarrGroup, None, None]:
+def store(
+    diskfmt: Literal["h5ad", "zarr"], tmp_path: Path
+) -> Generator[H5Group | ZarrGroup, None, None]:
     if diskfmt == "h5ad":
         file = h5py.File(tmp_path / "test.h5ad", "w")
         store = cast("H5Group", file["/"])

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -757,7 +757,9 @@ def test_write_to_root(store: _GroupStorageType, value):
     assert_equal(result, value)
 
 
-@pytest.mark.parametrize("consolidated", [True, False])
+@pytest.mark.parametrize(
+    "consolidated", [True, False], ids=["consolidated", "unconsolidated"]
+)
 @pytest.mark.zarr_io
 def test_read_zarr_from_group(tmp_path, consolidated):
     # https://github.com/scverse/anndata/issues/1056

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -963,7 +963,9 @@ def test_h5py_attr_limit(tmp_path):
     "elem_key", ["obs", "var", "obsm", "varm", "layers", "obsp", "varp", "uns"]
 )
 @pytest.mark.parametrize("store_type", ["zarr", "h5ad"])
-@pytest.mark.parametrize("disallow_forward_slash_in_h5ad", [True, False])
+@pytest.mark.parametrize(
+    "disallow_forward_slash_in_h5ad", [True, False], ids=["ban_slash", "allow_slash"]
+)
 def test_forward_slash_key(
     elem_key: Literal["obs", "var", "obsm", "varm", "layers", "obsp", "varp", "uns"],
     tmp_path: Path,
@@ -976,25 +978,34 @@ def test_forward_slash_key(
         (10,) if elem_key in ["obs", "var"] else (10, 10)
     )
     path = tmp_path / f"test.{store_type}"
+    can_write_slash_key = (
+        elem_key in {"uns", "obs", "var"}
+        and store_type == "h5ad"
+        and not disallow_forward_slash_in_h5ad
+    )
 
+    # try to write bad key and make sure we warn or throw an error
     with (
         ad.settings.override(
             disallow_forward_slash_in_h5ad=disallow_forward_slash_in_h5ad
         ),
-        pytest.raises(ValueError, match=r"Forward slashes")
-        if disallow_forward_slash_in_h5ad
-        else pytest.warns(FutureWarning, match=r"Forward slashes"),
+        pytest.warns(FutureWarning, match=r"Forward slashes")
+        if can_write_slash_key
+        else pytest.raises(ValueError, match=r"Forward slashes"),
     ):
         getattr(a, f"write_{store_type}")(path)
 
-    if not disallow_forward_slash_in_h5ad:
-        adata = getattr(ad, f"read_{store_type}")(path)
+    # read and check that bad keys were only written if allowed
+    elem = getattr(getattr(ad, f"read_{store_type}")(path), elem_key)
+    if can_write_slash_key:
         if elem_key in {"obs", "var"}:
-            assert "bad/key" in getattr(adata, elem_key)
-        elif elem_key == "uns":
-            assert "bad" in getattr(adata, elem_key)
+            assert "bad/key" in elem
         else:
-            assert not getattr(adata, elem_key).keys()
+            assert "bad" in elem
+    elif elem_key in {"obs", "var"}:
+        assert set(elem.columns) == {"_index"}
+    else:
+        assert not elem.keys()
 
 
 @pytest.mark.skipif(

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -975,15 +975,26 @@ def test_forward_slash_key(
     getattr(a, elem_key)["bad/key"] = np.ones(
         (10,) if elem_key in ["obs", "var"] else (10, 10)
     )
+    path = tmp_path / f"test.{store_type}"
+
     with (
         ad.settings.override(
             disallow_forward_slash_in_h5ad=disallow_forward_slash_in_h5ad
         ),
         pytest.raises(ValueError, match=r"Forward slashes")
         if disallow_forward_slash_in_h5ad
-        else pytest.warns(UserWarning, match=r"Forward slashes"),
+        else pytest.warns(FutureWarning, match=r"Forward slashes"),
     ):
-        getattr(a, f"write_{store_type}")(tmp_path / "does_not_matter_the_path.h5ad")
+        getattr(a, f"write_{store_type}")(path)
+
+    if not disallow_forward_slash_in_h5ad:
+        adata = getattr(ad, f"read_{store_type}")(path)
+        if elem_key in {"obs", "var"}:
+            assert "bad/key" in getattr(adata, elem_key)
+        elif elem_key == "uns":
+            assert "bad" in getattr(adata, elem_key)
+        else:
+            assert not getattr(adata, elem_key).keys()
 
 
 @pytest.mark.skipif(

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -19,6 +19,7 @@ from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 import anndata as ad
 from anndata._io.specs.registry import IORegistryError
 from anndata._io.zarr import open_write_group
+from anndata._types import AnnDataElem
 from anndata.compat import (
     CSArray,
     CSMatrix,
@@ -35,6 +36,7 @@ from anndata.tests.helpers import (
     jnp,
     jnp_array_or_idempotent,
 )
+from anndata.utils import get_literal_members
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -960,20 +962,20 @@ def test_h5py_attr_limit(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "elem_key", ["obs", "var", "obsm", "varm", "layers", "obsp", "varp", "uns"]
+    "elem_key", set(get_literal_members(AnnDataElem)) - {"raw", "X"}
 )
 @pytest.mark.parametrize("store_type", ["zarr", "h5ad"])
 @pytest.mark.parametrize(
     "disallow_forward_slash_in_h5ad", [True, False], ids=["ban_slash", "allow_slash"]
 )
 def test_forward_slash_key(
-    elem_key: Literal["obs", "var", "obsm", "varm", "layers", "obsp", "varp", "uns"],
-    tmp_path: Path,
-    store_type: Literal["zarr", "h5ad"],
     *,
+    tmp_path: Path,
+    elem_key: AnnDataElem,
+    store_type: Literal["zarr", "h5ad"],
     disallow_forward_slash_in_h5ad: bool,
-):
-    a = ad.AnnData(np.ones((10, 10)))
+) -> None:
+    a = ad.AnnData(shape=(10, 10))
     getattr(a, elem_key)["bad/key"] = np.ones(
         (10,) if elem_key in ["obs", "var"] else (10, 10)
     )
@@ -1003,6 +1005,36 @@ def test_forward_slash_key(
         else:
             assert "bad" in elem
     elif elem_key in {"obs", "var"}:
+        assert set(elem.columns) == {"_index"}
+    else:
+        assert not elem.keys()
+
+
+@pytest.mark.parametrize(
+    "elem_key", set(get_literal_members(AnnDataElem)) - {"raw", "X"}
+)
+@pytest.mark.parametrize("store_type", ["zarr", "h5ad"])
+@pytest.mark.parametrize("key", ["/", "/y"])
+def test_leading_slash_error(
+    *,
+    tmp_path: Path,
+    elem_key: AnnDataElem,
+    store_type: Literal["zarr", "h5ad"],
+    key: str,
+) -> None:
+    a = ad.AnnData(shape=(10, 10))
+    getattr(a, elem_key)[key] = np.ones(
+        (10,) if elem_key in ["obs", "var"] else (10, 10)
+    )
+    path = tmp_path / f"test.{store_type}"
+
+    # “not in the subpath” is raised by e.g. `write_elem(g["z"], "/y", ...)`,
+    # while “Forward slashes” is raised earlier by `write_anndata`/`write_h5ad`
+    with pytest.raises(ValueError, match=r"not in the subpath|Forward slashes"):
+        getattr(a, f"write_{store_type}")(path)
+
+    elem = getattr(getattr(ad, f"read_{store_type}")(path), elem_key)
+    if elem_key in {"obs", "var"}:
         assert set(elem.columns) == {"_index"}
     else:
         assert not elem.keys()

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -980,8 +980,8 @@ def test_forward_slash_key(
             disallow_forward_slash_in_h5ad=disallow_forward_slash_in_h5ad
         ),
         pytest.raises(ValueError, match=r"Forward slashes")
-        if store_type == "zarr" or disallow_forward_slash_in_h5ad
-        else pytest.warns(FutureWarning, match=r"Forward slashes"),
+        if disallow_forward_slash_in_h5ad
+        else nullcontext(),
     ):
         getattr(a, f"write_{store_type}")(tmp_path / "does_not_matter_the_path.h5ad")
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -987,7 +987,7 @@ def test_forward_slash_key(
 
 
 @pytest.mark.skipif(
-    find_spec("xarray"),
+    bool(find_spec("xarray")),
     reason="Xarray is installed so `read_{elem_}lazy` will not error",
 )
 @pytest.mark.parametrize(

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -981,7 +981,7 @@ def test_forward_slash_key(
         ),
         pytest.raises(ValueError, match=r"Forward slashes")
         if disallow_forward_slash_in_h5ad
-        else nullcontext(),
+        else pytest.warns(UserWarning, match=r"Forward slashes"),
     ):
         getattr(a, f"write_{store_type}")(tmp_path / "does_not_matter_the_path.h5ad")
 


### PR DESCRIPTION
OK, so this is broken: https://github.com/scverse/anndata/blob/9ebc55b42e2a794c2417d9738c9e9fc4e4a93df4/src/anndata/_io/specs/registry.py#L369

This fix changes the API in the following way:
1. `k="raw/var"` is no longer legal. A quirk of the broken check allowed that before, but it should never have worked.
2. `k=""` to write into the root is no longer legal, that should be `"/"`

the first one is definitely wanted, the second one used to work, but isn’t documented? Should I bring that back?

TODO:

- [x] I removed the `store_type == "zarr"` checks. I’m planning to bring them back.
- [x] Better error when people pass `k=""` or `k="."`
- [x] The current test failures are because setting `disallow_forward_slash_in_h5ad=False` and writing `{obs,var}m` results in unreadable anndata files. How should we deal with it? Disallow writing these even when it’s `False`?

----

<!-- Please:
1. Fill in the following check boxes
3. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #2099
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
