### PR TITLE
fix: relnotes for `0.12.16`

### DIFF
--- a/docs/release-notes/0.12.16.md
+++ b/docs/release-notes/0.12.16.md
@@ -1,0 +1,6 @@
+(v0.12.16)=
+### 0.12.16 {small}`2026-05-18`
+
+#### Bug fixes
+
+- `0.12.15` was released against main accidentally and yanked.  This version contains the correct branch.


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
