### PR TITLE
test: fix GPU tests and docs: fix WriteCallback param description

### DIFF
--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -207,7 +207,7 @@ class WriteCallback[RWAble: typing.RWAble](Protocol):
         store
             The store to which `elem` should be written.
         elem_name
-            The key to read in from the group.
+            The key to write out to the group.
         elem
             The element to write out.
         iospec

--- a/tests/accessors/test_get.py
+++ b/tests/accessors/test_get.py
@@ -124,7 +124,6 @@ def convert_ndarrays(
             v = v.toarray()
         return array_conv(v)
 
-    adata.X = conv(adata.X)
     for k, v in adata.layers.items():
         adata.layers[k] = conv(v)
     for k, v in adata.varm.items():


### PR DESCRIPTION
In #1707, we forgot to adapt the GPU tests, so `as_cupy` was called twice on `X` (once as `adata.layers[None]` and once as `adata.X`). Since `as_cupy` deliberately only handles non-cupy data, this failed.

/edit: looks like some unrelated tiny docs fix also snuck in. eh, good.