### PR TITLE
fix: load raw X when leaving backed mode

### DIFF
--- a/docs/release-notes/2460.fix.md
+++ b/docs/release-notes/2460.fix.md
@@ -1,0 +1,1 @@
+Fix setting {attr}`anndata.AnnData.filename` to {obj}`None` for backed objects so {attr}`anndata.AnnData.raw` keeps `raw.X` in memory {user}`ehsanestaji`

--- a/src/anndata/_core/file_backing.py
+++ b/src/anndata/_core/file_backing.py
@@ -115,7 +115,9 @@ class AnnDataFileManager:
 
     def _to_memory_mode(self):
         """Close the backing file, forget filename, *do* change to memory mode."""
-        self._adata.X = self._adata.X[()]
+        if self._adata.raw is not None:
+            self._adata.raw._X = to_memory(self._adata.raw.X)
+        self._adata.X = to_memory(self._adata.X)
         self._file.close()
         self._file = None
         self._filename = None

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -318,6 +318,19 @@ def test_return_to_memory_mode(adata: ad.AnnData, backing_h5ad: Path):
     bdata.filename = None
 
 
+def test_return_to_memory_mode_loads_raw_X(adata: ad.AnnData, backing_h5ad: Path):
+    adata.raw = adata.copy()
+    expected_raw_X = asarray(adata.raw.X)
+    adata.write_h5ad(backing_h5ad)
+    backed = ad.read_h5ad(backing_h5ad, backed="r")
+    assert backed.isbacked
+
+    backed.filename = None
+    assert not backed.isbacked
+    assert backed.raw.X is not None
+    assert np.array_equal(asarray(backed.raw.X), expected_raw_X)
+
+
 def test_backed_modification(adata: ad.AnnData, backing_h5ad: Path):
     adata.X[:, 1] = 0  # Make it a little sparse
     adata.X = sparse.csr_matrix(adata.X)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #623
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:

## Summary

Setting `adata.filename = None` on a backed object already materialized `adata.X`, but backed objects read from disk could still lose `adata.raw.X` because `raw._X` stayed `None` after the backing file was closed.

This PR materializes `raw.X` before leaving backed mode, adds a regression test for the backed-read path, and includes a release note fragment.

## Checks

- `uv run pytest tests/test_backed_hdf5.py::test_return_to_memory_mode_loads_raw_X -q`
- `uv run pytest tests/test_backed_hdf5.py::test_return_to_memory_mode tests/test_backed_hdf5.py::test_return_to_memory_mode_loads_raw_X tests/test_backed_hdf5.py::test_backed_raw tests/test_raw.py::test_raw_backed -q`
- `uv run pytest tests/test_raw.py -q`
- `uv run pytest tests/test_backed_hdf5.py -q`
- `uv run ruff check src/anndata/_core/file_backing.py tests/test_backed_hdf5.py`
- `uv run ruff format --check src/anndata/_core/file_backing.py tests/test_backed_hdf5.py`
- `git diff --check`
