### PR TITLE
fix: read_lazy crash on empty (zero-length) arrays (#2469)

### DIFF
--- a/docs/release-notes/2473.fix.md
+++ b/docs/release-notes/2473.fix.md
@@ -1,0 +1,1 @@
+Fix {func}`~anndata.experimental.read_lazy` crashing on empty (zero-length) arrays, e.g. an empty array stored in {attr}`~anndata.AnnData.uns` {smaller}`gaoflow`

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -70,6 +70,11 @@ _DEFAULT_STRIDE = 1000
 def compute_chunk_layout_for_axis_size(
     chunk_axis_size: int, full_axis_size: int
 ) -> tuple[int, ...]:
+    # A zero-length axis must be expressed as a single zero-length chunk:
+    # dask rejects empty chunk tuples ("Empty tuples are not allowed in
+    # chunks"), and ``np.divmod(0, 0)`` would otherwise divide by zero.
+    if full_axis_size == 0:
+        return (0,)
     n_strides, rest = np.divmod(full_axis_size, chunk_axis_size)
     chunk = (chunk_axis_size,) * n_strides
     if rest > 0:

--- a/tests/lazy/test_read.py
+++ b/tests/lazy/test_read.py
@@ -128,6 +128,22 @@ def test_uns_uses_dask(adata_remote: AnnData):
     assert isinstance(adata_remote.uns["nested"]["nested_further"]["array"], DaskArray)
 
 
+def test_read_lazy_empty_uns_array(tmp_path: Path):
+    # Regression test for #2469: an empty array in ``uns`` is stored unchunked,
+    # so the lazy chunk layout used to be an empty tuple, which dask rejects
+    # ("Empty tuples are not allowed in chunks"). It must read lazily instead.
+    path = tmp_path / "empty_uns.h5ad"
+    adata = AnnData()
+    adata.uns["uns_name"] = {"key_name": []}
+    adata.write_h5ad(path)
+
+    remote = read_lazy(path)
+    arr = remote.uns["uns_name"]["key_name"]
+    assert isinstance(arr, DaskArray)
+    assert arr.shape == (0,)
+    assert np.asarray(arr).shape == (0,)
+
+
 def test_to_memory(adata_remote: AnnData, adata_orig: AnnData):
     remote_to_memory = adata_remote.to_memory()
     assert_equal(remote_to_memory, adata_orig)


### PR DESCRIPTION
Fixes #2469.

## Problem

Reading a file that contains an empty array (e.g. an empty list stored in `uns`) with `experimental.read_lazy` crashes:

```python
import anndata, tempfile
from anndata import experimental

adata = anndata.AnnData()
adata.uns["uns_name"] = {"key_name": []}
adata.write_h5ad("x.h5ad")
experimental.read_lazy("x.h5ad")
# ValueError: Empty tuples are not allowed in chunks.
#             Express zero length dimensions with 0(s) in chunks
```

An empty array is stored unchunked, so `resolve_chunks` yields a chunk size of `0` for the zero-length axis. `compute_chunk_layout_for_axis_size(0, 0)` then runs `np.divmod(0, 0)` (a divide-by-zero `RuntimeWarning`), gets `n_strides = 0`, and returns the empty tuple `()` as the chunk layout. dask rejects that, as the traceback in the issue shows.

## Fix

Return `(0,)` for a zero-length axis — dask's required representation of a single zero-length chunk — which also sidesteps the `np.divmod(0, 0)` divide-by-zero. Non-empty axes are unchanged.

## Verification

Added `test_read_lazy_empty_uns_array` in `tests/lazy/test_read.py`, which writes an AnnData with an empty `uns` array, reads it lazily, and checks the result is a zero-length `DaskArray`. It fails on the current code with the `ValueError` above and passes with this change. Verified the existing non-empty chunk layouts are unchanged (`compute_chunk_layout_for_axis_size(1000, 2500) == (1000, 1000, 500)`), and the rest of `tests/lazy/test_read.py` continues to pass (one unrelated pre-existing error from the optional `awkward` dependency being absent).

I will add a release note once the PR number is assigned.