### PR TITLE
fix: handle `block_diag` warning

### DIFF
--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -5,6 +5,7 @@ Code for merging/ concatenating AnnData objects.
 from __future__ import annotations
 
 import uuid
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Mapping, MutableSet
 from functools import partial, reduce, singledispatch
@@ -1155,7 +1156,20 @@ def concat_pairwise_mapping(
         elif all(isinstance(el, DaskArray) for el in els):
             result[k] = _dask_block_diag(els)
         else:
-            result[k] = sparse.block_diag(els, format="csr")
+            # TODO: Remove the warning catch some time around scipy 1.2 (stated in the warning)
+            # https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html#existing-functions-that-need-careful-migration
+            with warnings.catch_warnings():
+                if any(isinstance(v, np.ndarray) for v in els):
+                    warnings.filterwarnings(
+                        "ignore",
+                        r"`block_diag` is switching to the sparse array interface.",
+                        DeprecationWarning,
+                    )
+
+            diag = sparse.block_diag(els, format="csr")
+            # TODO: Remove once we migrate internally to xxx_array
+            if isinstance(diag, CSArray):
+                result[k] = sparse.csr_matrix(diag)
     return result
 
 

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -1169,7 +1169,8 @@ def concat_pairwise_mapping(
                 diag = sparse.block_diag(els, format="csr")
             # TODO: Remove once we migrate internally to xxx_array
             if isinstance(diag, CSArray):
-                result[k] = sparse.csr_matrix(diag)
+                diag = sparse.csr_matrix(diag)
+            result[k] = diag
     return result
 
 

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -1166,7 +1166,7 @@ def concat_pairwise_mapping(
                         DeprecationWarning,
                     )
 
-            diag = sparse.block_diag(els, format="csr")
+                diag = sparse.block_diag(els, format="csr")
             # TODO: Remove once we migrate internally to xxx_array
             if isinstance(diag, CSArray):
                 result[k] = sparse.csr_matrix(diag)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

See https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html#existing-functions-that-need-careful-migration but the `scipy==1.18.0rc1` now emits this warning

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: Internal change
