### PR TITLE
fix: ignore awkward warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,9 +175,11 @@ filterwarnings_when_strict = [
     "default:anndata will no longer support zarr v2:DeprecationWarning",
     "default:Consolidated metadata is:UserWarning",
     "default:.*Struct:zarr.core.dtype.common.UnstableSpecificationWarning",
-    # Remove when https://github.com/zarr-developers/zarr-python/pull/3979 becomes min
+    # TODO: Remove when https://github.com/zarr-developers/zarr-python/pull/3979 becomes min
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:Writing zarr v2:UserWarning",
+    # TODO: remove when https://github.com/scikit-hep/awkward/issues/4078 is resolved
+    "default:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 python_files = [ "test_*.py" ]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,8 @@ filterwarnings = [
     "ignore:`__version__` is deprecated:FutureWarning:scanpy",
     # https://github.com/matplotlib/matplotlib/pull/30589
     "ignore:.*'(oneOf|parseString|resetCache|enablePackrat)'.*'(one_of|parse_string|reset_cache|enable_packrat)':DeprecationWarning:matplotlib",
+    # TODO: remove when https://github.com/scikit-hep/awkward/issues/4078 is resolved
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 # When `--strict-warnings` is used, all warnings are treated as errors, except those:
 filterwarnings_when_strict = [
@@ -178,8 +180,6 @@ filterwarnings_when_strict = [
     # TODO: Remove when https://github.com/zarr-developers/zarr-python/pull/3979 becomes min
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",
     "default:Writing zarr v2:UserWarning",
-    # TODO: remove when https://github.com/scikit-hep/awkward/issues/4078 is resolved
-    "default:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 python_files = [ "test_*.py" ]
 testpaths = [


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

Arose in #2478 which is pulling in the numpy RC but `main` is not (transient dependency bounding, not sure which).

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: dev change
