### PR TITLE
ci: bump codecov-action to v6 to fix signature verification

### DIFF
--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           report_type: test_results
           env_vars: ENV_NAME,IO_MARK
@@ -91,7 +91,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           env_vars: ENV_NAME,IO_MARK
           files: test-data/coverage.xml

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -80,7 +80,7 @@ jobs:
           uv run coverage combine
           uv run coverage xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
`codecov-action@v5` verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts. Uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key. Version pin bump.

Ref: https://github.com/codecov/codecov-action/issues/1956