### PR TITLE
Backport PR #2493: chore: deprecate `AnnLoader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 # anndata - Annotated data
 
-anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. anndata offers a broad range of computationally efficient features including, among others, sparse data support, lazy operations, and a PyTorch interface.
+anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. anndata offers a broad range of computationally efficient features including, among others, sparse data support, and lazy operations.
+A separate data loader package, [annbatch](https://annbatch.readthedocs.io/en/stable/), offers minibatch data loading functionality for applications ranging from linear models to foundation models,  scaling all the way up from small in-memory matrices to terabyte-scale disk-backed anndata datasets.
 
 - Discuss development on [GitHub](https://github.com/scverse/anndata).
 - Read the [documentation](https://anndata.readthedocs.io).

--- a/docs/api.md
+++ b/docs/api.md
@@ -137,6 +137,11 @@ In particular, for pytorch-based models.
    experimental.AnnLoader
 ```
 
+```{note}
+`AnnLoader` is deprecated and will be removed in 0.14.
+Please see {class}`annbatch.Loader` for the replacement.
+```
+
 Out of core concatenation
 
 ```{eval-rst}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ intersphinx_mapping = dict(
     zarr=("https://zarr.readthedocs.io/en/stable/", None),
     zarrs=("https://zarrs-python.readthedocs.io/en/stable/", None),
     scverse_misc=("https://scverse-misc.readthedocs.io/stable", None),
+    annbatch=("https://annbatch.readthedocs.io/en/stable/", None),
 )
 
 qualname_overrides = {

--- a/docs/release-notes/2493.chore.md
+++ b/docs/release-notes/2493.chore.md
@@ -1,0 +1,1 @@
+Deprecate {class}`~anndata.experimental.AnnLoader` in favor of {class}`annbatch.Loader` {user}`ilan-gold`

--- a/src/anndata/experimental/pytorch/_annloader.py
+++ b/src/anndata/experimental/pytorch/_annloader.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.sparse import issparse
+from scverse_misc import Deprecation, deprecated
 
 from ..._core.anndata import AnnData
 from ...compat import old_positionals
@@ -127,6 +128,9 @@ class AnnLoader(DataLoader):
     :class:`~anndata.experimental.AnnCollection` object or from an `AnnCollectionView` object.
     Takes care of the required conversions.
 
+    .. deprecated:: 0.12.17
+        Use :class:`annbatch.Loader` instead.
+
     Parameters
     ----------
     adatas
@@ -148,6 +152,9 @@ class AnnLoader(DataLoader):
         arguments for `AnnCollection` initialization.
     """
 
+    @deprecated(
+        Deprecation("0.12.17", "Use {class}`annbatch.Loader` instead of `AnnLoader`")
+    )
     @old_positionals("batch_size", "shuffle", "use_default_converter", "use_cuda")
     def __init__(
         self,

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -147,3 +147,14 @@ def test_warn_on_deprecated_extension_namespace():
 def test_keys_function_warns(adata: AnnData, name) -> None:
     with pytest.warns(FutureWarning, match=rf"{name}_keys is deprecated"):
         getattr(adata, f"{name}_keys")()
+
+
+def test_annloader_init_warns(adata: AnnData) -> None:
+    # We currently have no test env that has torch but I ran this locally.
+    pytest.importorskip("torch")
+    from anndata.experimental import AnnLoader
+
+    with pytest.warns(
+        FutureWarning, match=r"Use .*annbatch\.Loader.* instead of .*AnnLoader.*"
+    ):
+        AnnLoader(adata)


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
