### PR TITLE
chore: no longer warn on consolidated metadata writing

### DIFF
--- a/docs/release-notes/2497.chore.md
+++ b/docs/release-notes/2497.chore.md
@@ -1,0 +1,1 @@
+Add `consolidate_metadata` argument to {meth}`~anndata.AnnData.write_zarr` to allow opting out of consolidated metadata easily. No longer warn on its writing as it appears to be heading for stability in zarr. {user}`ilan-gold`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,8 +174,6 @@ filterwarnings_when_strict = [
     "default:(Observation|Variable) names are not unique. To make them unique:UserWarning",
     "default::scipy.sparse.SparseEfficiencyWarning",
     "default::dask.array.core.PerformanceWarning",
-    "default:anndata will no longer support zarr v2:DeprecationWarning",
-    "default:Consolidated metadata is:UserWarning",
     "default:.*Struct:zarr.core.dtype.common.UnstableSpecificationWarning",
     # TODO: Remove when https://github.com/zarr-developers/zarr-python/pull/3979 becomes min
     "default:.*FixedLengthUTF32:zarr.core.dtype.common.UnstableSpecificationWarning",

--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1751,6 +1751,7 @@ class AnnData:  # noqa: PLW1641
         *,
         chunks: tuple[int, ...] | None = None,
         convert_strings_to_categoricals: bool = True,
+        consolidate_metadata: bool = True,
     ):
         """\
         Write a hierarchical Zarr array store.
@@ -1763,6 +1764,8 @@ class AnnData:  # noqa: PLW1641
             Chunk shape.
         convert_strings_to_categoricals
             Convert string columns to categorical.
+        consolidate_metadata
+            Whether to consolidate the metadata of the store after writing.
         """
         from ..io import write_zarr
 
@@ -1778,6 +1781,7 @@ class AnnData:  # noqa: PLW1641
             self,
             chunks=chunks,
             convert_strings_to_categoricals=convert_strings_to_categoricals,
+            consolidate_metadata=consolidate_metadata,
         )
 
     def chunked_X(self, chunk_size: int | None = None):

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -55,6 +55,7 @@ def write_zarr(
     *,
     chunks: tuple[int, ...] | None = None,
     convert_strings_to_categoricals: bool = True,
+    consolidate_metadata: bool = True,
     **ds_kwargs,
 ) -> None:
     """See :meth:`~anndata.AnnData.write_zarr`."""
@@ -81,7 +82,17 @@ def write_zarr(
         f.attrs.setdefault("encoding-version", "0.1.0")
 
         write_dispatched(f, "/", adata, callback=callback, dataset_kwargs=ds_kwargs)
-        zarr.consolidate_metadata(f.store)
+        if consolidate_metadata:
+            with warnings.catch_warnings():
+                # Consolidated metadata will soon be a zarr convention/spec and should be safe to write.
+                # There is no sense in spamming our users about this.
+                # See https://github.com/zarr-developers/zarr-specs/pull/373
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r".*[Cc]onsolidated metadata.*",
+                    category=UserWarning,
+                )
+                zarr.consolidate_metadata(f.store)
 
 
 def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnData:

--- a/tests/lazy/conftest.py
+++ b/tests/lazy/conftest.py
@@ -145,7 +145,10 @@ def adata_remote_with_store_tall_skinny_path(
         dataset_kwargs=dict(chunks=(250,), shards=None),
     )
     # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
-    with pytest.warns(zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"):
+    with pytest.warns(
+        zarr.errors.ZarrUserWarning if hasattr(zarr, "errors") else UserWarning,
+        match=r"Consolidated metadata",
+    ):
         zarr.consolidate_metadata(g.store)
     return orig_path
 

--- a/tests/lazy/conftest.py
+++ b/tests/lazy/conftest.py
@@ -144,7 +144,9 @@ def adata_remote_with_store_tall_skinny_path(
         # No shards so we can track chunking exactly.
         dataset_kwargs=dict(chunks=(250,), shards=None),
     )
-    zarr.consolidate_metadata(g.store)
+    # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
+    with pytest.warns(zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"):
+        zarr.consolidate_metadata(g.store)
     return orig_path
 
 

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -768,7 +768,9 @@ def test_read_zarr_from_group(tmp_path, consolidated):
     write_elem(z.create_group("table"), "table", adata)
 
     if consolidated:
-        zarr.consolidate_metadata(z.store)
+        # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
+        with pytest.warns(zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"):
+            zarr.consolidate_metadata(z.store)
 
     read_func = zarr.open_consolidated if consolidated else zarr.open
 

--- a/tests/test_io_elementwise.py
+++ b/tests/test_io_elementwise.py
@@ -769,7 +769,12 @@ def test_read_zarr_from_group(tmp_path, consolidated):
 
     if consolidated:
         # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
-        with pytest.warns(zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"):
+        with pytest.warns(
+            zarr.errors.ZarrUserWarning
+            if hasattr(zarr, "errors") and hasattr(zarr.errors, "ZarrUserWarning")
+            else UserWarning,
+            match=r"Consolidated metadata",
+        ):
             zarr.consolidate_metadata(z.store)
 
     read_func = zarr.open_consolidated if consolidated else zarr.open

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -395,7 +395,9 @@ def test_read_full_io_error(tmp_path, name, read, write):
             })
             # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
             with pytest.warns(
-                zarr.errors.ZarrUserWarning if hasattr(zarr, "errors") else UserWarning,
+                zarr.errors.ZarrUserWarning
+                if hasattr(zarr, "errors") and hasattr(zarr.errors, "ZarrUserWarning")
+                else UserWarning,
                 match=r"Consolidated metadata",
             ):
                 zarr.consolidate_metadata(store.store)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -395,7 +395,8 @@ def test_read_full_io_error(tmp_path, name, read, write):
             })
             # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
             with pytest.warns(
-                zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"
+                zarr.errors.ZarrUserWarning if hasattr(zarr, "errors") else UserWarning,
+                match=r"Consolidated metadata",
             ):
                 zarr.consolidate_metadata(store.store)
         else:

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -393,7 +393,11 @@ def test_read_full_io_error(tmp_path, name, read, write):
                 **dict(store["obs"].attrs),
                 "encoding-type": "invalid",
             })
-            zarr.consolidate_metadata(store.store)
+            # Catch the warning so we are alerted once it is no longer surfaced i.e., once consolidated metadata stabilizes.
+            with pytest.warns(
+                zarr.errors.ZarrUserWarning, match=r"Consolidated metadata"
+            ):
+                zarr.consolidate_metadata(store.store)
         else:
             store["obs"].attrs["encoding-type"] = "invalid"
 


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

See comment in diff for more info, but it seems consolidated metadata should be safe (beyond xarray's total embrace of it).

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
