### PR TITLE
docs: clean up relnotes

### DIFF
--- a/docs/release-notes/0.13.0rc1.md
+++ b/docs/release-notes/0.13.0rc1.md
@@ -7,6 +7,7 @@
    (See also “Miscellaneous changes” below.)
 
 #### Breaking changes
+
 - Remove `dtype` argument from {class}`~anndata.AnnData` constructor. {user}`flying-sheep` ({pr}`1707`)
 - Remove internal use of inheritance inside {class}`~anndata.abc.CSRDataset` and {class}`~anndata.abc.CSCDataset` from {class}`scipy.sparse.spmatrix`.
   Users can thus no longer write to backed sparse stores but now the backed sparse classes can return {class}`cupyx.scipy.sparse.csr_matrix` and {class}`cupyx.scipy.sparse.csc_matrix` when configured properly with {mod}`zarr`.

--- a/docs/release-notes/0.13.0rc1.md
+++ b/docs/release-notes/0.13.0rc1.md
@@ -1,10 +1,11 @@
 (v0.13.0rc1)=
 ### 0.13.0rc1 {small}`2026-05-20`
 
-.. attention::
-   In anndata 0.14, {attr}`anndata.settings.allow_write_nullable_strings` will default to `True`,
-   so take care to test your code with the upcoming default value.
-   (See also “Miscellaneous changes” below.)
+:::{attention}
+In anndata 0.14, {attr}`anndata.settings.allow_write_nullable_strings` will default to `True`,
+so take care to test your code with the upcoming default value.
+(See also “Miscellaneous changes” below.)
+:::
 
 #### Breaking changes
 

--- a/docs/release-notes/0.13.0rc1.md
+++ b/docs/release-notes/0.13.0rc1.md
@@ -1,26 +1,16 @@
 (v0.13.0rc1)=
 ### 0.13.0rc1 {small}`2026-05-20`
 
+.. attention::
+   In anndata 0.14, {attr}`anndata.settings.allow_write_nullable_strings` will default to `True`,
+   so take care to test your code with the upcoming default value.
+   (See also “Miscellaneous changes” below.)
+
 #### Breaking changes
-
 - Remove `dtype` argument from {class}`~anndata.AnnData` constructor. {user}`flying-sheep` ({pr}`1707`)
-- Remove internal use of inheritance inside {class}`~anndata.abc.CSRDataset` and {class}`~anndata.abc.CSCDataset` from {class}`scipy.sparse.spmatrix`.  Users can thus no longer write to backed sparse stores but now the backed sparse classes can return {class}`cupyx.scipy.sparse.csr_matrix` and {class}`cupyx.scipy.sparse.csc_matrix` when configured properly with {mod}`zarr`. {user}`ilan-gold` ({pr}`1927`)
-- ..
-      this isn’t actually a breaking change, but it needs to be far up in the changelog.
-      maybe we should move the “attention” directive up when compiling release notes?
-
-  Switch {attr}`anndata.settings.allow_write_nullable_strings` to new default `None`,
-  which means the writing of pandas string arrays will be controlled by `pandas.options.future.infer_string`
-  (see the {doc}`pandas:user_guide/migration-3-strings`).
-  Setting `allow_write_nullable_strings=False` explicitly now means to try writing the array in the non-nullable string array format,
-  which was the only supported format up to anndata 0.11.
-
-  .. attention::
-
-     In anndata 0.14, {attr}`anndata.settings.allow_write_nullable_strings` will default to `True`,
-     so take care to test your code with the upcoming default value.
-
-  {smaller}`P Angerer` ({pr}`2133`)
+- Remove internal use of inheritance inside {class}`~anndata.abc.CSRDataset` and {class}`~anndata.abc.CSCDataset` from {class}`scipy.sparse.spmatrix`.
+  Users can thus no longer write to backed sparse stores but now the backed sparse classes can return {class}`cupyx.scipy.sparse.csr_matrix` and {class}`cupyx.scipy.sparse.csc_matrix` when configured properly with {mod}`zarr`.
+  {user}`ilan-gold` ({pr}`1927`)
 - Remove support for {mod}`zarr` `<3` dependency {user}`ilan-gold` ({pr}`2309`)
 - {attr}`anndata.AnnData.X` is now copy-on-write like the other elements like {attr}`~anndata.AnnData.layers`. Operations like `my_subset.X = 0` will *not* propagate back to original object. {user}`ilan-gold` ({pr}`2338`)
 - Remove `Anndata.__{set,del}item__` {user}`ilan-gold` ({pr}`2367`)
@@ -28,6 +18,8 @@
 
 #### Miscellaneous changes
 
+- Switch {attr}`anndata.settings.allow_write_nullable_strings` to new default `None`, which means the writing of pandas string arrays will be controlled by `pandas.options.future.infer_string` (see the {doc}`pandas:user_guide/migration-3-strings`).
+  Setting `allow_write_nullable_strings=False` explicitly now means to try writing the array in the non-nullable string array format, which was the only supported format up to anndata 0.11. {smaller}`P Angerer` ({pr}`2133`)
 - Flip default for {attr}`anndata.settings.disallow_forward_slash_in_h5ad` to `True`.
   Document writing to `k="/"` in {func}`~anndata.io.write_elem` and check `k` more strictly {user}`flying-sheep` ({pr}`2436`)
 
@@ -41,7 +33,6 @@
 - New {meth}`anndata.AnnData.unwriteable` for checking if an `AnnData` can be written {user}`ilan-gold` ({pr}`2372`)
 - Create a new setting {attr}`anndata.settings.restrict_index_types` to allow for custom in-memory indexes (i.e., for {attr}`~anndata.AnnData.obs` and {attr}`~anndata.AnnData.var`) to be passed to an {class}`~anndata.AnnData` object without being converted to a string type.
   Note that indexes recognized by {func}`pandas.api.types.is_integer_dtype` will still be stringified regardless of the setting.
-
   {user}`ilan-gold` ({pr}`2379`)
 - {attr}`anndata.settings.zarr_write_format` is now 3 and {func}`anndata.settings.auto_shard_zarr_v3` is now `True` (with `None` removed as an option).
   This means that sharded zarr v3 stores will be written with a target uncompressed shard size of 1GB unless the user either
@@ -50,9 +41,7 @@
   - explicitly creates a {class}`zarr.Group` with `zarr_format=2`, or
   - overrides the `shards` in `dataset_kwargs` passed in to {func}`~anndata.io.write_elem`
 
-  {user}`ilan-gold`
-
-  ({pr}`2439`)
+  {user}`ilan-gold` ({pr}`2439`)
 
 #### Bug fixes
 

--- a/docs/release-notes/0.13.0rc1.md
+++ b/docs/release-notes/0.13.0rc1.md
@@ -31,6 +31,7 @@
   {user}`flying-sheep` & {user}`ilan-gold` ({pr}`1707`)
 - Support setting with [array-api compatible](https://data-apis.org/array-api/latest/) objects i.e., `adata.X = jax.numpy.array([[0, 1], [2, 3]])` {user}`ilan-gold` {user}`amalia-k510` ({pr}`2071`)
 - Add support for Dask {class}`dask.array.Array`s containing {class}`~scipy.sparse.sparray`s {user}`flying-sheep` ({pr}`2087`)
+- Add {ref}`accessors` for referencing vectors in {class}`~anndata.AnnData` and {class}`~mudata.MuData` {user}`flying-sheep` ({pr}`2290`)
 - New {meth}`anndata.AnnData.unwriteable` for checking if an `AnnData` can be written {user}`ilan-gold` ({pr}`2372`)
 - Create a new setting {attr}`anndata.settings.restrict_index_types` to allow for custom in-memory indexes (i.e., for {attr}`~anndata.AnnData.obs` and {attr}`~anndata.AnnData.var`) to be passed to an {class}`~anndata.AnnData` object without being converted to a string type.
   Note that indexes recognized by {func}`pandas.api.types.is_integer_dtype` will still be stringified regardless of the setting.


### PR DESCRIPTION
they are messed up a bit:

- a comment doesn’t render as one and wasn’t applied
- an admonition wasn’t formatted correctly
- I forgot to add a ref path relnote

See https://icb-anndata--2505.com.readthedocs.build/en/2505/release-notes/index.html#version-0-13