### PR TITLE
fix: accessors: don't import mudata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ doc = [
     "sphinx-design",
     "anndata[dask]",
     "pandas>=3",
+    "mudata",
     # for unreleased changes
     { include-group = "dev-doc" },
 ]

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -6,7 +6,6 @@ import abc
 from collections.abc import Hashable
 from dataclasses import KW_ONLY, dataclass, field
 from functools import cached_property
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, ClassVar, cast, overload
 
 import pandas as pd
@@ -17,7 +16,7 @@ from .._core.views import ArrayView
 from .._core.xarray import Dataset2D
 from ..compat import CupySparseMatrix, DaskArray, has_xp
 
-if TYPE_CHECKING or find_spec("mudata"):
+if TYPE_CHECKING:
     from mudata import MuData
 else:
     MuData = type("MuData", (), {"__module__": "mudata"})


### PR DESCRIPTION
#2498 introduced circular dependencies, such that `import mudata` no longer works, unless one imports `anndata` first. So

```python
import anndata
import mudata
```
works fine, however
```python
import mudata
```
results in 
```python
ImportError: cannot import name 'MuData' from partially initialized module 'mudata' (most likely due to a circular import) (/data/ilia/mudata/src/mudata/__init__.py)
```

The `else` branch in the `if TYPE_CHECKING` block is sufficient to generate correctly linked documentation.

<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: only affects RC
