### PR TITLE
test(backed): add regression for filename=None after read_h5ad

### DIFF
--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -319,15 +319,15 @@ def test_return_to_memory_mode(adata: ad.AnnData, backing_h5ad: Path):
 
 
 @pytest.mark.parametrize(
-    ("x", "is_sparse"),
+    "x",
     [
-        pytest.param(np.arange(12).reshape(3, 4), False, id="dense"),
-        pytest.param(sparse.csr_matrix(np.arange(12).reshape(3, 4)), True, id="csr"),
-        pytest.param(sparse.csc_matrix(np.arange(12).reshape(3, 4)), True, id="csc"),
+        pytest.param(np.arange(12).reshape(3, 4), id="dense"),
+        pytest.param(sparse.csr_matrix(np.arange(12).reshape(3, 4)), id="csr"),
+        pytest.param(sparse.csc_matrix(np.arange(12).reshape(3, 4)), id="csc"),
     ],
 )
 def test_return_to_memory_mode_after_read_h5ad(
-    tmp_path: Path, x: np.ndarray | sparse.spmatrix, is_sparse: bool
+    tmp_path: Path, x: np.ndarray | sparse.spmatrix
 ):
     pth = tmp_path / "tmp.h5ad"
     expected = np.arange(12).reshape(3, 4)
@@ -340,7 +340,7 @@ def test_return_to_memory_mode_after_read_h5ad(
     assert not backed.isbacked
     assert backed.X is not None
 
-    got = backed.X.toarray() if is_sparse else backed.X
+    got = backed.X.toarray() if sparse.issparse(backed.X) else backed.X
     np.testing.assert_array_equal(got, expected)
 
 

--- a/tests/test_backed_hdf5.py
+++ b/tests/test_backed_hdf5.py
@@ -318,6 +318,32 @@ def test_return_to_memory_mode(adata: ad.AnnData, backing_h5ad: Path):
     bdata.filename = None
 
 
+@pytest.mark.parametrize(
+    ("x", "is_sparse"),
+    [
+        pytest.param(np.arange(12).reshape(3, 4), False, id="dense"),
+        pytest.param(sparse.csr_matrix(np.arange(12).reshape(3, 4)), True, id="csr"),
+        pytest.param(sparse.csc_matrix(np.arange(12).reshape(3, 4)), True, id="csc"),
+    ],
+)
+def test_return_to_memory_mode_after_read_h5ad(
+    tmp_path: Path, x: np.ndarray | sparse.spmatrix, is_sparse: bool
+):
+    pth = tmp_path / "tmp.h5ad"
+    expected = np.arange(12).reshape(3, 4)
+    ad.AnnData(X=x).write_h5ad(pth)
+
+    backed = ad.read_h5ad(pth, backed="r+")
+    assert backed.isbacked
+
+    backed.filename = None
+    assert not backed.isbacked
+    assert backed.X is not None
+
+    got = backed.X.toarray() if is_sparse else backed.X
+    np.testing.assert_array_equal(got, expected)
+
+
 def test_backed_modification(adata: ad.AnnData, backing_h5ad: Path):
     adata.X[:, 1] = 0  # Make it a little sparse
     adata.X = sparse.csr_matrix(adata.X)


### PR DESCRIPTION
## Summary
Adds regression coverage for switching from backed mode to memory mode when loading with ead_h5ad(..., backed='r+') and then setting data.filename = None.

## Details
- Adds a new parametrized test covering dense, CSR, and CSC X payloads.
- Verifies that after ilename=None:
  - isbacked is False
  - X is not None
  - data values are preserved

## Validation
- python -m pytest tests/test_backed_hdf5.py -k return_to_memory_mode -q

Refs #623
