### PR TITLE
refactor: use `sentinel` for `get` override

### DIFF
--- a/docs/accessors.rst
+++ b/docs/accessors.rst
@@ -186,7 +186,7 @@ Extending accessors
 
 There are three layers of extensibility:
 
-#.  subclassing :class:`RefAcc` and creating a new :class:`AdRef` instance for creating them:
+#.  subclassing :class:`AdRef` and creating a new :class:`AdAcc` instance for creating them:
 
     ..  code-block:: python
 
@@ -204,9 +204,6 @@ There are three layers of extensibility:
 
         adata = sc.datasets.pbmc3k_processed()
         plt.scatter(*A.obsm["X_umap"][:, [0, 1]], c=A.obs["n_counts"], data=adata)
-
-    Note that for implementing :meth:`RefAcc.get`, you will need :class:`NO_IDX`.
-
 
 #.  subclass one or more of the :term:`reference accessor`\ s, and create a new :class:`AdAcc` instance:
 
@@ -226,6 +223,9 @@ There are three layers of extensibility:
     >>> A = AdAcc(ref_class=TwoDRef, meta_cls=MyMetaAcc)
     >>> A.obs[["a", "b"]]
     A.obs[['a', 'b']]
+
+    Note that for implementing :meth:`RefAcc.get` when subclassing, you will need :class:`NO_IDX`.
+
 
 #.  subclass :class:`AdAcc` to add new accessors:
 

--- a/docs/accessors.rst
+++ b/docs/accessors.rst
@@ -167,6 +167,7 @@ See :class:`AdAcc` for examples of how to use it to create :term:`reference`\ s 
         :toctree: generated/
 
         Idx2D
+        NO_IDX
 
 ..  toctree::
     :hidden:
@@ -176,6 +177,7 @@ See :class:`AdAcc` for examples of how to use it to create :term:`reference`\ s 
     generated/anndata.acc.MultiAcc
     generated/anndata.acc.GraphAcc
     generated/anndata.acc.Idx2D
+    generated/anndata.acc.NO_IDX
 
 .. _extending accessors:
 
@@ -202,6 +204,8 @@ There are three layers of extensibility:
 
         adata = sc.datasets.pbmc3k_processed()
         plt.scatter(*A.obsm["X_umap"][:, [0, 1]], c=A.obs["n_counts"], data=adata)
+
+    Note that for implementing :meth:`RefAcc.get`, you will need :class:`NO_IDX`.
 
 
 #.  subclass one or more of the :term:`reference accessor`\ s, and create a new :class:`AdAcc` instance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "array-api-compat>=1.7.1",
     "legacy-api-wrap",
     "zarr >=3.1",
-    "typing-extensions; python_version<'3.13'",
+    "typing-extensions; python_version<='3.14'",
     "scverse-misc[settings]>=0.1.0",
 ]
 dynamic = [ "version" ]

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar, cast, overload
 
 if sys.version_info < (3, 15):
-    from typing_extensions import Sentinel
+    from typing_extensions import sentinel
 
 import pandas as pd
 import scipy.sparse as sp
@@ -57,7 +57,7 @@ type DataFrameLike = pd.DataFrame | Dataset2D
 type FullArray = _XDataType | DataFrameLike | AwkArray
 """A complete array one level up from an :class:`AdRef`, e.g. `adata[A.obs]` or `adata[A.obsm["pca"]]`."""
 
-_NO_IDX = Sentinel("NO_IDX")
+_NO_IDX = sentinel("NO_IDX")
 
 __all__ = [
     "A",
@@ -200,7 +200,7 @@ class RefAcc[R: AdRef[I], I, D: MuData | AnnData](abc.ABC):  # type: ignore
     @overload
     def get(self, data: D, idx: I, /) -> Array: ...
     @abc.abstractmethod
-    def get(self, data: D, idx: I | Sentinel = _NO_IDX, /) -> Array | FullArray:
+    def get(self, data: D, idx: I | sentinel = _NO_IDX, /) -> Array | FullArray:
         """Get the indexed array from the AnnData object at `idx`.
 
         When `idx` is omitted, return the full array one level up instead.
@@ -287,7 +287,7 @@ class LayerAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, AnnData]):
     @overload
     def get(self, adata: AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, adata: AnnData, idx: Idx2D | Sentinel = _NO_IDX, /
+        self, adata: AnnData, idx: Idx2D | sentinel = _NO_IDX, /
     ) -> _XDataType | InMemoryArray:
         if idx is _NO_IDX:
             return adata.X if self.k is None else adata.layers[self.k]
@@ -381,7 +381,7 @@ class MetaAcc[R: AdRef[str | None]](RefAcc[R, str | None, MuData | AnnData]):
         self, data: MuData | AnnData, k: str | None, /
     ) -> pd.api.extensions.ExtensionArray | XVariable: ...
     def get(
-        self, data: MuData | AnnData, k: str | None | Sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, k: str | None | sentinel = _NO_IDX, /
     ) -> DataFrameLike | pd.api.extensions.ExtensionArray | XVariable:
         full: DataFrameLike = getattr(data, self.dim)
         if k is _NO_IDX:
@@ -468,7 +468,7 @@ class MultiAcc[R: AdRef[int]](RefAcc[R, int, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, i: int, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, i: int | Sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, i: int | sentinel = _NO_IDX, /
     ) -> FullArray | InMemoryArray:
         full: FullArray = getattr(data, f"{self.dim}m")[self.k]
         if i is _NO_IDX:
@@ -564,7 +564,7 @@ class GraphAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, idx: Idx2D | Sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, idx: Idx2D | sentinel = _NO_IDX, /
     ) -> _XDataType | InMemoryArray:
         full: _XDataType = getattr(data, f"{self.dim}p")[self.k]
         if idx is _NO_IDX:

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -57,9 +57,11 @@ type DataFrameLike = pd.DataFrame | Dataset2D
 type FullArray = _XDataType | DataFrameLike | AwkArray
 """A complete array one level up from an :class:`AdRef`, e.g. `adata[A.obs]` or `adata[A.obsm["pca"]]`."""
 
-_NO_IDX = sentinel("NO_IDX")
+NO_IDX = sentinel("NO_IDX")
+"""Sentinel object needed for implementing :meth:`anndata.acc.RefAcc.get` when subclassing."""
 
 __all__ = [
+    "NO_IDX",
     "A",
     "AdAcc",
     "AdRef",
@@ -200,10 +202,10 @@ class RefAcc[R: AdRef[I], I, D: MuData | AnnData](abc.ABC):  # type: ignore
     @overload
     def get(self, data: D, idx: I, /) -> Array: ...
     @abc.abstractmethod
-    def get(self, data: D, idx: I | sentinel = _NO_IDX, /) -> Array | FullArray:
+    def get(self, data: D, idx: I | NO_IDX = NO_IDX, /) -> Array | FullArray:
         """Get the indexed array from the AnnData object at `idx`.
 
-        When `idx` is omitted, return the full array one level up instead.
+        When `idx` is omitted (i.e., `idx` is :class:`~anndata.acc.NO_IDX`), return the full array one level up instead.
         This has the same semantics as the `AdRef` path but one level up:
         `adata[A.obs]` returns the full :class:`~pandas.DataFrame` and `adata[A.obsm["pca"]]` the full :class:`numpy.ndarray`.
         These both have defined `shape`-like properties (or :class:`awkward.Array`), unlike, for example, :attr:`~anndata.AnnData.obsm` or similar.
@@ -287,9 +289,9 @@ class LayerAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, AnnData]):
     @overload
     def get(self, adata: AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, adata: AnnData, idx: Idx2D | sentinel = _NO_IDX, /
+        self, adata: AnnData, idx: Idx2D | NO_IDX = NO_IDX, /
     ) -> _XDataType | InMemoryArray:
-        if idx is _NO_IDX:
+        if idx is NO_IDX:
             return adata.X if self.k is None else adata.layers[self.k]
         # To keep things as lazy as possible, we don't reuse the full-array branch here
         arr = adata[idx].X if self.k is None else adata[idx].layers[self.k]
@@ -381,10 +383,10 @@ class MetaAcc[R: AdRef[str | None]](RefAcc[R, str | None, MuData | AnnData]):
         self, data: MuData | AnnData, k: str | None, /
     ) -> pd.api.extensions.ExtensionArray | XVariable: ...
     def get(
-        self, data: MuData | AnnData, k: str | None | sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, k: str | None | NO_IDX = NO_IDX, /
     ) -> DataFrameLike | pd.api.extensions.ExtensionArray | XVariable:
         full: DataFrameLike = getattr(data, self.dim)
-        if k is _NO_IDX:
+        if k is NO_IDX:
             return full
         match full, k:
             case pd.DataFrame() as df, None:
@@ -468,10 +470,10 @@ class MultiAcc[R: AdRef[int]](RefAcc[R, int, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, i: int, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, i: int | sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, i: int | NO_IDX = NO_IDX, /
     ) -> FullArray | InMemoryArray:
         full: FullArray = getattr(data, f"{self.dim}m")[self.k]
-        if i is _NO_IDX:
+        if i is NO_IDX:
             return full
         # TODO: remove slicing when dropping scipy <1.14
         return self._maybe_flatten(i, full[:, i : i + 1])
@@ -564,10 +566,10 @@ class GraphAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, idx: Idx2D | sentinel = _NO_IDX, /
+        self, data: MuData | AnnData, idx: Idx2D | NO_IDX = NO_IDX, /
     ) -> _XDataType | InMemoryArray:
         full: _XDataType = getattr(data, f"{self.dim}p")[self.k]
-        if idx is _NO_IDX:
+        if idx is NO_IDX:
             return full
         df = cast("pd.DataFrame", getattr(data, self.dim))
         # TODO: remove wrapping in [] when dropping scipy <1.14

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import abc
+import sys
 from collections.abc import Hashable
 from dataclasses import KW_ONLY, dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar, cast, overload
+
+if sys.version_info < (3, 15):
+    from typing_extensions import Sentinel
 
 import pandas as pd
 import scipy.sparse as sp
@@ -53,16 +57,7 @@ type DataFrameLike = pd.DataFrame | Dataset2D
 type FullArray = _XDataType | DataFrameLike | AwkArray
 """A complete array one level up from an :class:`AdRef`, e.g. `adata[A.obs]` or `adata[A.obsm["pca"]]`."""
 
-
-class _NoIdx:
-    """Sentinel for :meth:`RefAcc.get`: no index given, so return the full array."""
-
-    def __repr__(self) -> str:
-        return "Return Full Array"
-
-
-_NO_IDX = _NoIdx()
-
+_NO_IDX = Sentinel("NO_IDX")
 
 __all__ = [
     "A",
@@ -205,7 +200,7 @@ class RefAcc[R: AdRef[I], I, D: MuData | AnnData](abc.ABC):  # type: ignore
     @overload
     def get(self, data: D, idx: I, /) -> Array: ...
     @abc.abstractmethod
-    def get(self, data: D, idx: I | _NoIdx = _NO_IDX, /) -> Array | FullArray:
+    def get(self, data: D, idx: I | Sentinel = _NO_IDX, /) -> Array | FullArray:
         """Get the indexed array from the AnnData object at `idx`.
 
         When `idx` is omitted, return the full array one level up instead.
@@ -292,9 +287,9 @@ class LayerAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, AnnData]):
     @overload
     def get(self, adata: AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, adata: AnnData, idx: Idx2D | _NoIdx = _NO_IDX, /
+        self, adata: AnnData, idx: Idx2D | Sentinel = _NO_IDX, /
     ) -> _XDataType | InMemoryArray:
-        if isinstance(idx, _NoIdx):
+        if idx is _NO_IDX:
             return adata.X if self.k is None else adata.layers[self.k]
         # To keep things as lazy as possible, we don't reuse the full-array branch here
         arr = adata[idx].X if self.k is None else adata[idx].layers[self.k]
@@ -386,10 +381,10 @@ class MetaAcc[R: AdRef[str | None]](RefAcc[R, str | None, MuData | AnnData]):
         self, data: MuData | AnnData, k: str | None, /
     ) -> pd.api.extensions.ExtensionArray | XVariable: ...
     def get(
-        self, data: MuData | AnnData, k: str | None | _NoIdx = _NO_IDX, /
+        self, data: MuData | AnnData, k: str | None | Sentinel = _NO_IDX, /
     ) -> DataFrameLike | pd.api.extensions.ExtensionArray | XVariable:
         full: DataFrameLike = getattr(data, self.dim)
-        if isinstance(k, _NoIdx):
+        if k is _NO_IDX:
             return full
         match full, k:
             case pd.DataFrame() as df, None:
@@ -473,10 +468,10 @@ class MultiAcc[R: AdRef[int]](RefAcc[R, int, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, i: int, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, i: int | _NoIdx = _NO_IDX, /
+        self, data: MuData | AnnData, i: int | Sentinel = _NO_IDX, /
     ) -> FullArray | InMemoryArray:
         full: FullArray = getattr(data, f"{self.dim}m")[self.k]
-        if isinstance(i, _NoIdx):
+        if i is _NO_IDX:
             return full
         # TODO: remove slicing when dropping scipy <1.14
         return self._maybe_flatten(i, full[:, i : i + 1])
@@ -569,10 +564,10 @@ class GraphAcc[R: AdRef[Idx2D]](RefAcc[R, Idx2D, MuData | AnnData]):
     @overload
     def get(self, data: MuData | AnnData, idx: Idx2D, /) -> InMemoryArray: ...
     def get(
-        self, data: MuData | AnnData, idx: Idx2D | _NoIdx = _NO_IDX, /
+        self, data: MuData | AnnData, idx: Idx2D | Sentinel = _NO_IDX, /
     ) -> _XDataType | InMemoryArray:
         full: _XDataType = getattr(data, f"{self.dim}p")[self.k]
-        if isinstance(idx, _NoIdx):
+        if idx is _NO_IDX:
             return full
         df = cast("pd.DataFrame", getattr(data, self.dim))
         # TODO: remove wrapping in [] when dropping scipy <1.14


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

~~Using `Sentinel` for `RefAcc.get` means users can type-safely do their own overrides without needing our exact value.~~ Pipe dream, `Sentinel` is better than a random object, so now we export it and make it explicit

@ilia-kats sorry about this, @flying-sheep and I both dropped the ball on catching this

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: live change to existing feature
