### PR TITLE
fix: allow `resolve`ing `AdAcc`s

### DIFF
--- a/docs/release-notes/2550.fix.md
+++ b/docs/release-notes/2550.fix.md
@@ -1,0 +1,2 @@
+Allow {meth}`~anndata.acc.AdAcc.resolve` to resolve `AdAcc`s (e.g. `A.X`, `A.layers['y']`, `A.obsm['c']`, `A.obsp['g']`) in addition to `AdRef`s,
+when selected via `vec=False|None` (Resolve to `AdRef`s with `vec=True|None`) {user}`flying-sheep`

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -735,14 +735,42 @@ class AdAcc[R: AdRef]:
             raise ValueError(msg) from e
 
     @overload
-    def resolve(self, spec: str, *, strict: Literal[True] = True) -> R: ...
+    def resolve(
+        self, spec: str, *, strict: Literal[True] = True, vec: Literal[True]
+    ) -> R: ...
     @overload
-    def resolve(self, spec: str, *, strict: Literal[False]) -> R | None: ...
-    def resolve(self, spec: str, *, strict: bool = True) -> R | None:
+    def resolve(
+        self, spec: str, *, strict: Literal[False], vec: Literal[True]
+    ) -> R | None: ...
+    @overload
+    def resolve(
+        self, spec: str, *, strict: Literal[True] = True, vec: Literal[False]
+    ) -> LayerAcc[R] | MultiAcc[R] | GraphAcc[R]: ...
+    @overload
+    def resolve(
+        self, spec: str, *, strict: Literal[False], vec: Literal[False]
+    ) -> LayerAcc[R] | MultiAcc[R] | GraphAcc[R] | None: ...
+    @overload
+    def resolve(
+        self, spec: str, *, strict: Literal[True] = True, vec: None = None
+    ) -> R | LayerAcc[R] | MultiAcc[R] | GraphAcc[R]: ...
+    @overload
+    def resolve(
+        self, spec: str, *, strict: Literal[False], vec: None = None
+    ) -> R | LayerAcc[R] | MultiAcc[R] | GraphAcc[R] | None: ...
+    def resolve(
+        self, spec: str, *, strict: bool = True, vec: bool | None = None
+    ) -> R | LayerAcc[R] | MultiAcc[R] | GraphAcc[R] | None:
         """Create :class:`AdRef` from a simplified string.
+
+        If `vec` is `True`, `spec` must be an indexed form yielding an :class:`AdRef`, e.g. `"X[:,:]"`, `"obs.a"`, or `"obsm.c.0"` (the current default behavior).
+        If `vec` is `False`, `spec` must refer to a whole container instead (`"X"`, `"layers.<k>"`, `"obsm.<k>"`, `"varm.<k>"`, `"obsp.<k>"`, or `"varp.<k>"`), and a :class:`LayerAcc`/:class:`MultiAcc`/:class:`GraphAcc` is returned instead of an :class:`AdRef`.
+        If `vec` is unset, both forms are accepted.
 
         Examples
         --------
+        Indexed, yielding an `AdRef`:
+
         >>> A.resolve("X[:,:]")
         A.X[:, :]
         >>> A.resolve("layers.y[c,:]")
@@ -761,10 +789,21 @@ class AdAcc[R: AdRef]:
         A.obsp['g']['c1', :]
         >>> A.resolve("obsp.g[:,c2]")
         A.obsp['g'][:, 'c2']
+
+        Whole containers, yielding a `LayerAcc`/`MultiAcc`/`GraphAcc`:
+
+        >>> A.resolve("X", vec=False)
+        A.X
+        >>> A.resolve("layers.y", vec=False)
+        A.layers['y']
+        >>> A.resolve("obsm.c", vec=False)
+        A.obsm['c']
+        >>> A.resolve("obsp.g", vec=False)
+        A.obsp['g']
         """
         from ._parse_str import parse
 
-        return parse(self, spec, strict=strict)
+        return parse(self, spec, strict=strict, vec=vec)
 
     def __repr__(self) -> str:
         return "A"

--- a/src/anndata/acc/_parse_str.py
+++ b/src/anndata/acc/_parse_str.py
@@ -9,23 +9,46 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal
 
-    from . import AdAcc, AdRef, GraphAcc, Idx2D, LayerAcc
+    from . import AdAcc, AdRef, GraphAcc, Idx2D, LayerAcc, MultiAcc
 
 
 @overload
-def parse[P: AdRef](a: AdAcc[P], spec: str, *, strict: Literal[True] = True) -> P: ...
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[True] = True, vec: Literal[True]
+) -> P: ...
 @overload
-def parse[P: AdRef](a: AdAcc[P], spec: str, *, strict: Literal[False]) -> P | None: ...
-def parse[P: AdRef](a: AdAcc[P], spec: str, *, strict: bool = True) -> P | None:
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[False], vec: Literal[True]
+) -> P | None: ...
+@overload
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[True] = True, vec: Literal[False]
+) -> LayerAcc[P] | MultiAcc[P] | GraphAcc[P]: ...
+@overload
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[False], vec: Literal[False]
+) -> LayerAcc[P] | MultiAcc[P] | GraphAcc[P] | None: ...
+@overload
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[True] = True, vec: None = None
+) -> P | LayerAcc[P] | MultiAcc[P] | GraphAcc[P]: ...
+@overload
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: Literal[False], vec: None = None
+) -> P | LayerAcc[P] | MultiAcc[P] | GraphAcc[P] | None: ...
+def parse[P: AdRef](
+    a: AdAcc[P], spec: str, *, strict: bool = True, vec: bool | None = None
+) -> P | LayerAcc[P] | MultiAcc[P] | GraphAcc[P] | None:
     """Create accessor from string."""
     if not strict:
         try:
-            parse(a, spec)
+            parse(a, spec, vec=vec)
         except ValueError:
             return None
 
-    if spec.startswith("X["):
-        return _parse_path_2d(lambda _: a.X, spec)
+    if spec.startswith("X"):
+        _check_vec(spec, vec=vec, actual=(do_vec := "[" in spec))
+        return _parse_path_2d(lambda _: a.X, spec) if do_vec else a.X
     if "." not in spec:
         msg = (
             f"Cannot parse accessor {spec!r} that isn’t period-separated, "
@@ -33,21 +56,42 @@ def parse[P: AdRef](a: AdAcc[P], spec: str, *, strict: bool = True) -> P | None:
         )
         raise ValueError(msg)
     acc_name, rest = spec.split(".", 1)
-    match getattr(a, acc_name, None):
-        case LayerMapAcc() | GraphMapAcc() as acc:
-            return _parse_path_2d(acc.__getitem__, rest)
+    acc = getattr(a, acc_name, None)
+    if acc is None:  # pragma: no cover
+        msg = (
+            f"Unknown accessor {spec!r}. "
+            f"We support '{{{','.join(a.ATTRS)}}}.*' and `AdRef` instances."
+        )
+        raise ValueError(msg)
+    return _parse_dotted(acc, rest, spec, vec=vec)
+
+
+def _parse_dotted[P: AdRef](
+    acc: LayerMapAcc[P] | GraphMapAcc[P] | MetaAcc[P] | MultiMapAcc[P],
+    rest: str,
+    spec: str,
+    *,
+    vec: bool | None,
+) -> P | LayerAcc[P] | MultiAcc[P] | GraphAcc[P]:
+    match acc:
+        case LayerMapAcc() | GraphMapAcc():
+            _check_vec(spec, vec=vec, actual=(do_vec := "[" in rest))
+            return _parse_path_2d(acc.__getitem__, rest) if do_vec else acc[rest]
         case MetaAcc() as meta:
+            _check_vec(spec, vec=vec, actual=True)
             return meta[rest]
         case MultiMapAcc() as multi:
-            return _parse_path_multi(multi, rest)
-        case None:  # pragma: no cover
-            msg = (
-                f"Unknown accessor {spec!r}. "
-                f"We support '{{{','.join(a.ATTRS)}}}.*' and `AdRef` instances."
-            )
-            raise ValueError(msg)
+            _check_vec(spec, vec=vec, actual=(do_vec := "." in rest))
+            return _parse_path_multi(multi, rest) if do_vec else multi[rest]
     msg = f"Unhandled accessor {spec!r}. This is a bug!"  # pragma: no cover
     raise AssertionError(msg)  # pragma: no cover
+
+
+def _check_vec(spec: str, *, vec: bool | None, actual: bool) -> None:
+    if vec is not None and vec != actual:
+        kind = "a vector/`AdRef`" if actual else "a whole container"
+        msg = f"Accessor {spec!r} refers to {kind}, but {vec=} was requested"
+        raise ValueError(msg)
 
 
 def _parse_path_2d[P: AdRef](

--- a/tests/accessors/test_accessors.py
+++ b/tests/accessors/test_accessors.py
@@ -282,3 +282,69 @@ def test_get_full_array(
 def test_get_full_array_map_unsupported(adata: AnnData, acc: MultiMapAcc) -> None:
     with pytest.raises(IndexError, match=rf"Cannot index with {acc}"):
         adata[acc]
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        pytest.param("X[:,:]", A.X[:, :], id="x"),
+        pytest.param("layers.y[c,:]", A.layers["y"]["c", :], id="layer"),
+        pytest.param("layers.y[:,g]", A.layers["y"][:, "g"], id="layer-var"),
+        pytest.param("obs.a", A.obs["a"], id="obs"),
+        pytest.param("var.b", A.var["b"], id="var"),
+        pytest.param("obsm.c.0", A.obsm["c"][0], id="obsm"),
+        pytest.param("varm.d.1", A.varm["d"][1], id="varm"),
+        pytest.param("obsp.g[c1,:]", A.obsp["g"]["c1", :], id="obsp"),
+        pytest.param("obsp.g[:,c2]", A.obsp["g"][:, "c2"], id="obsp-var"),
+    ],
+)
+@pytest.mark.parametrize("vec", [None, True], ids=["vec=None", "vec=True"])
+def test_resolve_vec(spec: str, expected: AdRef, *, vec: Literal[True] | None) -> None:
+    assert A.resolve(spec, vec=vec) == expected
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        pytest.param("X", A.X, id="x"),
+        pytest.param("layers.y", A.layers["y"], id="layer"),
+        pytest.param("obsm.c", A.obsm["c"], id="obsm"),
+        pytest.param("varm.d", A.varm["d"], id="varm"),
+        pytest.param("obsp.g", A.obsp["g"], id="obsp"),
+        pytest.param("varp.h", A.varp["h"], id="varp"),
+    ],
+)
+@pytest.mark.parametrize("vec", [None, False], ids=["vec=None", "vec=False"])
+def test_resolve_matrix(
+    spec: str, expected: object, *, vec: Literal[False] | None
+) -> None:
+    assert A.resolve(spec, vec=vec) == expected
+
+
+@pytest.mark.parametrize(
+    ("spec", "vec"),
+    [
+        pytest.param("X", True, id="x-matrix-as-vec"),
+        pytest.param("X[:,:]", False, id="x-vec-as-matrix"),
+        pytest.param("layers.y", True, id="layer-matrix-as-vec"),
+        pytest.param("layers.y[c,:]", False, id="layer-vec-as-matrix"),
+        pytest.param("obs.a", False, id="obs-as-matrix"),
+        pytest.param("var.a", False, id="var-as-matrix"),
+        pytest.param("obsm.c", True, id="obsm-matrix-as-vec"),
+        pytest.param("obsm.c.0", False, id="obsm-vec-as-matrix"),
+        pytest.param("obsp.g", True, id="obsp-matrix-as-vec"),
+        pytest.param("obsp.g[c1,:]", False, id="obsp-vec-as-matrix"),
+    ],
+)
+def test_resolve_vec_mismatch(spec: str, *, vec: bool) -> None:
+    with pytest.raises(ValueError, match="vec"):
+        A.resolve(spec, vec=vec)
+
+
+@pytest.mark.parametrize(
+    ("spec", "vec"),
+    [("X", True), ("X[:,:]", False)],
+    ids=["as-vec", "as-matrix"],
+)
+def test_resolve_vec_mismatch_not_strict(spec: str, *, vec: bool) -> None:
+    assert A.resolve(spec, strict=False, vec=vec) is None


### PR DESCRIPTION
Actually more a feature, but it’s also an oversight that we decided to make `AdAcc`s more user-facing and didn’t use them here.

- [ ] Closes #
- [ ] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [ ] Release note not necessary because:
