### PR TITLE
fix: fall back to asarray when DLPack export of a read-only index fails; buffer error fix

### DIFF
--- a/src/anndata/compat/__init__.py
+++ b/src/anndata/compat/__init__.py
@@ -87,7 +87,11 @@ class IndexManager:
             existing_xp = existing.__array_namespace__()
             if existing_xp is xp:
                 return existing
-            return xp.from_dlpack(existing)
+            try:
+                return xp.from_dlpack(existing)
+            except BufferError:
+                # numpy#20742: read-only arrays can’t be exported via DLPack
+                return xp.asarray(existing)
         self.add_array(xp.from_dlpack(src_arr, copy=True))
         return self._manager[device]
 


### PR DESCRIPTION
Was running into issues with certain scanpy tests when testing with jax arrays. Example:

```
FAILED tests/test_pca.py::test_mask_defaults[jax_array-float32] - BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack (supported by newer DLPack version).
FAILED tests/test_pca.py::test_mask_var_argument_equivalence[float32-jax_array] - BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack (supported by newer DLPack version).
FAILED tests/test_pca.py::test_mask_defaults[jax_array-float64] - BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack (supported by newer DLPack version).
FAILED tests/test_pca.py::test_mask_var_argument_equivalence[float64-jax_array] - BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack (supported by newer DLPack version).
```

This is the same problem we already handle in `__array__` a few lines above, where the comment notes we can't round-trip jax arrays through DLPack and should let numpy handle it in `asarray` instead.

The fix keeps `from_dlpack` as the fast path and only falls back to `asarray` if it actually fails. The array API spec says `from_dlpack` raises `BufferError` in exactly this case, so catching it is the intended way to handle it.