### PR TITLE
Fix lazy dataframe reindexing with unloaded annotation indexes

### DIFF
--- a/docs/release-notes/2475.fix.md
+++ b/docs/release-notes/2475.fix.md
@@ -1,0 +1,1 @@
+Fix lazy concatenation of dataframe annotations when their true indexes were not loaded into memory.

--- a/src/anndata/_core/xarray.py
+++ b/src/anndata/_core/xarray.py
@@ -409,22 +409,26 @@ class Dataset2D(Mapping[Hashable, XDataArray | Self]):
         -------
             Reindexed dataset.
         """
-        index_dim = self.index_dim
         if axis != 0:  # pragma: no cover
             msg = f"Only axis 0 is supported, got axis: {axis}"
             raise ValueError(msg)
+        dataset = self
+        if dataset.true_index_dim != dataset.index_dim:
+            dataset = dataset.copy()
+            dataset.index = dataset.true_index
+        index_dim = dataset.index_dim
         # Dataset.reindex() can't handle ExtensionArrays
         extension_arrays = {
             col: data
-            for col, data in self._items()
+            for col, data in dataset._items()
             if pd.api.types.is_extension_array_dtype(data.dtype)
         }
-        el = self.ds.drop_vars(extension_arrays.keys())
+        el = dataset.ds.drop_vars(extension_arrays.keys())
         el = el.reindex({index_dim: index}, method=None, fill_value=fill_value)
         for col, data in extension_arrays.items():
             el[col] = XDataArray.from_series(
-                pd.Series(data.data, index=self.index).reindex(
-                    index.rename(self.index.name) if index is not None else index,
+                pd.Series(data.data, index=dataset.index).reindex(
+                    index.rename(dataset.index.name) if index is not None else index,
                     fill_value=fill_value,
                 )
             )

--- a/tests/lazy/test_concat.py
+++ b/tests/lazy/test_concat.py
@@ -304,6 +304,38 @@ def test_concat_data_subsetting(
     )
 
 
+def test_concat_dataframes_without_annotation_index(tmp_path: Path):
+    paths = []
+    for dataset_index in range(2):
+        path = tmp_path / f"{dataset_index}.zarr"
+        paths.append(path)
+        obs = pd.DataFrame(
+            {"value": np.arange(4)},
+            index=pd.Index(f"cell_{dataset_index}_{i}" for i in range(4)),
+        )
+        var = pd.DataFrame(
+            {"value": np.arange(4)},
+            index=pd.Index(
+                f"gene_{i}{f'_{dataset_index}' if i % 2 else ''}" for i in range(4)
+            ),
+        )
+        ad.AnnData(
+            X=np.ones((4, 4)),
+            obs=obs,
+            var=var,
+            obsm={"df": obs},
+            varm={"df": var},
+        ).write_zarr(path)
+
+    result = ad.concat(
+        [read_lazy(path, load_annotation_index=False) for path in paths],
+        join="outer",
+    )
+
+    assert result.shape == (8, 6)
+    assert result.obsm["df"].shape == (8, 1)
+
+
 @pytest.mark.parametrize(
     ("attr", "key"),
     (


### PR DESCRIPTION
- [x] Closes #2475
- [x] Tests added
- [ ] Release note not necessary because:

## Summary

Fix lazy concatenation of dataframe annotations when load_annotation_index=False and the datasets require outer reindexing.

## Root cause

Lazy dataframe annotations retain a temporary range index while their real annotation index is stored separately as the true index. Dataset2D.reindex aligned against that temporary range index. With pandas 3 string dtypes, xarray then attempted to fill the string index variable with np.nan and raised DTypePromotionError.

Reindexing now works on a shallow copy whose computational index has first been switched to the true annotation index. The original lazy dataset remains unchanged.

## Test plan

- [x] Reproduce #2475 on current main
- [x] Add a regression covering outer concatenation with unloaded annotation indexes
- [x] Confirm the regression fails without the source fix with the reported DTypePromotionError
- [x] Run tests/lazy/test_concat.py: 570 passed, 64 skipped, 16 xfailed, 56 subtests passed
- [x] Run Ruff checks and formatting checks on changed Python files
- [x] Add a release note fragment