### PR TITLE
feat: honor use_sparse_array_on_read in lazy sparse reads

### DIFF
--- a/docs/release-notes/2566.feat.md
+++ b/docs/release-notes/2566.feat.md
@@ -1,0 +1,1 @@
+Honor the `use_sparse_array_on_read` setting when lazily reading sparse data (e.g. `read_elem_lazy`), so lazy/backed reads return `csr_array`/`csc_array` consistently with in-memory reads {smaller}`Kayaba-Attribution`

--- a/src/anndata/_core/raw.py
+++ b/src/anndata/_core/raw.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from typing import ClassVar
 
     from ..acc import AdRef
-    from ..compat import CSMatrix
+    from ..compat import CSArray, CSMatrix
     from ..typing import Index, InMemoryArray, _Index1DNorm
     from .aligned_mapping import AxisArraysView
     from .anndata import AnnData
@@ -32,7 +32,7 @@ class Raw:
     def __init__(
         self,
         adata: AnnData,
-        X: np.ndarray | CSMatrix | None = None,
+        X: np.ndarray | CSMatrix | CSArray | None = None,
         var: pd.DataFrame | Mapping[str, Sequence] | None = None,
         varm: AxisArrays | Mapping[str, np.ndarray] | None = None,
     ) -> None:
@@ -74,7 +74,7 @@ class Raw:
         return self.X
 
     @property
-    def X(self) -> BaseCompressedSparseDataset | np.ndarray | CSMatrix:
+    def X(self) -> BaseCompressedSparseDataset | np.ndarray | CSMatrix | CSArray:
         # TODO: Handle unsorted array of integer indices for h5py.Datasets
         if not self._adata.isbacked:
             return self._X

--- a/src/anndata/_io/specs/lazy_methods.py
+++ b/src/anndata/_io/specs/lazy_methods.py
@@ -167,7 +167,10 @@ def read_sparse_as_dask(
     chunk_layout = (
         (chunks_minor, chunks_major) if is_csc else (chunks_major, chunks_minor)
     )
-    memory_format = sparse.csc_matrix if is_csc else sparse.csr_matrix
+    if ad.settings.use_sparse_array_on_read:
+        memory_format = sparse.csc_array if is_csc else sparse.csr_array
+    else:
+        memory_format = sparse.csc_matrix if is_csc else sparse.csr_matrix
     make_chunk = partial(make_dask_chunk, path_or_sparse_dataset, elem_name)
     da_mtx = da.map_blocks(
         make_chunk,

--- a/tests/lazy/test_read.py
+++ b/tests/lazy/test_read.py
@@ -9,8 +9,11 @@ import numpy as np
 import pandas as pd
 import pytest
 import zarr
+from scipy import sparse
 
+import anndata as ad
 from anndata import AnnData
+from anndata._io.zarr import open_write_group
 from anndata.compat import DaskArray
 from anndata.experimental import read_elem_lazy, read_lazy
 from anndata.experimental.backed._io import ANNDATA_ELEMS
@@ -295,3 +298,25 @@ def test_nullable_string_index_decoding(tmp_path: Path):
 
     assert obs_names == expected_obs
     assert var_names == expected_var
+
+
+@pytest.mark.parametrize("sparse_format", ["csr", "csc"])
+@pytest.mark.parametrize(
+    "use_sparse_array_on_read", [True, False], ids=["array", "matrix"]
+)
+def test_read_elem_lazy_honors_sparse_array_setting(
+    tmp_path: Path, sparse_format: str, *, use_sparse_array_on_read: bool
+):
+    """`read_elem_lazy` should build its dask meta with a type that honors
+    ``settings.use_sparse_array_on_read`` (cs{r,c}_array vs cs{r,c}_matrix)."""
+    X = getattr(sparse, f"{sparse_format}_matrix")(sparse.random(50, 40, density=0.1))
+    f = open_write_group(tmp_path / "test.zarr", mode="a")
+    write_elem(f, "X", X)
+
+    with ad.settings.override(use_sparse_array_on_read=use_sparse_array_on_read):
+        result = read_elem_lazy(f["X"])
+
+    assert isinstance(result, DaskArray)
+    kind = "array" if use_sparse_array_on_read else "matrix"
+    expected_cls = getattr(sparse, f"{sparse_format}_{kind}")
+    assert isinstance(result._meta, expected_cls)


### PR DESCRIPTION
Part of #2477 (foundation PR — intentionally does **not** close the issue; PRs 2-3 follow).

The first, non-breaking step of the `cs{r,c}_array` migration.

### What
- `read_sparse_as_dask` (the lazy/dask sparse read path) now honors `settings.use_sparse_array_on_read`, mirroring the in-memory read path (`BackedSparseMatrix.memory_format`). It previously hardcoded `cs{r,c}_matrix`, so lazy/backed reads ignored the setting.
- Widen `Raw.__init__`'s `X` parameter and the `Raw.X` property return type to `CSMatrix | CSArray` (they were `CSMatrix`-only).

### Why
Preparation for turning `use_sparse_array_on_read` on by default: the read paths should agree on the container type first. This removes an inconsistency where in-memory reads honored the setting but lazy reads did not.

### Notes
- Non-breaking: the default (`use_sparse_array_on_read = False`) is unchanged, so behavior is identical unless a user has already opted in.
- Added `test_read_elem_lazy_honors_sparse_array_setting` (csr/csc x array/matrix). The affected modules (`test_read.py`, `test_backed_sparse.py`, `test_raw.py`, `test_x.py`) pass under `--strict-warnings`.

---

- [ ] Closes # <!-- part of #2477; intentionally does not close -->
- [x] Tests added
