### PR TITLE
fix: replace H5AD only after successful write

### DIFF
--- a/docs/release-notes/2570.fix.md
+++ b/docs/release-notes/2570.fix.md
@@ -1,0 +1,1 @@
+{meth}`~anndata.AnnData.write_h5ad` now replaces an existing HDF5 file only after a successful write. This change preserves the existing file when the write or replacement fails. {user}`stanbot8`

--- a/src/anndata/_io/h5ad.py
+++ b/src/anndata/_io/h5ad.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+import shutil
+import tempfile
 from collections.abc import MutableMapping
+from contextlib import contextmanager, nullcontext
 from functools import partial
 from pathlib import Path
 from types import MappingProxyType
@@ -47,6 +50,40 @@ if TYPE_CHECKING:
     from .._types import StorageType
 
 
+@contextmanager
+def _write_path(filepath: Path, mode: str):
+    if mode != "w":
+        yield filepath
+        return
+
+    target = filepath.resolve()
+    target_exists = target.exists()
+    if target_exists and target.stat().st_nlink > 1:
+        msg = f"Cannot safely overwrite {target} because it has multiple hard links."
+        raise OSError(msg)
+
+    with tempfile.TemporaryDirectory(
+        dir=target.parent, prefix=f".{target.name}-", suffix=".tmp"
+    ) as directory:
+        temporary = Path(directory) / target.name
+        target_handle = (
+            h5py.File(target, "r+")
+            if target_exists and h5py.is_hdf5(target)
+            else nullcontext()
+        )
+        with target_handle:
+            yield temporary
+            if target.exists():
+                if target.stat().st_nlink > 1:
+                    msg = (
+                        f"Cannot safely overwrite {target} because it has "
+                        "multiple hard links."
+                    )
+                    raise OSError(msg)
+                shutil.copymode(target, temporary)
+        temporary.replace(target)
+
+
 @no_write_dataset_2d
 def write_h5ad(
     filepath: PathLike[str] | str,
@@ -81,7 +118,7 @@ def write_h5ad(
     if adata.isbacked:  # close so that we can reopen below
         adata.file.close()
 
-    with h5py.File(filepath, mode) as f:
+    with _write_path(filepath, mode) as write_path, h5py.File(write_path, mode) as f:
         # TODO: Use spec writing system for this
         # Currently can't use write_dispatched here because this function is also called to do an
         # inplace update of a backed object, which would delete "/"

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import errno
+import os
 import re
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import ExitStack, contextmanager, nullcontext
 from functools import partial
 from importlib.util import find_spec
 from pathlib import Path
@@ -17,6 +19,7 @@ import zarr
 from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 
 import anndata as ad
+from anndata._io import h5ad as h5ad_io
 from anndata._io.specs.registry import IORegistryError
 from anndata._io.zarr import open_write_group
 from anndata._types import AnnDataElem
@@ -334,6 +337,167 @@ def test_readwrite_h5ad_one_dimension(typ, backing_h5ad):
     adata = ad.read_h5ad(backing_h5ad)
     assert adata.shape == (3, 1)
     assert_equal(adata, adata_one)
+
+
+def _write_h5ad_value(path: Path, value: int) -> None:
+    ad.AnnData(np.array([[value]])).write_h5ad(path)
+
+
+def _try_write_h5ad(path: Path, value: int) -> OSError | None:
+    try:
+        _write_h5ad_value(path, value)
+    except OSError as error:
+        return error
+    return None
+
+
+def test_write_h5ad_preserves_locked_file(tmp_path: Path) -> None:
+    path = tmp_path / "adata.h5ad"
+    _write_h5ad_value(path, 1)
+    original = path.read_bytes()
+
+    with h5py.File(path, "r") as reader:
+        with pytest.raises(
+            OSError, match=r"(?i)(lock|open|permission|used by another process)"
+        ):
+            _write_h5ad_value(path, 2)
+        assert reader["X"][0, 0] == 1
+
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("race_at", ["exists", "replace"])
+def test_write_h5ad_race_keeps_both_paths_valid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, race_at: str
+) -> None:
+    path = tmp_path / "adata.h5ad"
+    _write_h5ad_value(path, 1)
+    original = path.read_bytes()
+    original_exists = Path.exists
+    original_replace = Path.replace
+    reader: h5py.File | None = None
+
+    with ExitStack() as readers:
+        if race_at == "exists":
+            path.unlink()
+
+            def exists_after_reader_opens(source: Path) -> bool:
+                nonlocal reader
+                if source != path or reader is not None:
+                    return original_exists(source)
+                path.write_bytes(original)
+                reader = readers.enter_context(h5py.File(path, "r"))
+                return False
+
+            monkeypatch.setattr(Path, "exists", exists_after_reader_opens)
+        else:
+
+            def replace_with_reader(source: Path, target: Path) -> Path:
+                nonlocal reader
+                reader = readers.enter_context(h5py.File(path, "r"))
+                return original_replace(source, target)
+
+            monkeypatch.setattr(Path, "replace", replace_with_reader)
+
+        write_error = _try_write_h5ad(path, 2)
+        assert reader is not None
+        assert reader["X"][0, 0] == 1
+
+    expected = 1 if write_error else 2
+    assert ad.read_h5ad(path).X[0, 0] == expected
+
+
+@pytest.mark.parametrize(
+    ("failure_at", "initial"),
+    [
+        ("write", "hdf5"),
+        ("write", "other"),
+        ("write", "missing"),
+        ("replace", "hdf5"),
+    ],
+)
+def test_write_h5ad_failure_preserves_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_at: Literal["write", "replace"],
+    initial: str,
+) -> None:
+    path = tmp_path / "adata.h5ad"
+    if initial == "hdf5":
+        _write_h5ad_value(path, 1)
+    elif initial == "other":
+        path.write_bytes(b"not an HDF5 file")
+    original = path.read_bytes() if path.exists() else None
+
+    write_error = OSError(errno.ENOSPC, "No space left on device")
+
+    def fail(*args, **kwargs) -> None:
+        raise write_error
+
+    if failure_at == "write":
+        monkeypatch.setattr(h5ad_io, "write_elem", fail)
+    else:
+        monkeypatch.setattr(Path, "replace", fail)
+    with pytest.raises(OSError, match=re.escape(str(write_error))) as error:
+        _write_h5ad_value(path, 2)
+
+    assert error.value is write_error
+    if original is None:
+        assert not path.exists()
+    else:
+        assert path.read_bytes() == original
+    assert not tuple(tmp_path.glob(".adata.h5ad-*.tmp"))
+
+
+def test_write_h5ad_preserves_symlink(tmp_path: Path) -> None:
+    path = tmp_path / "adata.h5ad"
+    link = tmp_path / "linked.h5ad"
+    _write_h5ad_value(path, 1)
+    try:
+        link.symlink_to(path)
+    except OSError as error:
+        pytest.skip(f"Cannot create a symbolic link: {error}")
+
+    _write_h5ad_value(link, 2)
+
+    assert link.is_symlink()
+    assert ad.read_h5ad(path).X[0, 0] == 2
+
+
+def test_write_h5ad_rejects_hard_links(tmp_path: Path) -> None:
+    path = tmp_path / "adata.h5ad"
+    link = tmp_path / "linked.h5ad"
+    _write_h5ad_value(path, 1)
+    try:
+        link.hardlink_to(path)
+    except OSError as error:
+        pytest.skip(f"Cannot create a hard link: {error}")
+    original = path.read_bytes()
+
+    with pytest.raises(OSError, match="multiple hard links"):
+        _write_h5ad_value(path, 2)
+
+    assert path.read_bytes() == original
+    assert link.read_bytes() == original
+
+
+@pytest.mark.parametrize("initial", ["missing", "existing"])
+@pytest.mark.skipif(os.name == "nt", reason="Windows has no POSIX file mode.")
+def test_write_h5ad_file_mode(tmp_path: Path, initial: str) -> None:
+    path = tmp_path / "adata.h5ad"
+    if initial == "existing":
+        _write_h5ad_value(path, 1)
+        path.chmod(0o640)
+        expected = 0o640
+    else:
+        direct = tmp_path / "direct.h5ad"
+        with h5py.File(direct, "w") as f:
+            f["X"] = np.array([[1]])
+        expected = direct.stat().st_mode & 0o777
+
+    _write_h5ad_value(path, 2)
+
+    assert path.stat().st_mode & 0o777 == expected
 
 
 @pytest.mark.parametrize("typ", ARRAY_TYPES)
@@ -1034,7 +1198,10 @@ def test_forward_slash_key(
     ):
         getattr(a, f"write_{store_type}")(path)
 
-    # read and check that bad keys were only written if allowed
+    if store_type == "h5ad" and not can_write_slash_key:
+        assert not path.exists()
+        return
+
     elem = getattr(getattr(ad, f"read_{store_type}")(path), elem_key)
     if can_write_slash_key:
         if elem_key in {"obs", "var"}:
@@ -1069,6 +1236,10 @@ def test_leading_slash_error(
     # while “Forward slashes” is raised earlier by `write_anndata`/`write_h5ad`
     with pytest.raises(ValueError, match=r"not in the subpath|Forward slashes"):
         getattr(a, f"write_{store_type}")(path)
+
+    if store_type == "h5ad":
+        assert not path.exists()
+        return
 
     elem = getattr(getattr(ad, f"read_{store_type}")(path), elem_key)
     if elem_key in {"obs", "var"}:


### PR DESCRIPTION
### Summary

HDF5 can truncate a live H5AD target before it reports a lock failure ([h5py issue 1864](https://github.com/h5py/h5py/issues/1864), [HDF5 issue HDFFV-11230](https://jira.hdfgroup.org/browse/HDFFV-11230)). This change writes a complete replacement to a temporary file. It replaces the target only after the write succeeds. Closes [#522](https://github.com/scverse/anndata/issues/522).

### Design

The live target is never opened with `mode="w"`. A failed write leaves an existing target unchanged. A successful replacement publishes a complete new file. The replacement preserves symbolic links.

The implementation changes [`src/anndata/_io/h5ad.py`](https://github.com/stanbot8/anndata/blob/68c7fa5d8283140215ee359d4470116abb8a1ac9/src/anndata/_io/h5ad.py#L88). The design follows [the reported truncation reproducer](https://github.com/scverse/anndata/issues/522#issuecomment-3709729233), [the requested overwrite behavior](https://github.com/scverse/anndata/issues/522#issuecomment-1230639899), and [the HDF5 lock analysis](https://github.com/scverse/anndata/issues/522#issuecomment-1230517918).

### Limitations

- The overwrite briefly needs additional free space approximately equal to the new H5AD file size. A 10 GB output can need approximately 10 GB of additional free space.
- The replacement rejects a target with multiple hard links.
- The replacement changes the inode and copies the file mode.
- It does not copy ownership, ACLs, or extended attributes.
- It does not add directory-sync steps.

### Tests

- Race tests cover file appearance, replacement, and concurrent readers.
- Disk-full tests preserve existing HDF5 and non-HDF5 targets. New targets stay absent.
- New files keep the direct-create POSIX file mode.
- Focused tests passed on Windows and Ubuntu.
- The full Windows read/write suite passed 256 tests and skipped 23.
- Stress tests passed 60 reader cases and 10 rounds with 4 writers.
- The installed wheel, 64 MiB replacement, and pre-commit checks passed.

All 11 [CPU matrix jobs](https://github.com/scverse/anndata/actions/runs/30098479245) passed. The [benchmark](https://github.com/scverse/anndata/actions/runs/30098479563/job/89498321944) and [patch coverage](https://app.codecov.io/gh/scverse/anndata/pull/2570) checks passed.

<details>
<summary>Commands</summary>

```console
pytest -q tests/test_readwrite.py -k 'test_write_h5ad'
```

</details>
