### PR TITLE
fix: suggest store class when reading a packed zarr store by path

### DIFF
--- a/docs/release-notes/2571.fix.md
+++ b/docs/release-notes/2571.fix.md
@@ -1,0 +1,1 @@
+Suggest the store class to use when {func}`~anndata.io.read_zarr` is passed the path of a single-file store such as `adata.zarr.zip`, instead of only raising `GroupNotFoundError` {user}`JOhnsonKC201`

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import os
 import warnings
 from contextlib import contextmanager, nullcontext
 from importlib.util import find_spec
+from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import zarr
 from scipy import sparse
+from zarr.errors import GroupNotFoundError
 
 from .._core.anndata import AnnData
 from .._settings import settings
@@ -20,6 +24,7 @@ from .specs import read_elem
 from .utils import _read_legacy_raw, no_write_dataset_2d, report_read_key_on_error
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import Any
 
     from zarr.core.common import AccessModeLiteral
@@ -95,6 +100,23 @@ def write_zarr(
                 zarr.consolidate_metadata(f.store)
 
 
+# Suffixes of paths that hold a whole store in a single file.
+# `zarr.open_group` treats such a path as a directory store and finds no group in
+# it, so the user has to wrap it in the matching store class themselves.
+_PACKED_STORE_CLASSES: Mapping[str, str] = MappingProxyType({
+    ".zip": "zarr.storage.ZipStore"
+})
+
+
+def _add_packed_store_note(e: BaseException, store: StoreLike) -> None:
+    """Suggest the store class to use if `store` looks like a single-file store."""
+    if not isinstance(store, os.PathLike | str):
+        return
+    path = os.fspath(store)
+    if (cls_name := _PACKED_STORE_CLASSES.get(Path(path).suffix)) is not None:
+        e.add_note(f"Did you mean `read_zarr({cls_name}({path!r}))`?")
+
+
 def read_zarr(store: StoreLike | zarr.Group) -> AnnData:
     """\
     Read from a hierarchical Zarr array store.
@@ -124,7 +146,14 @@ def read_zarr(store: StoreLike | zarr.Group) -> AnnData:
         return func(elem)
 
     with zarrs_context():
-        f = store if isinstance(store, zarr.Group) else zarr.open_group(store, mode="r")
+        if isinstance(store, zarr.Group):
+            f = store
+        else:
+            try:
+                f = zarr.open_group(store, mode="r")
+            except GroupNotFoundError as e:
+                _add_packed_store_note(e, store)
+                raise
         adata = read_dispatched(f, callback=callback)
         if not isinstance(adata, AnnData):
             msg = f"Expected an AnnData at the store root, got {type(adata).__name__}"

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import os
 import warnings
 from contextlib import contextmanager, nullcontext
 from importlib.util import find_spec
+from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import zarr
 from scipy import sparse
+from zarr.errors import GroupNotFoundError
 
 from .._core.anndata import AnnData
 from .._settings import settings
@@ -20,7 +24,7 @@ from .specs import read_elem
 from .utils import _read_legacy_raw, no_write_dataset_2d, report_read_key_on_error
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
     from os import PathLike
 
     from zarr.core.common import AccessModeLiteral
@@ -95,6 +99,23 @@ def write_zarr(
                 zarr.consolidate_metadata(f.store)
 
 
+# Suffixes of paths that hold a whole store in a single file.
+# `zarr.open` treats such a path as a directory store and finds no group in it,
+# so the user has to wrap it in the matching store class themselves.
+_PACKED_STORE_CLASSES: Mapping[str, str] = MappingProxyType({
+    ".zip": "zarr.storage.ZipStore"
+})
+
+
+def _add_packed_store_note(e: BaseException, store: StoreLike) -> None:
+    """Suggest the store class to use if `store` looks like a single-file store."""
+    if not isinstance(store, os.PathLike | str):
+        return
+    path = os.fspath(store)
+    if (cls_name := _PACKED_STORE_CLASSES.get(Path(path).suffix)) is not None:
+        e.add_note(f"Did you mean `read_zarr({cls_name}({path!r}))`?")
+
+
 def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnData:
     """\
     Read from a hierarchical Zarr array store.
@@ -123,7 +144,14 @@ def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnDa
         return func(elem)
 
     with zarrs_context():
-        f = store if isinstance(store, zarr.Group) else zarr.open(store, mode="r")
+        if isinstance(store, zarr.Group):
+            f = store
+        else:
+            try:
+                f = zarr.open(store, mode="r")
+            except GroupNotFoundError as e:
+                _add_packed_store_note(e, store)
+                raise
         adata = read_dispatched(f, callback=callback)
 
         # Backwards compat (should figure out which version)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -928,6 +928,33 @@ def test_backwards_compat_zarr() -> None:
     assert_equal(pbmc_zarr, pbmc_orig)
 
 
+def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
+    """Reading a zipped store by path suggests the store class to wrap it in."""
+    pth = tmp_path / "adata.zarr.zip"
+    orig = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
+    with zarr.storage.ZipStore(pth, mode="w") as store:
+        orig.write_zarr(store)
+
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(pth)
+    assert any("zarr.storage.ZipStore" in note for note in exc_info.value.__notes__)
+
+    # the suggested incantation works
+    with zarr.storage.ZipStore(pth, mode="r") as store:
+        assert_equal(ad.io.read_zarr(store), orig)
+
+
+def test_read_zarr_dir_path_suggests_nothing(tmp_path: Path) -> None:
+    """Paths that aren’t single-file stores get no (misleading) suggestion."""
+    pth = tmp_path / "adata.zarr"
+    pth.mkdir()
+
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(pth)
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert not any("Did you mean" in note for note in notes)
+
+
 def test_adata_in_uns(tmp_path, diskfmt, roundtrip):
     pth = tmp_path / f"adatas_in_uns.{diskfmt}"
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
+import zipfile
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from importlib.util import find_spec
@@ -41,6 +42,8 @@ from anndata.utils import get_literal_members
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from typing import Literal
+
+    from zarr.storage import StoreLike
 
 HERE = Path(__file__).parent
 ARRAY_TYPES = [
@@ -930,10 +933,14 @@ def test_backwards_compat_zarr() -> None:
 
 def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
     """Reading a zipped store by path suggests the store class to wrap it in."""
-    pth = tmp_path / "adata.zarr.zip"
     orig = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
-    with zarr.storage.ZipStore(pth, mode="w") as store:
-        orig.write_zarr(store)
+    dir_pth = tmp_path / "adata.zarr"
+    orig.write_zarr(dir_pth)
+    # zip the store’s contents; a ZipStore expects them at the archive root
+    pth = tmp_path / "adata.zarr.zip"
+    with zipfile.ZipFile(pth, mode="w") as zf:
+        for elem in filter(Path.is_file, dir_pth.rglob("*")):
+            zf.write(elem, elem.relative_to(dir_pth).as_posix())
 
     with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
         ad.io.read_zarr(pth)
@@ -944,13 +951,25 @@ def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
         assert_equal(ad.io.read_zarr(store), orig)
 
 
-def test_read_zarr_dir_path_suggests_nothing(tmp_path: Path) -> None:
-    """Paths that aren’t single-file stores get no (misleading) suggestion."""
+def _empty_dir_store(tmp_path: Path) -> Path:
     pth = tmp_path / "adata.zarr"
     pth.mkdir()
+    return pth
 
+
+@pytest.mark.parametrize(
+    "make_store",
+    [
+        pytest.param(_empty_dir_store, id="dir"),
+        pytest.param(lambda _: zarr.storage.MemoryStore(), id="memory"),
+    ],
+)
+def test_read_zarr_suggests_nothing(
+    tmp_path: Path, make_store: Callable[[Path], StoreLike]
+) -> None:
+    """Stores that aren’t single-file paths get no (misleading) suggestion."""
     with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
-        ad.io.read_zarr(pth)
+        ad.io.read_zarr(make_store(tmp_path))
     notes = getattr(exc_info.value, "__notes__", [])
     assert not any("Did you mean" in note for note in notes)
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -933,6 +933,33 @@ def test_backwards_compat_zarr() -> None:
     assert_equal(pbmc_zarr, pbmc_orig)
 
 
+def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
+    """Reading a zipped store by path suggests the store class to wrap it in."""
+    pth = tmp_path / "adata.zarr.zip"
+    orig = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
+    with zarr.storage.ZipStore(pth, mode="w") as store:
+        orig.write_zarr(store)
+
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(pth)
+    assert any("zarr.storage.ZipStore" in note for note in exc_info.value.__notes__)
+
+    # the suggested incantation works
+    with zarr.storage.ZipStore(pth, mode="r") as store:
+        assert_equal(ad.io.read_zarr(store), orig)
+
+
+def test_read_zarr_dir_path_suggests_nothing(tmp_path: Path) -> None:
+    """Paths that aren’t single-file stores get no (misleading) suggestion."""
+    pth = tmp_path / "adata.zarr"
+    pth.mkdir()
+
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(pth)
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert not any("Did you mean" in note for note in notes)
+
+
 def test_adata_in_uns(tmp_path, diskfmt, roundtrip):
     pth = tmp_path / f"adatas_in_uns.{diskfmt}"
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
+import zipfile
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from importlib.util import find_spec
@@ -35,6 +36,8 @@ from anndata.utils import get_literal_members
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from typing import Any, Literal
+
+    from zarr.storage import StoreLike
 
 HERE = Path(__file__).parent
 ARRAY_TYPES = [
@@ -935,10 +938,14 @@ def test_backwards_compat_zarr() -> None:
 
 def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
     """Reading a zipped store by path suggests the store class to wrap it in."""
-    pth = tmp_path / "adata.zarr.zip"
     orig = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
-    with zarr.storage.ZipStore(pth, mode="w") as store:
-        orig.write_zarr(store)
+    dir_pth = tmp_path / "adata.zarr"
+    orig.write_zarr(dir_pth)
+    # zip the store’s contents; a ZipStore expects them at the archive root
+    pth = tmp_path / "adata.zarr.zip"
+    with zipfile.ZipFile(pth, mode="w") as zf:
+        for elem in filter(Path.is_file, dir_pth.rglob("*")):
+            zf.write(elem, elem.relative_to(dir_pth).as_posix())
 
     with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
         ad.io.read_zarr(pth)
@@ -949,13 +956,25 @@ def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
         assert_equal(ad.io.read_zarr(store), orig)
 
 
-def test_read_zarr_dir_path_suggests_nothing(tmp_path: Path) -> None:
-    """Paths that aren’t single-file stores get no (misleading) suggestion."""
+def _empty_dir_store(tmp_path: Path) -> Path:
     pth = tmp_path / "adata.zarr"
     pth.mkdir()
+    return pth
 
+
+@pytest.mark.parametrize(
+    "make_store",
+    [
+        pytest.param(_empty_dir_store, id="dir"),
+        pytest.param(lambda _: zarr.storage.MemoryStore(), id="memory"),
+    ],
+)
+def test_read_zarr_suggests_nothing(
+    tmp_path: Path, make_store: Callable[[Path], StoreLike]
+) -> None:
+    """Stores that aren’t single-file paths get no (misleading) suggestion."""
     with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
-        ad.io.read_zarr(pth)
+        ad.io.read_zarr(make_store(tmp_path))
     notes = getattr(exc_info.value, "__notes__", [])
     assert not any("Did you mean" in note for note in notes)
 


### PR DESCRIPTION
- [x] Closes #2152
- [x] Tests added
- [ ] Release note not necessary because:

## Problem

`zarr.open` treats a path like `adata.zarr.zip` as a directory store, finds no
group in it, and raises a bare `GroupNotFoundError`. Nothing in that error hints
that the path has to be wrapped in a store class first, so the fix is hard to
guess:

```python
adata.write_zarr(zarr.storage.ZipStore("adata.zarr.zip", mode="w"))

ad.io.read_zarr("adata.zarr.zip")
# zarr.errors.GroupNotFoundError: No group found in store
# StorePath(LocalStore, 'file://…/adata.zarr.zip') at path ''
```

## Approach

This follows @flying-sheep's suggestion in
https://github.com/scverse/anndata/issues/2152#issuecomment-3415058901. When
`read_zarr` gets a path-like whose suffix is known to hold a whole store in a
single file, the raised error gets a note naming the store class to use:

```
Did you mean `read_zarr(zarr.storage.ZipStore('adata.zarr.zip'))`?
```

Deliberately **not** done, per @ilan-gold's comment on the same issue: the
suffix is not used to open a `ZipStore` automatically. Reading such a path still
raises, so there is no magic-string store inference and no behaviour change
beyond the added note. `add_note` is already the codebase's idiom for enriching
I/O errors (`anndata._io.utils.add_key_note`).

The mapping from suffix to store class is a module-level constant, so other
single-file stores can be added later without touching the logic.

`read_lazy` opens user-supplied paths the same way
(`anndata/experimental/backed/_io.py`) and so has the same rough edge. I left it
alone to keep this focused on the reported issue. Happy to extend it there in
this PR or a follow-up, whichever you prefer.

## Test plan

- [x] `test_read_zarr_zip_path_suggests_store`: asserts the note is attached,
      and that the incantation it suggests actually round-trips
- [x] `test_read_zarr_dir_path_suggests_nothing`: a directory store that holds
      no group gets no misleading suggestion
- [x] Both verified to fail before the source change and pass after
- [x] Full suite (`-m "not dask_distributed"`): 8051 passed, 1441 skipped,
      210 xfailed, 154 subtests passed in 7:45. The 3 failures are pre-existing
      and unrelated (all reproduce on `main`, and none touch this code path):
      `test_write_large_categorical[zarr2/zarr3]` is an OOM from running 16
      xdist workers locally and passes when run serially;
      `test_concatenate_disk.py::test_output_dir_exists` passes a Windows path
      to `pytest.raises(match=...)`, which is an invalid regex (`incomplete
      escape \U`) on Windows only.
- [x] `dask_distributed` shard: 59 passed, 6 skipped
- [x] `ruff check`, `ruff format --check`, `ruff check --preview --select=PLR0917`,
      and `codespell` clean on the changed files
