### PR TITLE
docs: Fix two docstring parameter names

### DIFF
--- a/src/anndata/_io/specs/methods.py
+++ b/src/anndata/_io/specs/methods.py
@@ -106,7 +106,7 @@ def zarr_v3_compressor_compat(dataset_kwargs: dict) -> dict:
 
     Parameters
     ----------
-    dataset_kwarg
+    dataset_kwargs
         The kwarg dict potentially containing "compressor"
 
     Returns

--- a/src/anndata/_types.py
+++ b/src/anndata/_types.py
@@ -253,8 +253,9 @@ class ReduceFunc[T](Protocol):
             The current element.
         accumulate
             The value being accumulated.
-        ref_acc
-            A reference to help uses distinguish where they are in the `AnnData` object.
+        attr_name
+            The name of the attribute being visited, to help distinguish where
+            you are in the `AnnData` object.
 
         Returns
         -------


### PR DESCRIPTION
Two docstrings name a parameter the signature does not have.

`_io/specs/methods.py`, `zarr_v3_compressor_compat`: documents `dataset_kwarg`, the parameter is `dataset_kwargs`. A missing `s`.

`_types.py`, `ReduceFunc.__call__`: documents `ref_acc` while the third keyword argument is `attr_name`. The old description ("A reference to help uses distinguish where they are in the `AnnData` object") does not quite fit `attr_name`, so I reworded it to say what that argument is. If the wording is off, tell me and I will use yours.

Documentation only, no behaviour change.

- [ ] Closes #
- [ ] Tests added
- [x] Release note not necessary because: docstring text only, no user-visible change.
