### PR TITLE
test: sort parametrized set values for pytest-xdist

### DIFF
--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -996,7 +996,7 @@ def test_h5py_attr_limit(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "elem_key", set(get_literal_members(AnnDataElem)) - {"raw", "X"}
+    "elem_key", sorted(set(get_literal_members(AnnDataElem)) - {"raw", "X"})
 )
 @pytest.mark.parametrize("store_type", ["zarr", "h5ad"])
 @pytest.mark.parametrize(
@@ -1053,7 +1053,7 @@ def test_forward_slash_key(
 
 
 @pytest.mark.parametrize(
-    "elem_key", set(get_literal_members(AnnDataElem)) - {"raw", "X"}
+    "elem_key", sorted(set(get_literal_members(AnnDataElem)) - {"raw", "X"})
 )
 @pytest.mark.parametrize("store_type", ["zarr", "h5ad"])
 @pytest.mark.parametrize("key", ["/", "/y"])


### PR DESCRIPTION
- Closes #2585 

- Release note not necessary because: only fixes running tests using pytest-xdist

See https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent

