### PR TITLE
fix: stricter accessor validation

### DIFF
--- a/src/anndata/acc/_parse_str.py
+++ b/src/anndata/acc/_parse_str.py
@@ -57,7 +57,14 @@ def _parse[P: AdRef](
 ) -> P | LayerAcc[P] | MultiAcc[P] | GraphAcc[P]:
     if spec.startswith("X"):
         _check_vec(spec, vec=vec, actual=(do_vec := "[" in spec))
-        return _parse_path_2d(lambda _: a.X, spec) if do_vec else a.X
+
+        def _get_x(name: str, /) -> LayerAcc[P]:
+            if name != "X":
+                msg = f"Unknown accessor name {name!r}"
+                raise ValueError(msg)
+            return a.X
+
+        return _parse_path_2d(_get_x, spec) if do_vec else _get_x(spec)
     if "." not in spec:
         msg = (
             f"Cannot parse accessor {spec!r} that isn’t period-separated, "

--- a/tests/accessors/test_accessors.py
+++ b/tests/accessors/test_accessors.py
@@ -415,6 +415,18 @@ def test_resolve_vec_mismatch(spec: str, *, vec: Literal[True, False]) -> None:
 
 
 @pytest.mark.parametrize(
+    ("spec", "pat"),
+    [
+        pytest.param("Xenon", r"Unknown accessor name", id="x-like"),
+        pytest.param("Xenon[:,:]", r"Unknown accessor name", id="x-vec-like"),
+    ],
+)
+def test_resolve_errors(spec: str, *, pat: str) -> None:
+    with pytest.raises(ValueError, match=pat):
+        A.resolve(spec)
+
+
+@pytest.mark.parametrize(
     ("spec", "vec"),
     [("X", True), ("X[:,:]", False)],
     ids=["as-vec", "as-matrix"],


### PR DESCRIPTION
<!-- Please:
1. Fill in the following check boxes
2. Make sure checks pass (Ignore “Triage” ones)
-->

- [x] Closes #2604
- [x] Tests added

<!-- only check the following checkbox (and add a reason) if you want to skip release notes -->
- [x] Release note not necessary because: small internal change
