### PR TITLE
fix: promote bool columns to nullable boolean when reindexing alt-axis annotations under outer join

### DIFF
--- a/docs/release-notes/2609.fix.md
+++ b/docs/release-notes/2609.fix.md
@@ -1,0 +1,1 @@
+Fix writing the result of `concat`/`concat_on_disk` with `join="outer"` and a union `merge` strategy when alternate-axis annotations contain `bool` columns, by promoting them to nullable `boolean` on reindexing instead of `object` {user}`srikarjy`

--- a/src/anndata/_core/merge.py
+++ b/src/anndata/_core/merge.py
@@ -593,6 +593,10 @@ class Reindexer:
     ):
         if fill_value is None:
             fill_value = np.nan
+        # Reindexing with missing values promotes numpy bool columns to object,
+        # which cannot be written to disk, so use pandas' nullable boolean dtype instead.
+        if isinstance(el, pd.DataFrame) and -1 in self.idx:
+            el = np_bool_to_pd_bool_array(el.copy())
         # axis=1 is not supported for Dataset2D, but it will throw an error
         axis = cast("Literal[0]", axis)
         return el.reindex(self.new_idx, axis=axis, fill_value=fill_value)
@@ -1207,7 +1211,7 @@ def concat_pairwise_mapping(
 def merge_dataframes(
     dfs: Iterable[pd.DataFrame], new_index, merge_strategy=merge_unique
 ) -> pd.DataFrame:
-    dfs = [df.reindex(index=new_index) for df in dfs]
+    dfs = [Reindexer(df.index, new_index)(df, axis=0) for df in dfs]
     # New dataframe with all shared data
     new_df = pd.DataFrame(merge_strategy(dfs), index=new_index)
     return new_df

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -1417,6 +1417,25 @@ def test_bool_promotion():
     assert result.obs["bool"].dtype == np.dtype(bool)
 
 
+def test_bool_promotion_alt_axis(tmp_path):
+    # https://github.com/scverse/anndata/issues/1505
+    # Outer join with a union merge strategy reindexes alt-axis annotations,
+    # which promoted numpy bool columns to object and made the result unwritable.
+    a = AnnData(
+        np.ones((3, 2)),
+        var=pd.DataFrame({"bool": [True, False]}, index=["g1", "g2"]),
+    )
+    b = AnnData(
+        np.ones((3, 2)),
+        var=pd.DataFrame({"bool": [True, True]}, index=["g2", "g3"]),
+    )
+    result = concat([a, b], join="outer", merge="first")
+
+    assert pd.api.types.is_bool_dtype(result.var["bool"])
+    assert pd.isnull(result.var.loc["g3", "bool"])
+    result.write_h5ad(tmp_path / "result.h5ad")
+
+
 @pytest.mark.parametrize(
     ("index_unique", "expect_unique"),
     [


### PR DESCRIPTION
Part of #1505.

### The bug

With `join="outer"` and any union merge strategy (`first`/`unique`/`same`/`only`), the alternate-axis dataframe is reindexed to the union index. Reindexing a plain numpy `bool` column introduces missing values, which pandas promotes to `object` dtype holding `[True, False, nan]`. The IO registry then dispatches that column to the string writer, which fails with `TypeError: Can't implicitly convert non-string objects to strings` (h5py) or `expected unicode string, found True` (zarr) — the outer-join `TypeError` cluster from #1505's failure list.

```python
import anndata as ad, numpy as np, pandas as pd

a = ad.AnnData(np.ones((3, 2)), var=pd.DataFrame({"flag": [True, False]}, index=["g1", "g2"]))
b = ad.AnnData(np.ones((3, 2)), var=pd.DataFrame({"flag": [True, True]}, index=["g2", "g3"]))
m = ad.concat([a, b], join="outer", merge="first")
m.write_h5ad("out.h5ad")  # TypeError before this PR
```

Notably this is not specific to `concat_on_disk`: in-memory `concat` produces the same unwritable `object` column, so the fix lives in the shared merge layer rather than `experimental/merge.py`.

### The fix

- `Reindexer._apply_to_df_like` promotes numpy `bool` columns to pandas nullable `boolean` before reindexing, only when the reindex actually introduces missing values (so inner joins / aligned indices keep plain `bool`, matching the behavior tested in `test_bool_promotion`). This reuses the previously-unused `np_bool_to_pd_bool_array` helper.
- `merge_dataframes` now routes its reindexing through `Reindexer` instead of a bare `df.reindex`, so `var`/`obs` and `varm`/`obsm` share the same path.

This mirrors how the concat axis already handles the same promotion (#1001), but the resulting dtype change (`bool` → nullable `boolean` in merged alt-axis annotations under outer join) is user-visible — happy to switch to a different fill policy if preferred.