### PR TITLE
Backport PR #2571 on branch 0.13.x (fix: suggest store class when reading a packed zarr store by path)

### DIFF
--- a/docs/release-notes/2571.fix.md
+++ b/docs/release-notes/2571.fix.md
@@ -1,0 +1,1 @@
+Suggest the store class to use when {func}`~anndata.io.read_zarr` is passed the path of a single-file store such as `adata.zarr.zip`, instead of only raising `GroupNotFoundError` {user}`JOhnsonKC201`

--- a/src/anndata/_io/zarr.py
+++ b/src/anndata/_io/zarr.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import os
 import warnings
 from contextlib import contextmanager, nullcontext
 from importlib.util import find_spec
+from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import zarr
 from scipy import sparse
+from zarr.errors import GroupNotFoundError
 
 from .._core.anndata import AnnData
 from .._settings import settings
@@ -20,7 +24,7 @@ from .specs import read_elem
 from .utils import _read_legacy_raw, no_write_dataset_2d, report_read_key_on_error
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
     from os import PathLike
 
     from zarr.core.common import AccessModeLiteral
@@ -95,6 +99,23 @@ def write_zarr(
                 zarr.consolidate_metadata(f.store)
 
 
+# Suffixes of paths that hold a whole store in a single file.
+# `zarr.open_group` treats such a path as a directory store and finds no group in
+# it, so the user has to wrap it in the matching store class themselves.
+_PACKED_STORE_CLASSES: Mapping[str, str] = MappingProxyType({
+    ".zip": "zarr.storage.ZipStore"
+})
+
+
+def _add_packed_store_note(e: BaseException, store: StoreLike) -> None:
+    """Suggest the store class to use if `store` looks like a single-file store."""
+    if not isinstance(store, os.PathLike | str):
+        return
+    path = os.fspath(store)
+    if (cls_name := _PACKED_STORE_CLASSES.get(Path(path).suffix)) is not None:
+        e.add_note(f"Did you mean `read_zarr({cls_name}({path!r}))`?")
+
+
 def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnData:
     """\
     Read from a hierarchical Zarr array store.
@@ -123,7 +144,14 @@ def read_zarr(store: PathLike[str] | str | MutableMapping | zarr.Group) -> AnnDa
         return func(elem)
 
     with zarrs_context():
-        f = store if isinstance(store, zarr.Group) else zarr.open(store, mode="r")
+        if isinstance(store, zarr.Group):
+            f = store
+        else:
+            try:
+                f = zarr.open(store, mode="r")
+            except GroupNotFoundError as e:
+                _add_packed_store_note(e, store)
+                raise
         adata = read_dispatched(f, callback=callback)
 
         # Backwards compat (should figure out which version)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
+import zipfile
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from importlib.util import find_spec
@@ -34,6 +35,8 @@ from anndata.utils import get_literal_members
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from typing import Literal
+
+    from zarr.storage import StoreLike
 
 HERE = Path(__file__).parent
 ARRAY_TYPES = [
@@ -916,6 +919,49 @@ def test_backwards_compat_zarr() -> None:
         pbmc_zarr = ad.read_zarr(z)
 
     assert_equal(pbmc_zarr, pbmc_orig)
+
+
+def test_read_zarr_zip_path_suggests_store(tmp_path: Path) -> None:
+    """Reading a zipped store by path suggests the store class to wrap it in."""
+    orig = gen_adata((3, 2), **GEN_ADATA_NO_XARRAY_ARGS)
+    dir_pth = tmp_path / "adata.zarr"
+    orig.write_zarr(dir_pth)
+    # zip the store’s contents; a ZipStore expects them at the archive root
+    pth = tmp_path / "adata.zarr.zip"
+    with zipfile.ZipFile(pth, mode="w") as zf:
+        for elem in filter(Path.is_file, dir_pth.rglob("*")):
+            zf.write(elem, elem.relative_to(dir_pth).as_posix())
+
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(pth)
+    assert any("zarr.storage.ZipStore" in note for note in exc_info.value.__notes__)
+
+    # the suggested incantation works
+    with zarr.storage.ZipStore(pth, mode="r") as store:
+        assert_equal(ad.io.read_zarr(store), orig)
+
+
+def _empty_dir_store(tmp_path: Path) -> Path:
+    pth = tmp_path / "adata.zarr"
+    pth.mkdir()
+    return pth
+
+
+@pytest.mark.parametrize(
+    "make_store",
+    [
+        pytest.param(_empty_dir_store, id="dir"),
+        pytest.param(lambda _: zarr.storage.MemoryStore(), id="memory"),
+    ],
+)
+def test_read_zarr_suggests_nothing(
+    tmp_path: Path, make_store: Callable[[Path], StoreLike]
+) -> None:
+    """Stores that aren’t single-file paths get no (misleading) suggestion."""
+    with pytest.raises(zarr.errors.GroupNotFoundError) as exc_info:
+        ad.io.read_zarr(make_store(tmp_path))
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert not any("Did you mean" in note for note in notes)
 
 
 def test_adata_in_uns(tmp_path, diskfmt, roundtrip):


### PR DESCRIPTION
Backports #2571 
