### PR TITLE
Backport PR #2613 on branch 0.13.x (fix(acc): raise on out-of-range MultiAcc column index instead of returning empty)

### DIFF
--- a/docs/release-notes/2613.fix.md
+++ b/docs/release-notes/2613.fix.md
@@ -1,0 +1,1 @@
+Raise `IndexError` instead of returning an empty array when a `MultiAcc` column index is out of range, and accept negative indices {user}`dylanpulver`

--- a/src/anndata/acc/__init__.py
+++ b/src/anndata/acc/__init__.py
@@ -462,9 +462,9 @@ class MultiAcc[R: AdRef[int]](RefAcc[R, int, MuData | AnnData]):
 
     def isin(self, data: MuData | AnnData, idx: int | None = None) -> bool:
         m: AxisArrays = getattr(data, f"{self.dim}m")
-        if self.k not in m:
+        if (arr := m.get(self.k)) is None:
             return False
-        return idx is None or idx in range(m[self.k].shape[1])
+        return idx is None or -arr.shape[1] <= idx < m[self.k].shape[1]
 
     @overload
     def get(self, data: MuData | AnnData, /) -> FullArray: ...
@@ -476,6 +476,13 @@ class MultiAcc[R: AdRef[int]](RefAcc[R, int, MuData | AnnData]):
         full: FullArray = getattr(data, f"{self.dim}m")[self.k]
         if i is NO_IDX:
             return full
+        n_cols: int = full.shape[1]
+        if not -n_cols <= i < n_cols:
+            msg = (
+                f"Column index `{i}` is out of range for {self} with {n_cols} columns."
+            )
+            raise IndexError(msg)
+        i += n_cols * (i < 0)
         # TODO: remove slicing when dropping scipy <1.14
         return self._maybe_flatten(i, full[:, i : i + 1])
 

--- a/tests/accessors/test_accessors.py
+++ b/tests/accessors/test_accessors.py
@@ -292,6 +292,8 @@ def test_special[C](
         A.layers["a"],
         A.obsm,
         A.obsm["umap"],
+        A.obsm["umap"][-1],  # negative indices count from the end, as in numpy
+        A.obsm["umap"][-2],
         A.varp,
         A.varp["cons"],
     ],
@@ -308,6 +310,7 @@ def test_in(adata: AnnData, ref_or_acc: AdRef | MapAcc) -> None:
         A.layers["a"][:, "cell-3"],  # not a var name
         A.layers["b"],
         A.obsm["umap"][:, 3],
+        A.obsm["umap"][:, -3],
         A.obsm["b"],
         A.varm,
         A.obsp,

--- a/tests/accessors/test_get.py
+++ b/tests/accessors/test_get.py
@@ -30,6 +30,7 @@ from anndata.utils import asarray
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Literal
 
     from anndata import AnnData
     from anndata.acc import AdRef, InMemoryArray
@@ -47,6 +48,8 @@ ND_PATHS: list[tuple[AdRef, Callable[[AnnData], InMemoryArray]]] = [
     (A.layers["a"]["cell-77", :], lambda ad: ad["cell-77"].layers["a"]),
     (A.obsm["umap"][0], lambda ad: asarray(ad.obsm["umap"])[:, 0]),
     (A.obsm["umap"][1], lambda ad: asarray(ad.obsm["umap"])[:, 1]),
+    (A.obsm["umap"][-1], lambda ad: asarray(ad.obsm["umap"])[:, -1]),
+    (A.obsm["umap"][-2], lambda ad: asarray(ad.obsm["umap"])[:, -2]),
     (A.varp["cons"][:, :], lambda ad: asarray(ad.varp["cons"])),
     (A.varp["cons"]["gene-46", :], lambda ad: asarray(ad.varp["cons"])[46, :]),
     (A.varp["cons"][:, "gene-46"], lambda ad: asarray(ad.varp["cons"])[:, 46]),
@@ -197,3 +200,17 @@ def test_get_values(
     assert isinstance(vals, type_expected)
     vals_np = asarray(vals)
     np.testing.assert_array_equal(vals_np, expected, strict=True)
+
+
+@pytest.mark.parametrize("i", [2, 99, -3], ids=str)
+@pytest.mark.parametrize("dim", ["obs", "var"], ids=str)
+def test_get_multi_out_of_range(
+    adata: AnnData, dim: Literal["obs", "var"], i: int
+) -> None:
+    """Out-of-range column indices raise instead of yielding an empty array."""
+    adata.varm["pcs"] = np.zeros((adata.n_vars, 2))  # `obsm["umap"]` also has 2 columns
+    ad_ref = getattr(A, f"{dim}m")["umap" if dim == "obs" else "pcs"][i]
+    assert ad_ref not in adata
+    msg = rf"Column index `{i}` is out of range for A\.{dim}m\[.+\] with 2 columns\."
+    with pytest.raises(IndexError, match=msg):
+        adata[ad_ref]


### PR DESCRIPTION
Backports https://github.com/scverse/anndata/issues/2613