### PR TITLE
docs: clarify in-place string conversion during writes

### DIFF
--- a/src/anndata/_core/anndata.py
+++ b/src/anndata/_core/anndata.py
@@ -1694,7 +1694,9 @@ class AnnData:  # noqa: PLW1641
         filename
             Filename of data file. Defaults to backing file.
         convert_strings_to_categoricals
-            Convert string columns to categorical.
+            Convert string columns to categorical before writing. This conversion
+            modifies :attr:`obs`, :attr:`var`, and ``raw.var`` in place. Set to
+            `False` to preserve their in-memory dtypes.
         compression
             For [`lzf`, `gzip`], see the h5py :ref:`dataset_compression`.
 
@@ -1826,7 +1828,9 @@ class AnnData:  # noqa: PLW1641
         chunks
             Chunk shape.
         convert_strings_to_categoricals
-            Convert string columns to categorical.
+            Convert string columns to categorical before writing. This conversion
+            modifies :attr:`obs`, :attr:`var`, and ``raw.var`` in place. Set to
+            `False` to preserve their in-memory dtypes.
         consolidate_metadata
             Whether to consolidate the metadata of the store after writing.
         """


### PR DESCRIPTION
- [x] Closes #2610
- [ ] Tests added

- [x] Release note not necessary because: this clarifies existing API behavior without changing runtime behavior.

## Summary

Clarify that `convert_strings_to_categoricals=True` modifies `obs`, `var`, and `raw.var` in place before `write_h5ad()` and `write_zarr()` serialize the object.

The updated parameter documentation also points users to `convert_strings_to_categoricals=False` when they need to preserve the in-memory dtypes.

## Context

Both writers call the in-place `AnnData.strings_to_categoricals()` helper before writing. This behavior is longstanding, and #1474 made it optional, but the public method documentation currently says only “Convert string columns to categorical,” which does not make the side effect clear.

This PR documents the current contract only. It does not change the default, serialization behavior, or on-disk format.

## Validation

- `python -m pytest tests/test_readwrite.py::test_write_categorical -q` — 6 passed
- `ruff check src/anndata/_core/anndata.py`
- `ruff format --check src/anndata/_core/anndata.py`
- `git diff --check`

AI assistance disclosure: I used Codex to help trace the write paths, inspect the history, and draft the documentation. I manually reproduced the behavior, reviewed the final diff, and ran the listed checks.
