### PR TITLE
docs: back to upstream sphinx-autodoc-typehints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dev-doc = [
 doc = [
     "anndata[dask]",
     "awkward>=2.6.3",
-    "ipython",                                                                                               # For syntax highlighting in notebooks
+    "ipython",                            # For syntax highlighting in notebooks
     "mudata",
     "myst-nb>=1.4",
     "myst-parser",
@@ -92,8 +92,7 @@ doc = [
     "scanpydoc[theme,typehints]>=0.17.1",
     "scverse-misc[sphinx]",
     "sphinx>=9.1",
-    # TODO: drop URL once https://github.com/tox-dev/sphinx-autodoc-typehints/pull/766 is released
-    "sphinx-autodoc-typehints @ git+https://github.com/tox-dev/sphinx-autodoc-typehints@refs/pull/766/head",
+    "sphinx-autodoc-typehints>=3.13.6",
     "sphinx-book-theme>=1.1",
     "sphinx-copybutton",
     "sphinx-design",


### PR DESCRIPTION
the patch used for #2633 has been upstreamed